### PR TITLE
fix: only show max depth warning when slider is at maximum

### DIFF
--- a/src/components/DependencyView.test.tsx
+++ b/src/components/DependencyView.test.tsx
@@ -159,7 +159,7 @@ describe("DependencyView", () => {
     });
   });
 
-  it("displays warnings when max depth reached", async () => {
+  it("does not display max depth warning when depth is below slider max", async () => {
     mockGetDependencyTree.mockResolvedValue({
       ...mockDependencyTreeResponse,
       max_depth_reached: true,
@@ -170,8 +170,9 @@ describe("DependencyView", () => {
     await triggerSearch("linux");
 
     await waitFor(() => {
-      expect(screen.getByText(/Maximum depth reached/)).toBeInTheDocument();
+      expect(screen.getByText("3 nodes")).toBeInTheDocument();
     });
+    expect(screen.queryByText(/Maximum depth reached/)).not.toBeInTheDocument();
   });
 
   it("renders SVG graph container", async () => {

--- a/src/components/DependencyView.tsx
+++ b/src/components/DependencyView.tsx
@@ -223,7 +223,7 @@ export const DependencyView: React.FC<DependencyViewProps> = ({ initialPackage }
       setEdges(response.edges);
       setRootId(response.root);
       setWarnings(response.warnings);
-      if (response.max_depth_reached) {
+      if (response.max_depth_reached && depthVal >= 5) {
         setWarnings((prev) => [...prev, "Maximum depth reached. Some dependencies may not be shown."]);
       }
     } catch (ex) {


### PR DESCRIPTION
The warning was showing at any depth where the traversal hit the configured limit, which was misleading when the user could simply increase the slider.