### PR TITLE
fix: detect and recover from stale pacman database locks

### DIFF
--- a/backend/src/handlers/lock.rs
+++ b/backend/src/handlers/lock.rs
@@ -1,0 +1,98 @@
+use anyhow::{Context, Result};
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::util::emit_json;
+
+#[derive(Serialize)]
+pub struct LockStatus {
+    pub locked: bool,
+    pub stale: bool,
+    pub lock_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocking_process: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct LockRemoveResult {
+    pub removed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+fn db_path() -> PathBuf {
+    PathBuf::from(
+        pacmanconf::Config::new()
+            .ok()
+            .map(|c| c.db_path)
+            .unwrap_or_else(|| "/var/lib/pacman/".to_string()),
+    )
+}
+
+fn find_db_user(db_path: &Path) -> Option<String> {
+    for entry in fs::read_dir("/proc").ok()?.flatten() {
+        let pid = entry.file_name().to_str()?.to_string();
+        if !pid.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let fd_dir = entry.path().join("fd");
+        let fds = match fs::read_dir(&fd_dir) {
+            Ok(fds) => fds,
+            Err(_) => continue,
+        };
+        for fd in fds.flatten() {
+            if let Ok(target) = fs::read_link(fd.path())
+                && target.starts_with(db_path)
+            {
+                let comm = fs::read_to_string(entry.path().join("comm"))
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                return Some(format!("{} (pid {})", comm, pid));
+            }
+        }
+    }
+    None
+}
+
+pub fn check_lock() -> Result<()> {
+    let db = db_path();
+    let lock = db.join("db.lck");
+    let locked = lock.exists();
+    let blocking = if locked { find_db_user(&db) } else { None };
+    let stale = locked && blocking.is_none();
+
+    emit_json(&LockStatus {
+        locked,
+        stale,
+        lock_path: lock.to_string_lossy().to_string(),
+        blocking_process: blocking,
+    })
+}
+
+pub fn remove_stale_lock() -> Result<()> {
+    let db = db_path();
+    let lock = db.join("db.lck");
+
+    if !lock.exists() {
+        return emit_json(&LockRemoveResult {
+            removed: false,
+            error: Some("No lock file exists".to_string()),
+        });
+    }
+
+    if let Some(proc) = find_db_user(&db) {
+        return emit_json(&LockRemoveResult {
+            removed: false,
+            error: Some(format!("Database in use by {}", proc)),
+        });
+    }
+
+    fs::remove_file(&lock).context("Failed to remove lock file")?;
+
+    emit_json(&LockRemoveResult {
+        removed: true,
+        error: None,
+    })
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod dependency;
 pub mod downgrade;
 pub mod keyring;
+pub mod lock;
 pub mod log;
 pub mod mirrors;
 pub mod mutation;
@@ -18,6 +19,7 @@ pub use config::{add_ignored, list_ignored, remove_ignored};
 pub use dependency::get_dependency_tree;
 pub use downgrade::{downgrade_package, list_downgrades};
 pub use keyring::{init_keyring, keyring_status, refresh_keyring};
+pub use lock::{check_lock, remove_stale_lock};
 pub use log::{get_grouped_history, get_history};
 pub use mirrors::{fetch_mirror_status, list_mirrors, save_mirrorlist, test_mirrors};
 pub use mutation::{

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -77,7 +77,7 @@ pub fn preflight_upgrade(ignore_pkgs: &[String]) -> Result<()> {
         Ok(tx) => tx,
         Err(e) => {
             let response = PreflightResponse {
-                error: Some(format!("{}", e)),
+                error: Some(format!("{:#}", e)),
                 ..Default::default()
             };
             return emit_json(&response);

--- a/backend/src/handlers/scheduled.rs
+++ b/backend/src/handlers/scheduled.rs
@@ -347,7 +347,7 @@ pub fn scheduled_run() -> Result<()> {
                 success: false,
                 packages_checked,
                 packages_upgraded: 0,
-                error: Some(format!("Failed to initialize transaction: {}", e)),
+                error: Some(format!("{:#}", e)),
                 details,
             };
             log_run(&entry)?;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,14 +1,14 @@
 use std::env;
 
 use cockpit_pacman_backend::handlers::{
-    add_ignored, check_security, check_updates, clean_cache, downgrade_package,
+    add_ignored, check_lock, check_security, check_updates, clean_cache, downgrade_package,
     fetch_mirror_status, fetch_news, get_cache_info, get_dependency_tree, get_grouped_history,
     get_history, get_reboot_status, get_schedule_config, get_scheduled_runs, init_keyring,
     install_package, keyring_status, list_downgrades, list_ignored, list_installed, list_mirrors,
     list_orphans, local_package_info, preflight_upgrade, refresh_keyring, remove_ignored,
-    remove_orphans, remove_package, run_upgrade, save_mirrorlist, scheduled_run, search,
-    security_info, set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
-    sync_package_info, test_mirrors,
+    remove_orphans, remove_package, remove_stale_lock, run_upgrade, save_mirrorlist, scheduled_run,
+    search, security_info, set_schedule_config, signoff_list, signoff_revoke, signoff_sign,
+    sync_database, sync_package_info, test_mirrors,
 };
 use cockpit_pacman_backend::models::MirrorEntry;
 use cockpit_pacman_backend::validation::{
@@ -116,6 +116,10 @@ fn print_usage() {
     eprintln!("                         CREDS: base64-encoded JSON {{username, password}}");
     eprintln!("  check-security         Check installed packages against Arch Security Tracker");
     eprintln!("  security-info NAME     Get security advisory history for a package");
+    eprintln!(
+        "  check-lock             Check if the pacman database lock exists and if it's stale"
+    );
+    eprintln!("  remove-stale-lock      Remove a stale database lock (requires root)");
 }
 
 fn main() {
@@ -427,6 +431,8 @@ fn main() {
             }
             validate_package_name(&args[2]).and_then(|_| security_info(&args[2]))
         }
+        "check-lock" => check_lock(),
+        "remove-stale-lock" => remove_stale_lock(),
         "help" | "--help" | "-h" => {
             print_usage();
             Ok(())

--- a/src/api.ts
+++ b/src/api.ts
@@ -318,6 +318,26 @@ export async function checkUpdates(): Promise<UpdatesResponse> {
   return runBackend<UpdatesResponse>("check-updates");
 }
 
+export interface LockStatus {
+  locked: boolean;
+  stale: boolean;
+  lock_path: string;
+  blocking_process?: string;
+}
+
+export interface LockRemoveResult {
+  removed: boolean;
+  error?: string;
+}
+
+export async function checkLock(): Promise<LockStatus> {
+  return runBackend<LockStatus>("check-lock");
+}
+
+export async function removeStaleLock(): Promise<LockRemoveResult> {
+  return runBackend<LockRemoveResult>("remove-stale-lock", [], { superuser: "require" });
+}
+
 export interface PackageSecurityAdvisory {
   package: string;
   severity: string;

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -27,6 +27,8 @@ vi.mock("../api", async () => {
     getCacheInfo: vi.fn(),
     getKeyringStatus: vi.fn(),
     fetchNews: vi.fn(),
+    checkLock: vi.fn(),
+    removeStaleLock: vi.fn(),
   };
 });
 
@@ -41,6 +43,8 @@ const mockListOrphans = vi.mocked(api.listOrphans);
 const mockGetCacheInfo = vi.mocked(api.getCacheInfo);
 const mockGetKeyringStatus = vi.mocked(api.getKeyringStatus);
 const mockFetchNews = vi.mocked(api.fetchNews);
+const mockCheckLock = vi.mocked(api.checkLock);
+const mockRemoveStaleLock = vi.mocked(api.removeStaleLock);
 
 describe("UpdatesView", () => {
   beforeEach(() => {
@@ -72,6 +76,8 @@ describe("UpdatesView", () => {
       warnings: [],
     });
     mockFetchNews.mockResolvedValue(mockNewsResponseEmpty);
+    mockCheckLock.mockResolvedValue({ locked: true, stale: true, lock_path: "/var/lib/pacman/db.lck" });
+    mockRemoveStaleLock.mockResolvedValue({ removed: true });
     mockRunUpgrade.mockReturnValue({ cancel: vi.fn() });
     mockSyncDatabase.mockImplementation((callbacks) => {
       setTimeout(() => callbacks.onComplete(), 0);
@@ -493,14 +499,59 @@ describe("UpdatesView", () => {
       });
     });
 
-    it("displays lock error with special message", async () => {
+    it("displays lock error with stale lock recovery", async () => {
       mockCheckUpdates.mockRejectedValue(new Error("Unable to lock database"));
       render(<UpdatesView />);
 
       await waitFor(() => {
         expect(screen.getByText("Database is locked")).toBeInTheDocument();
       });
-      expect(screen.getByText(/Another package manager operation/)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/stale lock file/)).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /Remove stale lock/ })).toBeInTheDocument();
+    });
+
+    it("displays lock error for transaction init failure", async () => {
+      mockCheckUpdates.mockRejectedValue(new Error("Failed to initialize transaction: unable to lock database"));
+      render(<UpdatesView />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Database is locked")).toBeInTheDocument();
+      });
+    });
+
+    it("shows active process when lock is not stale", async () => {
+      mockCheckUpdates.mockRejectedValue(new Error("Unable to lock database"));
+      mockCheckLock.mockResolvedValue({
+        locked: true,
+        stale: false,
+        lock_path: "/var/lib/pacman/db.lck",
+        blocking_process: "pacman (pid 1234)",
+      });
+      render(<UpdatesView />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Database is locked")).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/pacman \(pid 1234\)/)).toBeInTheDocument();
+      });
+    });
+
+    it("auto-retries when lock is already cleared", async () => {
+      mockCheckUpdates.mockRejectedValueOnce(new Error("Unable to lock database"));
+      mockCheckUpdates.mockResolvedValueOnce(mockUpdatesResponse);
+      mockCheckLock.mockResolvedValue({
+        locked: false,
+        stale: false,
+        lock_path: "/var/lib/pacman/db.lck",
+      });
+      render(<UpdatesView />);
+
+      await waitFor(() => {
+        expect(mockCheckUpdates).toHaveBeenCalledTimes(2);
+      });
     });
 
     it("shows retry button on error", async () => {

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -79,6 +79,8 @@ import {
   getKeyringStatus,
   fetchNews,
   getSignoffList,
+  checkLock,
+  removeStaleLock,
 } from "../api";
 import type { KeyringCredentials } from "../api";
 
@@ -220,6 +222,74 @@ interface UpdatesViewProps {
   onViewSignoffs?: () => void;
   signoffCredentials?: KeyringCredentials | null;
 }
+
+const LockErrorBody: React.FC<{ onRetry: () => void }> = ({ onRetry }) => {
+  const [checking, setChecking] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [lockInfo, setLockInfo] = useState<{ stale: boolean; process?: string } | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setChecking(true);
+    checkLock()
+      .then((status) => {
+        if (!status.locked) {
+          onRetry();
+          return;
+        }
+        setLockInfo({ stale: status.stale, process: status.blocking_process });
+      })
+      .catch(() => setLockInfo(null))
+      .finally(() => setChecking(false));
+  }, [onRetry]);
+
+  const handleRemoveLock = async () => {
+    setRemoving(true);
+    setRemoveError(null);
+    try {
+      const result = await removeStaleLock();
+      if (result.removed) {
+        onRetry();
+      } else {
+        setRemoveError(result.error || "Failed to remove lock");
+      }
+    } catch (ex) {
+      setRemoveError(ex instanceof Error ? ex.message : String(ex));
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  if (checking) {
+    return <Content component={ContentVariants.p}>Checking lock status...</Content>;
+  }
+
+  if (lockInfo?.stale === false && lockInfo.process) {
+    return (
+      <Content component={ContentVariants.p}>
+        The database is locked by <strong>{lockInfo.process}</strong>. Wait for it to finish, then retry.
+      </Content>
+    );
+  }
+
+  return (
+    <>
+      <Content component={ContentVariants.p}>
+        A stale lock file is blocking database access. No package manager process is running.
+      </Content>
+      {removeError && (
+        <Content component={ContentVariants.p} className="pf-v6-u-mt-sm pf-v6-u-danger-color-100">
+          {removeError}
+        </Content>
+      )}
+      <Content component={ContentVariants.p} className="pf-v6-u-mt-sm">
+        <Button variant="primary" onClick={handleRemoveLock} isLoading={removing} isDisabled={removing}>
+          Remove stale lock and retry
+        </Button>
+      </Content>
+    </>
+  );
+};
 
 export const UpdatesView: React.FC<UpdatesViewProps> = ({ onViewDependencies, onViewHistory, onViewOrphans, onViewCache, onViewKeyring, onViewSignoffs, signoffCredentials }) => {
   const [state, setState] = useState<ViewState>("loading");
@@ -778,7 +848,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ onViewDependencies, on
   }
 
   if (state === "error") {
-    const isLockError = error?.toLowerCase().includes("unable to lock database");
+    const isLockError = error ? /unable to lock database|failed to initialize transaction/i.test(error) : false;
     const isNetworkError = error ? /failed to retrieve|unable to connect|could not resolve|timed\s+out|timeout|dns|connection refused/i.test(error) : false;
     return (
       <Card>
@@ -791,7 +861,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ onViewDependencies, on
           >
             <EmptyStateBody>
               {isLockError
-                ? "Another package manager operation is in progress. This could be a system upgrade, package installation, or database sync. Please wait for it to complete before checking for updates."
+                ? <LockErrorBody onRetry={loadUpdates} />
                 : error}
               {isNetworkError && !isLockError && (
                 <Content component={ContentVariants.p} className="pf-v6-u-mt-sm">


### PR DESCRIPTION
Stale db.lck files caused "Failed to initialize transaction" errors that the frontend didn't recognize as lock-related. The preflight handler used `format!("{}", e)` which stripped the root cause from the anyhow chain, and the scheduled handler double-wrapped the context.