### PR TITLE
feat: group history entries by upgrade runs with accordion UI

### DIFF
--- a/backend/src/handlers/log.rs
+++ b/backend/src/handlers/log.rs
@@ -1,17 +1,31 @@
 use anyhow::Result;
+use chrono::NaiveDateTime;
 use pacman_log::{Action, LogReader};
 
-use crate::models::{LogEntry, LogResponse};
+use crate::models::{GroupedLogResponse, LogEntry, LogGroup, LogResponse};
 
-pub fn get_history(offset: usize, limit: usize, filter: Option<&str>) -> Result<()> {
-    let reader = LogReader::system();
+const GROUP_THRESHOLD_SECS: i64 = 60;
 
-    let filter_action = filter.and_then(|f| match f {
+struct LogStats {
+    entries: Vec<LogEntry>,
+    total_upgraded: usize,
+    total_installed: usize,
+    total_removed: usize,
+    total_other: usize,
+}
+
+fn parse_filter(filter: Option<&str>) -> Option<Action> {
+    filter.and_then(|f| match f {
         "upgraded" => Some(Action::Upgraded),
         "installed" => Some(Action::Installed),
         "removed" => Some(Action::Removed),
         _ => None,
-    });
+    })
+}
+
+fn collect_log_entries(filter: Option<&str>) -> LogStats {
+    let reader = LogReader::system();
+    let filter_action = parse_filter(filter);
 
     let mut entries: Vec<LogEntry> = Vec::new();
     let mut total_upgraded = 0usize;
@@ -53,18 +67,229 @@ pub fn get_history(offset: usize, limit: usize, filter: Option<&str>) -> Result<
         }
     }
 
