### PR TITLE
feat: replace paccache with native alpm cache cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Update frequency and packaging metadata in package details modal (e4b0e09)
 - View history button in package details modal (aade846)
 - Package install from the details modal (b89a33f)
-- Arch Security Tracker integration with severity badges and vulnerable package count (b24ffe9)
+- Arch Security Tracker integration with severity badges and vulnerable package count (cc30314)
 
 ### Fixed
 - History search input losing focus during background refetch (bdebb0c)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Cockpit plugin for Arch Linux package management using direct alpm.rs integration.
 
+Mirror: https://gitlab.archlinux.org/pfeifferj/cockpit-pacman
+
 ## Features
 
 ![Check for and apply system updates](docs/img/updates.png)
@@ -44,14 +46,6 @@ Test and configure pacman mirrors
 ```bash
 sudo pacman -S cockpit
 sudo systemctl enable --now cockpit.socket
-```
-
-### Optional dependencies
-
-The plugin is self-contained for most functionality. Cache cleanup requires `paccache` from `pacman-contrib`:
-
-```bash
-sudo pacman -S pacman-contrib
 ```
 
 ## Installation

--- a/backend/src/handlers/cache.rs
+++ b/backend/src/handlers/cache.rs
@@ -1,6 +1,7 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 use crate::alpm::get_handle;
 use crate::models::{CacheInfo, CachePackage, StreamEvent};
@@ -53,44 +54,104 @@ pub fn get_cache_info() -> Result<()> {
     emit_json(&info)
 }
 
