### PR TITLE
feat: add network error with status page link

### DIFF
--- a/backend/src/handlers/news.rs
+++ b/backend/src/handlers/news.rs
@@ -11,7 +11,7 @@ const MAX_RSS_BYTES: u64 = 512 * 1024;
 
 pub fn fetch_news(days: u32) -> Result<()> {
     let days = days.min(365);
-    let items = fetch_news_items(days).unwrap_or_default();
+    let items = fetch_news_items(days)?;
     emit_json(&NewsResponse { items })
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,5 @@ export const MAX_LOG_SIZE_BYTES = 100000;
 export const LOG_CONTAINER_HEIGHT = "300px";
 
 export const NEWS_LOOKBACK_DAYS = 30;
+
+export const ARCH_STATUS_URL = "https://status.archlinux.org/";


### PR DESCRIPTION
Show a link to status.archlinux.org when check-updates or sync-database fails with a network-related error.