-    let total = entries.len();
-    let paginated: Vec<LogEntry> = entries.into_iter().skip(offset).take(limit).collect();
-
-    let response = LogResponse {
-        entries: paginated,
-        total,
+    LogStats {
+        entries,
         total_upgraded,
         total_installed,
         total_removed,
         total_other,
+    }
+}
+
+pub fn get_history(offset: usize, limit: usize, filter: Option<&str>) -> Result<()> {
+    let stats = collect_log_entries(filter);
+    let total = stats.entries.len();
+    let paginated: Vec<LogEntry> = stats.entries.into_iter().skip(offset).take(limit).collect();
+
+    let response = LogResponse {
+        entries: paginated,
+        total,
+        total_upgraded: stats.total_upgraded,
+        total_installed: stats.total_installed,
+        total_removed: stats.total_removed,
+        total_other: stats.total_other,
     };
 
     println!("{}", serde_json::to_string(&response)?);
     Ok(())
+}
+
+fn parse_timestamp(ts: &str) -> Option<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(ts, "%Y-%m-%dT%H:%M:%S%z").ok()
+}
+
+fn count_actions(entries: &[LogEntry]) -> (usize, usize, usize, usize, usize) {
+    entries.iter().fold(
+        (0, 0, 0, 0, 0),
+        |(up, ins, rem, down, re), entry| match entry.action.as_str() {
+            "upgraded" => (up + 1, ins, rem, down, re),
+            "installed" => (up, ins + 1, rem, down, re),
+            "removed" => (up, ins, rem + 1, down, re),
+            "downgraded" => (up, ins, rem, down + 1, re),
+            "reinstalled" => (up, ins, rem, down, re + 1),
+            _ => (up, ins, rem, down, re),
+        },
+    )
+}
+
+fn finalize_group(entries: Vec<LogEntry>, group_index: usize) -> LogGroup {
+    let (upgraded, installed, removed, downgraded, reinstalled) = count_actions(&entries);
+    let start_time = entries
+        .last()
+        .map_or(String::new(), |e| e.timestamp.clone());
+    let end_time = entries
+        .first()
+        .map_or(String::new(), |e| e.timestamp.clone());
+
+    LogGroup {
+        id: format!("group-{}", group_index),
+        start_time,
+        end_time,
+        entries,
+        upgraded_count: upgraded,
+        installed_count: installed,
+        removed_count: removed,
+        downgraded_count: downgraded,
+        reinstalled_count: reinstalled,
+    }
+}
+
+pub fn get_grouped_history(offset: usize, limit: usize, filter: Option<&str>) -> Result<()> {
+    let stats = collect_log_entries(filter);
+
+    let mut groups: Vec<LogGroup> = Vec::new();
+    let mut current_group_entries: Vec<LogEntry> = Vec::new();
+    let mut last_timestamp: Option<NaiveDateTime> = None;
+
+    for entry in stats.entries {
+        let current_ts = parse_timestamp(&entry.timestamp);
+
+        let should_start_new_group = match (last_timestamp, current_ts) {
+            (Some(last), Some(current)) => {
+                let diff = (last - current).num_seconds().abs();
+                diff > GROUP_THRESHOLD_SECS
+            }
+            (None, _) => false,
+            (Some(_), None) => true,
+        };
+
+        if should_start_new_group && !current_group_entries.is_empty() {
+            groups.push(finalize_group(current_group_entries, groups.len()));
+            current_group_entries = Vec::new();
+        }
+
+        last_timestamp = current_ts;
+        current_group_entries.push(entry);
+    }
+
+    if !current_group_entries.is_empty() {
+        groups.push(finalize_group(current_group_entries, groups.len()));
+    }
+
+    let total_groups = groups.len();
+    let paginated_groups: Vec<LogGroup> = groups.into_iter().skip(offset).take(limit).collect();
+
+    let response = GroupedLogResponse {
+        groups: paginated_groups,
+        total_groups,
+        total_upgraded: stats.total_upgraded,
+        total_installed: stats.total_installed,
+        total_removed: stats.total_removed,
+        total_other: stats.total_other,
+    };
+
+    println!("{}", serde_json::to_string(&response)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_timestamp_with_positive_offset() {
+        let ts = "2026-01-21T23:14:45+0100";
+        let result = parse_timestamp(ts);
+        assert!(result.is_some());
+        let dt = result.unwrap();
+        assert_eq!(dt.format("%Y-%m-%d").to_string(), "2026-01-21");
+    }
+
+    #[test]
+    fn test_parse_timestamp_with_utc() {
+        let ts = "2026-01-21T23:14:45+0000";
+        let result = parse_timestamp(ts);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_parse_timestamp_with_negative_offset() {
+        let ts = "2026-01-21T23:14:45-0500";
+        let result = parse_timestamp(ts);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_count_actions() {
+        let entries = vec![
+            LogEntry {
+                timestamp: "2026-01-21T10:00:00+0000".to_string(),
+                action: "upgraded".to_string(),
+                package: "pkg1".to_string(),
+                old_version: Some("1.0".to_string()),
+                new_version: Some("2.0".to_string()),
+            },
+            LogEntry {
+                timestamp: "2026-01-21T10:00:01+0000".to_string(),
+                action: "upgraded".to_string(),
+                package: "pkg2".to_string(),
+                old_version: Some("1.0".to_string()),
+                new_version: Some("2.0".to_string()),
+            },
+            LogEntry {
+                timestamp: "2026-01-21T10:00:02+0000".to_string(),
+                action: "installed".to_string(),
+                package: "pkg3".to_string(),
+                old_version: None,
+                new_version: Some("1.0".to_string()),
+            },
+            LogEntry {
+                timestamp: "2026-01-21T10:00:03+0000".to_string(),
+                action: "removed".to_string(),
+                package: "pkg4".to_string(),
+                old_version: Some("1.0".to_string()),
+                new_version: None,
+            },
+        ];
+
+        let (up, ins, rem, down, re) = count_actions(&entries);
+        assert_eq!(up, 2);
+        assert_eq!(ins, 1);
+        assert_eq!(rem, 1);
+        assert_eq!(down, 0);
+        assert_eq!(re, 0);
+    }
+
+    #[test]
+    fn test_finalize_group() {
+        let entries = vec![
+            LogEntry {
+                timestamp: "2026-01-21T10:00:05+0000".to_string(),
+                action: "upgraded".to_string(),
+                package: "pkg1".to_string(),
+                old_version: Some("1.0".to_string()),
+                new_version: Some("2.0".to_string()),
+            },
+            LogEntry {
+                timestamp: "2026-01-21T10:00:00+0000".to_string(),
+                action: "installed".to_string(),
+                package: "pkg2".to_string(),
+                old_version: None,
+                new_version: Some("1.0".to_string()),
+            },
+        ];
+
+        let group = finalize_group(entries, 0);
+        assert_eq!(group.id, "group-0");
+        assert_eq!(group.start_time, "2026-01-21T10:00:00+0000");
+        assert_eq!(group.end_time, "2026-01-21T10:00:05+0000");
+        assert_eq!(group.upgraded_count, 1);
+        assert_eq!(group.installed_count, 1);
+        assert_eq!(group.entries.len(), 2);
+    }
+
+    #[test]
+    fn test_grouping_threshold() {
+        let ts1 = parse_timestamp("2026-01-21T10:00:00+0000").unwrap();
+        let ts2 = parse_timestamp("2026-01-21T10:00:59+0000").unwrap();
+        let ts3 = parse_timestamp("2026-01-21T10:01:01+0000").unwrap();
+
+        // 59 seconds apart - should be same group
+        let diff1 = (ts2 - ts1).num_seconds().abs();
+        assert!(diff1 <= GROUP_THRESHOLD_SECS);
+
+        // 61 seconds apart - should be different groups
+        let diff2 = (ts3 - ts1).num_seconds().abs();
+        assert!(diff2 > GROUP_THRESHOLD_SECS);
+    }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -12,7 +12,7 @@ pub use cache::{clean_cache, get_cache_info};
 pub use config::{add_ignored, list_ignored, remove_ignored};
 pub use downgrade::{downgrade_package, list_downgrades};
 pub use keyring::{init_keyring, keyring_status, refresh_keyring};
-pub use log::get_history;
+pub use log::{get_grouped_history, get_history};
 pub use mutation::{preflight_upgrade, remove_orphans, run_upgrade, sync_database};
 pub use query::{
     check_updates, list_installed, list_orphans, local_package_info, search, sync_package_info,

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -236,7 +236,7 @@ pub struct CacheInfo {
     pub path: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct LogEntry {
     pub timestamp: String,
     pub action: String,
@@ -249,6 +249,29 @@ pub struct LogEntry {
 pub struct LogResponse {
     pub entries: Vec<LogEntry>,
     pub total: usize,
+    pub total_upgraded: usize,
+    pub total_installed: usize,
+    pub total_removed: usize,
+    pub total_other: usize,
+}
+
+#[derive(Serialize, Clone)]
+pub struct LogGroup {
+    pub id: String,
+    pub start_time: String,
+    pub end_time: String,
+    pub entries: Vec<LogEntry>,
+    pub upgraded_count: usize,
+    pub installed_count: usize,
+    pub removed_count: usize,
+    pub downgraded_count: usize,
+    pub reinstalled_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct GroupedLogResponse {
+    pub groups: Vec<LogGroup>,
+    pub total_groups: usize,
     pub total_upgraded: usize,
     pub total_installed: usize,
     pub total_removed: usize,

--- a/src/api.ts
+++ b/src/api.ts
@@ -693,6 +693,36 @@ export async function getHistory(params: HistoryParams = {}): Promise<LogRespons
   return runBackend<LogResponse>("history", [String(offset), String(limit), filter]);
 }
 
+export interface LogGroup {
+  id: string;
+  start_time: string;
+  end_time: string;
+  entries: LogEntry[];
+  upgraded_count: number;
+  installed_count: number;
+  removed_count: number;
+  downgraded_count: number;
+  reinstalled_count: number;
+}
+
+export interface GroupedLogResponse {
+  groups: LogGroup[];
+  total_groups: number;
+  total_upgraded: number;
+  total_installed: number;
+  total_removed: number;
+  total_other: number;
+}
+
+export async function getGroupedHistory(params: HistoryParams = {}): Promise<GroupedLogResponse> {
+  const { offset = 0, limit = 20, filter = "all" } = params;
+  return runBackend<GroupedLogResponse>("history-grouped", [
+    String(offset),
+    String(limit),
+    filter,
+  ]);
+}
+
 export interface CachedVersion {
   name: string;
   version: string;

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -6,6 +6,8 @@ import type {
   PreflightResponse,
   SyncPackageDetails,
   RebootStatus,
+  GroupedLogResponse,
+  LogGroup,
 } from "../api";
 
 export const mockPackageListResponse: PackageListResponse = {
@@ -243,4 +245,94 @@ export const mockRebootStatusCriticalPackages: RebootStatus = {
   installed_kernel: "6.18.5.arch1-1",
   kernel_package: "linux",
   updated_packages: ["systemd", "linux-firmware"],
+};
+
+export const mockLogGroups: LogGroup[] = [
+  {
+    id: "group-0",
+    start_time: "2026-01-22T10:30:00+0000",
+    end_time: "2026-01-22T10:30:45+0000",
+    entries: [
+      {
+        timestamp: "2026-01-22T10:30:45+0000",
+        action: "upgraded",
+        package: "linux",
+        old_version: "6.18.4-arch1-1",
+        new_version: "6.18.5-arch1-1",
+      },
+      {
+        timestamp: "2026-01-22T10:30:30+0000",
+        action: "upgraded",
+        package: "linux-firmware",
+        old_version: "20250115.9fc05f5b-1",
+        new_version: "20260120.abc123-1",
+      },
+      {
+        timestamp: "2026-01-22T10:30:00+0000",
+        action: "upgraded",
+        package: "systemd",
+        old_version: "256.5-1",
+        new_version: "256.6-1",
+      },
+    ],
+    upgraded_count: 3,
+    installed_count: 0,
+    removed_count: 0,
+    downgraded_count: 0,
+    reinstalled_count: 0,
+  },
+  {
+    id: "group-1",
+    start_time: "2026-01-21T14:15:00+0000",
+    end_time: "2026-01-21T14:15:30+0000",
+    entries: [
+      {
+        timestamp: "2026-01-21T14:15:30+0000",
+        action: "installed",
+        package: "neovim",
+        old_version: null,
+        new_version: "0.10.0-1",
+      },
+      {
+        timestamp: "2026-01-21T14:15:00+0000",
+        action: "installed",
+        package: "tree-sitter",
+        old_version: null,
+        new_version: "0.22.6-1",
+      },
+    ],
+    upgraded_count: 0,
+    installed_count: 2,
+    removed_count: 0,
+    downgraded_count: 0,
+    reinstalled_count: 0,
+  },
+  {
+    id: "group-2",
+    start_time: "2026-01-20T09:00:00+0000",
+    end_time: "2026-01-20T09:00:00+0000",
+    entries: [
+      {
+        timestamp: "2026-01-20T09:00:00+0000",
+        action: "removed",
+        package: "deprecated-package",
+        old_version: "1.0.0-1",
+        new_version: null,
+      },
+    ],
+    upgraded_count: 0,
+    installed_count: 0,
+    removed_count: 1,
+    downgraded_count: 0,
+    reinstalled_count: 0,
+  },
+];
+
+export const mockGroupedLogResponse: GroupedLogResponse = {
+  groups: mockLogGroups,
+  total_groups: 3,
+  total_upgraded: 3,
+  total_installed: 2,
+  total_removed: 1,
+  total_other: 0,
 };


### PR DESCRIPTION
Group pacman log entries into transactions that occurred within 60 seconds of each other. Display groups in a collapsible accordion with summary labels showing action counts per group.