### PR TITLE
fix: re-add system hookdir after alpm_utils overwrites it

### DIFF
--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -829,6 +829,21 @@ mod integration {
     }
 
     #[test]
+    fn test_system_hookdir_present() {
+        let handle = get_handle().expect("Failed to get handle");
+        let hookdirs: Vec<&str> = handle.hookdirs().iter().collect();
+
+        assert!(
+            hookdirs
+                .iter()
+                .any(|d| d.contains("usr/share/libalpm/hooks")),
+            "System hookdir /usr/share/libalpm/hooks/ missing from hookdirs: {:?}. \
+             Without it, post-transaction hooks (mkinitcpio, depmod, systemd) will not run.",
+            hookdirs
+        );
+    }
+
+    #[test]
     fn test_package_has_expected_fields() {
         let handle = get_handle().expect("Failed to get handle");
         let localdb = handle.localdb();


### PR DESCRIPTION
alpm_utils::configure_alpm() uses set_hookdirs() which replaces the system hookdir (/usr/share/libalpm/hooks/) set by alpm_initialize(). This prevents post-transaction hooks (mkinitcpio, depmod, systemd) from running, resulting in unbootable systems after kernel upgrades.

Re-add the system hookdir via add_hookdir() to match pacman's own behavior, which uses add_hookdir() to avoid this exact problem.

Upstream: https://github.com/archlinux/alpm.rs/issues/65