-pub fn clean_cache(keep_versions: u32) -> Result<()> {
+pub fn clean_cache(keep_versions: u32, filter_pkgs: &[String]) -> Result<()> {
+    let handle = get_handle()?;
+    let cache_dir = get_cache_dir();
+    let cache_path = Path::new(&cache_dir);
+
     emit_event(&StreamEvent::Event {
         event: "Starting cache cleanup".to_string(),
         package: None,
     });
 
-    let keep_arg = format!("-k{}", keep_versions);
-    let output = Command::new("paccache")
-        .args(["-r", &keep_arg, "-v"])
-        .output()
-        .context("Failed to run paccache")?;
+    if !cache_path.exists() {
+        emit_event(&StreamEvent::Complete {
+            success: true,
+            message: Some("Cache directory does not exist".to_string()),
+        });
+        return Ok(());
+    }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let filter: HashSet<&str> = filter_pkgs.iter().map(|s| s.as_str()).collect();
 
-    for line in stdout.lines().chain(stderr.lines()) {
-        if !line.trim().is_empty() {
-            emit_event(&StreamEvent::Log {
-                level: "info".to_string(),
-                message: line.to_string(),
-            });
+    let mut groups: HashMap<String, Vec<(fs::DirEntry, String, String)>> = HashMap::new();
+    for (entry, filename, name, version) in load_cache_packages(&handle, cache_path) {
+        if !filter.is_empty() && !filter.contains(name.as_str()) {
+            continue;
+        }
+        groups
+            .entry(name)
+            .or_default()
+            .push((entry, filename, version));
+    }
+
+    let mut removed_count: u32 = 0;
+    let mut freed_bytes: u64 = 0;
+    let keep = keep_versions as usize;
+
+    for versions in groups.values_mut() {
+        versions.sort_by(|a, b| alpm::vercmp(b.2.as_str(), a.2.as_str()));
+
+        for (entry, filename, _) in versions.iter().skip(keep) {
+            let path = entry.path();
+            let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    removed_count += 1;
+                    freed_bytes += size;
+                    emit_event(&StreamEvent::Log {
+                        level: "info".to_string(),
+                        message: format!("Removed {}", filename),
+                    });
+
+                    let sig_path = path.with_file_name(format!("{}.sig", filename));
+                    if sig_path.exists()
+                        && let Err(e) = fs::remove_file(&sig_path)
+                    {
+                        emit_event(&StreamEvent::Log {
+                            level: "warning".to_string(),
+                            message: format!("Failed to remove {}.sig: {}", filename, e),
+                        });
+                    }
+                }
+                Err(e) => {
+                    emit_event(&StreamEvent::Log {
+                        level: "warning".to_string(),
+                        message: format!("Failed to remove {}: {}", filename, e),
+                    });
+                }
+            }
         }
     }
 
-    if output.status.success() {
-        emit_event(&StreamEvent::Complete {
-            success: true,
-            message: Some("Cache cleanup completed".to_string()),
-        });
+    let message = if removed_count == 0 {
+        "No packages to remove".to_string()
     } else {
-        emit_event(&StreamEvent::Complete {
-            success: false,
-            message: Some(format!(
-                "paccache failed with exit code {}",
-                output.status.code().unwrap_or(-1)
-            )),
-        });
-    }
+        format!(
+            "Removed {} package{}, freed {}",
+            removed_count,
+            if removed_count == 1 { "" } else { "s" },
+            format_bytes(freed_bytes)
+        )
+    };
+
+    emit_event(&StreamEvent::Complete {
+        success: true,
+        message: Some(message),
+    });
 
     Ok(())
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB"];
+    let mut size = bytes as f64;
+    for unit in UNITS {
+        if size < 1024.0 {
+            return format!("{:.2} {}", size, unit);
+        }
+        size /= 1024.0;
+    }
+    format!("{:.2} TiB", size)
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -66,8 +66,9 @@ fn print_usage() {
     eprintln!("  add-ignored NAME       Add a package to the ignored list (requires root)");
     eprintln!("  remove-ignored NAME    Remove a package from the ignored list (requires root)");
     eprintln!("  cache-info             Show package cache information and size");
-    eprintln!("  clean-cache [KEEP]     Clean package cache (requires root)");
+    eprintln!("  clean-cache [KEEP] [PKGS]  Clean package cache (requires root)");
     eprintln!("                         KEEP: number of versions to keep (default: 3)");
+    eprintln!("                         PKGS: comma-separated package names to clean");
     eprintln!("  history [offset] [limit] [filter] [search]");
     eprintln!("                         View package history from pacman.log");
     eprintln!("                         filter: all|upgraded|installed|removed");
@@ -260,7 +261,23 @@ fn main() {
         "cache-info" => get_cache_info(),
         "clean-cache" => {
             let keep_versions = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(3);
-            validate_keep_versions(keep_versions).and_then(|_| clean_cache(keep_versions))
+            let filter_pkgs: Vec<String> = args
+                .get(3)
+                .filter(|s| !s.is_empty())
+                .map(|s| {
+                    s.split(',')
+                        .map(|p| p.trim().to_string())
+                        .filter(|p| !p.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            validate_keep_versions(keep_versions)
+                .and_then(|_| {
+                    filter_pkgs
+                        .iter()
+                        .try_for_each(|p| validate_package_name(p))
+                })
+                .and_then(|_| clean_cache(keep_versions, &filter_pkgs))
         }
         "history" => {
             let offset = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);

--- a/src/api.ts
+++ b/src/api.ts
@@ -725,8 +725,9 @@ export async function getCacheInfo(): Promise<CacheInfo> {
   return runBackend<CacheInfo>("cache-info");
 }
 
-export function cleanCache(callbacks: UpgradeCallbacks, keepVersions: number = 3): { cancel: () => void } {
-  return runStreamingBackend("clean-cache", [String(keepVersions)], callbacks);
+export function cleanCache(callbacks: UpgradeCallbacks, keepVersions: number = 3, packages?: string[]): { cancel: () => void } {
+  const pkgArg = packages && packages.length > 0 ? packages.map(pkg => sanitizeSearchInput(pkg)).join(",") : "";
+  return runStreamingBackend("clean-cache", [String(keepVersions), pkgArg], callbacks);
 }
 
 export interface LogEntry {

--- a/src/components/CacheView.tsx
+++ b/src/components/CacheView.tsx
@@ -10,6 +10,7 @@ import {
   CardBody,
   CardTitle,
   Button,
+  Checkbox,
   EmptyState,
   EmptyStateBody,
   EmptyStateActions,
@@ -71,6 +72,8 @@ export const CacheView: React.FC = () => {
   useBackdropClose(confirmModalOpen, () => setConfirmModalOpen(false));
   const [keepVersions, setKeepVersions] = useState(3);
   const [searchFilter, setSearchFilter] = useState("");
+  const [selectedPackages, setSelectedPackages] = useState<Set<string>>(new Set());
+  const hasInitializedSelection = useRef(false);
   const { selectedPackage, detailsLoading, detailsError, fetchDetails, clearDetails } = usePackageDetails();
   const { page, perPage, onSetPage, onPerPageSelect, resetPage } = usePagination();
   const cancelRef = useRef<(() => void) | null>(null);
@@ -123,6 +126,7 @@ export const CacheView: React.FC = () => {
     setLog("");
     setIsDetailsExpanded(true);
 
+    const packages = Array.from(selectedPackages);
     const { cancel } = cleanCache(
       {
         onData: (data) => setLog((prev) => {
@@ -139,7 +143,8 @@ export const CacheView: React.FC = () => {
           cancelRef.current = null;
         },
       },
-      keepVersions
+      keepVersions,
+      packages
     );
     cancelRef.current = cancel;
   };
@@ -171,6 +176,46 @@ export const CacheView: React.FC = () => {
       totalSize: versions.reduce((sum, v) => sum + v.size, 0),
     }));
   }, [cacheData]);
+
+  useEffect(() => {
+    if (groupedPackages.length === 0) {
+      hasInitializedSelection.current = false;
+      return;
+    }
+    if (hasInitializedSelection.current) {
+      setSelectedPackages((prev) => {
+        const existing = new Set(groupedPackages.map((g) => g.name));
+        const next = new Set<string>();
+        for (const pkg of prev) {
+          if (existing.has(pkg)) next.add(pkg);
+        }
+        return next;
+      });
+      return;
+    }
+    setSelectedPackages(new Set(groupedPackages.map((g) => g.name)));
+    hasInitializedSelection.current = true;
+  }, [groupedPackages]);
+
+  const togglePackageSelection = (name: string) => {
+    setSelectedPackages((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const selectAllPackages = () => {
+    setSelectedPackages(new Set(groupedPackages.map((g) => g.name)));
+  };
+
+  const deselectAllPackages = () => {
+    setSelectedPackages(new Set());
+  };
+
+  const areAllSelected = selectedPackages.size === groupedPackages.length && groupedPackages.length > 0;
+  const areSomeSelected = selectedPackages.size > 0 && selectedPackages.size < groupedPackages.length;
 
   const sortedGroups = useMemo(() => {
     return [...groupedPackages].sort((a, b) => {
@@ -384,8 +429,11 @@ export const CacheView: React.FC = () => {
                 variant="secondary"
                 icon={<TrashIcon />}
                 onClick={handleCleanCache}
+                isDisabled={selectedPackages.size === 0}
               >
-                Clean Cache
+                {selectedPackages.size > 0 && !areAllSelected
+                  ? `Clean ${selectedPackages.size} package${selectedPackages.size !== 1 ? "s" : ""}`
+                  : "Clean Cache"}
               </Button>
             </ToolbarItem>
             <ToolbarItem variant="pagination" align={{ default: "alignEnd" }}>
@@ -405,14 +453,32 @@ export const CacheView: React.FC = () => {
         <Table aria-label="Cached packages" variant="compact">
           <Thead>
             <Tr>
+              <Th screenReaderText="Select">
+                <Checkbox
+                  id="select-all-cache"
+                  isChecked={areAllSelected ? true : areSomeSelected ? null : false}
+                  onChange={(_event, checked) => checked ? selectAllPackages() : deselectAllPackages()}
+                  aria-label="Select all packages"
+                />
+              </Th>
               <Th sort={getSortParams(0)}>Package</Th>
               <Th sort={getSortParams(1)}>Version</Th>
               <Th sort={getSortParams(2)}>Size</Th>
             </Tr>
           </Thead>
           <Tbody>
-            {paginatedGroups.map((group) => (
-              <Tr key={group.name} isClickable onRowClick={() => handleRowClick(group.name)}>
+            {paginatedGroups.map((group) => {
+              const isSelected = selectedPackages.has(group.name);
+              return (
+              <Tr key={group.name} isClickable onRowClick={() => handleRowClick(group.name)} isRowSelected={isSelected}>
+                <Td
+                  select={{
+                    rowIndex: 0,
+                    onSelect: () => togglePackageSelection(group.name),
+                    isSelected,
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                />
                 <Td dataLabel="Package">
                   <Button variant="link" isInline className="pf-v6-u-p-0">
                     {group.name}
@@ -429,7 +495,8 @@ export const CacheView: React.FC = () => {
                 </Td>
                 <Td dataLabel="Size">{formatSize(group.totalSize)}</Td>
               </Tr>
-            ))}
+              );
+            })}
           </Tbody>
         </Table>
         <Toolbar>
@@ -458,7 +525,9 @@ export const CacheView: React.FC = () => {
         <ModalBody>
           <Content>
             <Content component={ContentVariants.p}>
-              This will remove old versions of cached packages, keeping only the most recent versions.
+              {areAllSelected
+                ? "This will remove old versions of all cached packages, keeping only the most recent versions."
+                : `This will clean ${selectedPackages.size} of ${groupedPackages.length} cached packages.`}
             </Content>
             <Content component={ContentVariants.p} className="pf-v6-u-mt-md pf-v6-u-mb-sm">
               <strong>Versions to keep:</strong>
@@ -481,12 +550,12 @@ export const CacheView: React.FC = () => {
             <Content component={ContentVariants.p} className="pf-v6-u-mt-md">
               {keepVersions === 0
                 ? "All cached packages will be removed."
-                : `The ${keepVersions} most recent version${keepVersions !== 1 ? "s" : ""} of each package will be kept.`}
+                : `The ${keepVersions} most recent version${keepVersions !== 1 ? "s" : ""} of each selected package will be kept.`}
             </Content>
           </Content>
         </ModalBody>
         <ModalFooter>
-          <Button key="confirm" variant="primary" onClick={startCleanup}>
+          <Button key="confirm" variant="primary" onClick={startCleanup} isDisabled={selectedPackages.size === 0}>
             Clean Cache
           </Button>
           <Button key="cancel" variant="link" onClick={() => setConfirmModalOpen(false)}>


### PR DESCRIPTION
Drop the pacman-contrib dependency by implementing cache cleanup directly with alpm. Packages are grouped by name, sorted by version, and pruned to keep only the N newest. Adds checkboxes to the cache table so users can select which packages to clean.

Closes: #28