### PR TITLE
feat: add Arch Linux news feed to UpdatesView

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -53,6 +53,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "atom_syndication"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f68d23e2cb4fd958c705b91a6b4c80ceeaf27a9e11651272a8389d5ce1a4a3"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "diligent-date-parser",
+ "never",
+ "quick-xml",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +158,7 @@ dependencies = [
  "pacman-key",
  "pacman-log",
  "pacmanconf",
+ "rss",
  "serde",
  "serde_json",
  "tokio",
@@ -178,6 +192,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "diligent-date-parser"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ede7d79366f419921e2e2f67889c12125726692a313bffb474bd5f37a581e9"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +276,15 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -214,6 +312,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs2"
@@ -289,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +452,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
 
 [[package]]
 name = "nix"
@@ -445,6 +561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +591,18 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rss"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2107738f003660f0a91f56fd3e3bd3ab5d918b2ddaf1e1ec2136fb1c46f71bf"
+dependencies = [
+ "atom_syndication",
+ "derive_builder",
+ "never",
+ "quick-xml",
 ]
 
 [[package]]
@@ -572,6 +710,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,6 +19,7 @@ fs2 = "0.4"
 pacman-key = "0.1.2"
 pacman-log = "0.1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+rss = "2"
 ureq = "3"
 
 [profile.release]

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod keyring;
 pub mod log;
 pub mod mirrors;
 pub mod mutation;
+pub mod news;
 pub mod query;
 pub mod reboot;
 pub mod scheduled;
@@ -18,6 +19,7 @@ pub use keyring::{init_keyring, keyring_status, refresh_keyring};
 pub use log::{get_grouped_history, get_history};
 pub use mirrors::{fetch_mirror_status, list_mirrors, save_mirrorlist, test_mirrors};
 pub use mutation::{preflight_upgrade, remove_orphans, run_upgrade, sync_database};
+pub use news::fetch_news;
 pub use query::{
     check_updates, list_installed, list_orphans, local_package_info, search, sync_package_info,
 };

--- a/backend/src/handlers/news.rs
+++ b/backend/src/handlers/news.rs
@@ -1,0 +1,161 @@
+use anyhow::Result;
+use chrono::Utc;
+use std::io::Read;
+use std::time::Duration;
+
+use crate::models::{NewsItem, NewsResponse};
+use crate::util::emit_json;
+
+const ARCH_NEWS_URL: &str = "https://archlinux.org/feeds/news/";
+const MAX_RSS_BYTES: u64 = 512 * 1024;
+
+pub fn fetch_news(days: u32) -> Result<()> {
+    let days = days.min(365);
+    let items = fetch_news_items(days).unwrap_or_default();
+    emit_json(&NewsResponse { items })
+}
+
+fn fetch_news_items(days: u32) -> Result<Vec<NewsItem>> {
+    let agent = ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(15)))
+            .build(),
+    );
+
+    let mut body = agent.get(ARCH_NEWS_URL).call()?.into_body();
+    let mut buf = Vec::new();
+    body.as_reader().take(MAX_RSS_BYTES).read_to_end(&mut buf)?;
+
+    let channel = rss::Channel::read_from(&buf[..])?;
+    let cutoff = Utc::now() - chrono::Duration::days(i64::from(days));
+
+    let mut items = Vec::new();
+    for item in channel.items() {
+        let pub_date = match item.pub_date() {
+            Some(d) => d,
+            None => continue,
+        };
+        let parsed = match chrono::DateTime::parse_from_rfc2822(pub_date) {
+            Ok(dt) => dt.with_timezone(&Utc),
+            Err(_) => continue,
+        };
+        if parsed < cutoff {
+            continue;
+        }
+
+        let title = item.title().unwrap_or("").to_string();
+        let link = item.link().unwrap_or("").to_string();
+        let summary = item
+            .description()
+            .map(|d| strip_html_and_truncate(d, 300))
+            .unwrap_or_default();
+
+        items.push(NewsItem {
+            title,
+            link,
+            published: parsed.to_rfc3339(),
+            summary,
+        });
+    }
+
+    Ok(items)
+}
+
+pub(crate) fn strip_html_and_truncate(html: &str, max_len: usize) -> String {
+    let mut result = String::with_capacity(html.len());
+    let mut in_tag = false;
+    let mut chars = html.chars().peekable();
+    let mut last_was_space = false;
+
+    while let Some(ch) = chars.next() {
+        if ch == '<' {
+            in_tag = true;
+            continue;
+        }
+        if ch == '>' {
+            in_tag = false;
+            if !result.is_empty() && !last_was_space {
+                result.push(' ');
+                last_was_space = true;
+            }
+            continue;
+        }
+        if in_tag {
+            continue;
+        }
+        if ch == '&' {
+            let entity = decode_entity(&mut chars);
+            for ec in entity.chars() {
+                if ec.is_whitespace() {
+                    if !last_was_space && !result.is_empty() {
+                        result.push(' ');
+                        last_was_space = true;
+                    }
+                } else {
+                    result.push(ec);
+                    last_was_space = false;
+                }
+            }
+            continue;
+        }
+        if ch.is_whitespace() {
+            if !last_was_space && !result.is_empty() {
+                result.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            result.push(ch);
+            last_was_space = false;
+        }
+    }
+
+    let trimmed = result.trim_end().to_string();
+    if trimmed.len() <= max_len {
+        return trimmed;
+    }
+
+    let truncated = &trimmed[..max_len];
+    match truncated.rfind(' ') {
+        Some(pos) if pos > max_len / 2 => format!("{}...", &truncated[..pos]),
+        _ => format!("{}...", truncated),
+    }
+}
+
+fn decode_entity(chars: &mut std::iter::Peekable<std::str::Chars>) -> String {
+    let mut entity = String::new();
+    let mut terminated = false;
+    for _ in 0..10 {
+        match chars.next() {
+            Some(';') => {
+                terminated = true;
+                break;
+            }
+            Some(c) => entity.push(c),
+            None => break,
+        }
+    }
+    if !terminated {
+        return format!("&{}", entity);
+    }
+    match entity.as_str() {
+        "amp" => "&".to_string(),
+        "lt" => "<".to_string(),
+        "gt" => ">".to_string(),
+        "quot" => "\"".to_string(),
+        "apos" => "'".to_string(),
+        "nbsp" => " ".to_string(),
+        _ if entity.starts_with('#') => {
+            let code_str = &entity[1..];
+            let code_point = if let Some(hex) = code_str.strip_prefix('x') {
+                u32::from_str_radix(hex, 16).ok()
+            } else {
+                code_str.parse::<u32>().ok()
+            };
+            code_point
+                .and_then(char::from_u32)
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| format!("&{};", entity))
+        }
+        _ => format!("&{};", entity),
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use cockpit_pacman_backend::handlers::{
-    add_ignored, check_updates, clean_cache, downgrade_package, fetch_mirror_status,
+    add_ignored, check_updates, clean_cache, downgrade_package, fetch_mirror_status, fetch_news,
     get_cache_info, get_dependency_tree, get_grouped_history, get_history, get_reboot_status,
     get_schedule_config, get_scheduled_runs, init_keyring, keyring_status, list_downgrades,
     list_ignored, list_installed, list_mirrors, list_orphans, local_package_info,
@@ -96,6 +96,8 @@ fn print_usage() {
     eprintln!("                         Get dependency tree for a package");
     eprintln!("                         depth: 1-10 (default: 3)");
     eprintln!("                         direction: forward|reverse|both (default: forward)");
+    eprintln!("  fetch-news [days]      Fetch recent Arch Linux news items");
+    eprintln!("                         days: lookback period (default: 30)");
 }
 
 fn main() {
@@ -324,6 +326,10 @@ fn main() {
                 .and_then(|_| validate_depth(depth))
                 .and_then(|_| validate_direction(direction))
                 .and_then(|_| get_dependency_tree(&args[2], depth, direction))
+        }
+        "fetch-news" => {
+            let days = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(30u32);
+            fetch_news(days)
         }
         "help" | "--help" | "-h" => {
             print_usage();

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,6 +1,19 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
+pub struct NewsItem {
+    pub title: String,
+    pub link: String,
+    pub published: String,
+    pub summary: String,
+}
+
+#[derive(Serialize)]
+pub struct NewsResponse {
+    pub items: Vec<NewsItem>,
+}
+
+#[derive(Serialize)]
 pub struct Package {
     pub name: String,
     pub version: String,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1015,6 +1015,21 @@ export interface DependencyTreeResponse {
   warnings: string[];
 }
 
+export interface NewsItem {
+  title: string;
+  link: string;
+  published: string;
+  summary: string;
+}
+
+export interface NewsResponse {
+  items: NewsItem[];
+}
+
+export async function fetchNews(days: number = 30): Promise<NewsResponse> {
+  return runBackend<NewsResponse>("fetch-news", [String(days)]);
+}
+
 export type DependencyDirection = "forward" | "reverse" | "both";
 
 export interface DependencyTreeParams {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,3 +13,5 @@ export const STREAMING_TIMEOUT_SECS = 300;
 export const MAX_LOG_SIZE_BYTES = 100000;
 
 export const LOG_CONTAINER_HEIGHT = "300px";
+
+export const NEWS_LOOKBACK_DAYS = 30;

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -9,6 +9,7 @@ import type {
   GroupedLogResponse,
   LogGroup,
   DependencyTreeResponse,
+  NewsResponse,
 } from "../api";
 
 export const mockPackageListResponse: PackageListResponse = {
@@ -336,6 +337,27 @@ export const mockGroupedLogResponse: GroupedLogResponse = {
   total_installed: 2,
   total_removed: 1,
   total_other: 0,
+};
+
+export const mockNewsResponse: NewsResponse = {
+  items: [
+    {
+      title: "grub 2:2.12-3 requires manual intervention",
+      link: "https://archlinux.org/news/grub-2212-3/",
+      published: "2026-02-01T00:00:00+00:00",
+      summary: "Users of grub need to reinstall grub after upgrading to resolve boot issues.",
+    },
+    {
+      title: "OpenSSL 3.4 update",
+      link: "https://archlinux.org/news/openssl-34/",
+      published: "2026-01-15T00:00:00+00:00",
+      summary: "OpenSSL has been updated to 3.4. Users may need to rebuild custom modules.",
+    },
+  ],
+};
+
+export const mockNewsResponseEmpty: NewsResponse = {
+  items: [],
 };
 
 export const mockDependencyTreeResponse: DependencyTreeResponse = {


### PR DESCRIPTION
Fetch recent items from the Arch Linux RSS news feed and display them as dismissible info alerts in UpdatesView. Dismissed items persist to localStorage across sessions.