### PR TITLE
feat: add mirrorlist backup history, restore, and delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 playwright-report/
 test-results/
 todo.txt
+.calira/

--- a/backend/src/handlers/mirrors.rs
+++ b/backend/src/handlers/mirrors.rs
@@ -7,8 +7,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::check_cancel_early;
 use crate::models::{
-    MirrorEntry, MirrorListResponse, MirrorStatus, MirrorStatusResponse, MirrorTestResult,
-    RefreshMirrorsResponse, SaveMirrorlistResponse, StreamEvent,
+    MirrorBackup, MirrorBackupListResponse, MirrorEntry, MirrorListResponse, MirrorStatus,
+    MirrorStatusResponse, MirrorTestResult, RefreshMirrorsResponse, RestoreMirrorBackupResponse,
+    SaveMirrorlistResponse, StreamEvent,
 };
 use crate::util::{TimeoutGuard, emit_event, emit_json, setup_signal_handler};
 use crate::validation::validate_mirror_url;
@@ -397,6 +398,130 @@ pub fn save_mirrorlist(mirrors: &[MirrorEntry]) -> Result<()> {
     };
 
     emit_json(&response)
+}
+
+fn count_mirrors_in_file(path: &Path) -> Result<(usize, usize)> {
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut enabled = 0usize;
+    let mut total = 0usize;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('#') {
+            let content = trimmed.trim_start_matches('#').trim();
+            if content.starts_with("Server") && parse_server_line(content).is_some() {
+                total += 1;
+            }
+            continue;
+        }
+
+        if trimmed.starts_with("Server") && parse_server_line(trimmed).is_some() {
+            enabled += 1;
+            total += 1;
+        }
+    }
+
+    Ok((enabled, total))
+}
+
+pub fn list_mirror_backups() -> Result<()> {
+    let parent = Path::new("/etc/pacman.d");
+    let mut backups: Vec<MirrorBackup> = Vec::new();
+
+    for entry in fs::read_dir(parent)? {
+        let entry = entry?;
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+
+        let timestamp_str = match name.strip_prefix("mirrorlist.backup.") {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let timestamp: i64 = match timestamp_str.parse() {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+
+        let metadata = entry.metadata()?;
+        let size = metadata.len();
+
+        let (enabled_count, total_count) = count_mirrors_in_file(&entry.path()).unwrap_or((0, 0));
+
+        let date = chrono::DateTime::from_timestamp(timestamp, 0)
+            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        backups.push(MirrorBackup {
+            timestamp,
+            date,
+            enabled_count,
+            total_count,
+            size,
+        });
+    }
+
+    backups.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    emit_json(&MirrorBackupListResponse { backups })
+}
+
+pub fn restore_mirror_backup(timestamp: i64) -> Result<()> {
+    let backup_path = format!("{}{}", BACKUP_PREFIX, timestamp);
+    let backup = Path::new(&backup_path);
+
+    if !backup.exists() {
+        anyhow::bail!("Backup not found: {}", backup_path);
+    }
+
+    let mirrorlist = Path::new(MIRRORLIST_PATH);
+
+    // Create a backup of the current mirrorlist before restoring
+    let pre_restore_backup = if mirrorlist.exists() {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let path = format!("{}{}", BACKUP_PREFIX, ts);
+        fs::copy(mirrorlist, &path)?;
+        Some(path)
+    } else {
+        None
+    };
+
+    fs::copy(backup, mirrorlist)?;
+
+    cleanup_old_backups()?;
+
+    let response = RestoreMirrorBackupResponse {
+        success: true,
+        backup_path: pre_restore_backup,
+        message: format!("Restored mirrorlist from backup {}", backup_path),
+    };
+
+    emit_json(&response)
+}
+
+pub fn delete_mirror_backup(timestamp: i64) -> Result<()> {
+    let backup_path = format!("{}{}", BACKUP_PREFIX, timestamp);
+    let backup = Path::new(&backup_path);
+
+    if !backup.exists() {
+        anyhow::bail!("Backup not found: {}", backup_path);
+    }
+
+    fs::remove_file(backup)?;
+
+    emit_json(&RestoreMirrorBackupResponse {
+        success: true,
+        backup_path: None,
+        message: format!("Deleted backup {}", backup_path),
+    })
 }
 
 fn cleanup_old_backups() -> Result<()> {

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -22,7 +22,8 @@ pub use keyring::{init_keyring, keyring_status, refresh_keyring};
 pub use lock::{check_lock, remove_stale_lock};
 pub use log::{get_grouped_history, get_history};
 pub use mirrors::{
-    fetch_mirror_status, list_mirrors, refresh_mirrors, save_mirrorlist, test_mirrors,
+    delete_mirror_backup, fetch_mirror_status, list_mirror_backups, list_mirrors, refresh_mirrors,
+    restore_mirror_backup, save_mirrorlist, test_mirrors,
 };
 pub use mutation::{
     install_package, preflight_upgrade, remove_orphans, remove_package, run_upgrade, sync_database,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,14 +1,15 @@
 use std::env;
 
 use cockpit_pacman_backend::handlers::{
-    add_ignored, check_lock, check_security, check_updates, clean_cache, downgrade_package,
-    fetch_mirror_status, fetch_news, get_cache_info, get_dependency_tree, get_grouped_history,
-    get_history, get_reboot_status, get_schedule_config, get_scheduled_runs, init_keyring,
-    install_package, keyring_status, list_downgrades, list_ignored, list_installed, list_mirrors,
-    list_orphans, local_package_info, preflight_upgrade, refresh_keyring, refresh_mirrors,
-    remove_ignored, remove_orphans, remove_package, remove_stale_lock, run_upgrade,
-    save_mirrorlist, scheduled_run, search, security_info, set_schedule_config, signoff_list,
-    signoff_revoke, signoff_sign, sync_database, sync_package_info, test_mirrors,
+    add_ignored, check_lock, check_security, check_updates, clean_cache, delete_mirror_backup,
+    downgrade_package, fetch_mirror_status, fetch_news, get_cache_info, get_dependency_tree,
+    get_grouped_history, get_history, get_reboot_status, get_schedule_config, get_scheduled_runs,
+    init_keyring, install_package, keyring_status, list_downgrades, list_ignored, list_installed,
+    list_mirror_backups, list_mirrors, list_orphans, local_package_info, preflight_upgrade,
+    refresh_keyring, refresh_mirrors, remove_ignored, remove_orphans, remove_package,
+    remove_stale_lock, restore_mirror_backup, run_upgrade, save_mirrorlist, scheduled_run, search,
+    security_info, set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
+    sync_package_info, test_mirrors,
 };
 use cockpit_pacman_backend::models::MirrorEntry;
 use cockpit_pacman_backend::validation::{
@@ -108,6 +109,11 @@ fn print_usage() {
     eprintln!("                         timeout: seconds (default: 60)");
     eprintln!("  save-mirrorlist <json> Save mirrorlist (requires root)");
     eprintln!("                         json: JSON array of mirror entries");
+    eprintln!("  list-mirror-backups    List available mirrorlist backups");
+    eprintln!("  restore-mirror-backup <timestamp>");
+    eprintln!("                         Restore a mirrorlist backup (requires root)");
+    eprintln!("  delete-mirror-backup <timestamp>");
+    eprintln!("                         Delete a mirrorlist backup (requires root)");
     eprintln!("  dependency-tree NAME [depth] [direction]");
     eprintln!("                         Get dependency tree for a package");
     eprintln!("                         depth: 1-10 (default: 3)");
@@ -399,6 +405,33 @@ fn main() {
                         .map_err(|e| anyhow::anyhow!("Invalid JSON: {}", e))
                 })
                 .and_then(|mirrors| save_mirrorlist(&mirrors))
+        }
+        "list-mirror-backups" => list_mirror_backups(),
+        "restore-mirror-backup" => {
+            if args.len() < 3 {
+                eprintln!("Error: restore-mirror-backup requires a timestamp");
+                std::process::exit(1);
+            }
+            match args[2].parse::<i64>() {
+                Ok(ts) => restore_mirror_backup(ts),
+                Err(_) => {
+                    eprintln!("Error: invalid timestamp '{}'", args[2]);
+                    std::process::exit(1);
+                }
+            }
+        }
+        "delete-mirror-backup" => {
+            if args.len() < 3 {
+                eprintln!("Error: delete-mirror-backup requires a timestamp");
+                std::process::exit(1);
+            }
+            match args[2].parse::<i64>() {
+                Ok(ts) => delete_mirror_backup(ts),
+                Err(_) => {
+                    eprintln!("Error: invalid timestamp '{}'", args[2]);
+                    std::process::exit(1);
+                }
+            }
         }
         "dependency-tree" => {
             if args.len() < 3 {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -432,6 +432,27 @@ pub struct RefreshMirrorsResponse {
     pub last_check: Option<String>,
 }
 
+#[derive(Serialize)]
+pub struct MirrorBackup {
+    pub timestamp: i64,
+    pub date: String,
+    pub enabled_count: usize,
+    pub total_count: usize,
+    pub size: u64,
+}
+
+#[derive(Serialize)]
+pub struct MirrorBackupListResponse {
+    pub backups: Vec<MirrorBackup>,
+}
+
+#[derive(Serialize)]
+pub struct RestoreMirrorBackupResponse {
+    pub success: bool,
+    pub backup_path: Option<String>,
+    pub message: String,
+}
+
 #[derive(Serialize, Clone)]
 pub struct DependencyNode {
     pub id: String,

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::models::{
-    NewsItem, NewsResponse, Package, PackageDetails, PackageListResponse, SearchResult, UpdateInfo,
-    UpdatesResponse,
+    MirrorBackup, MirrorBackupListResponse, NewsItem, NewsResponse, Package, PackageDetails,
+    PackageListResponse, RestoreMirrorBackupResponse, SearchResult, UpdateInfo, UpdatesResponse,
 };
 use crate::util::parse_package_filename;
 use crate::validation::{
@@ -1002,4 +1002,84 @@ mod integration {
         );
         assert!(pkg.isize() >= 0, "Package size should be non-negative");
     }
+}
+
+// --- Mirror backup serialization tests ---
+
+#[test]
+fn test_mirror_backup_serialization() {
+    let backup = MirrorBackup {
+        timestamp: 1704067200,
+        date: "2024-01-01 00:00:00 UTC".to_string(),
+        enabled_count: 3,
+        total_count: 10,
+        size: 2048,
+    };
+
+    let json = serde_json::to_string(&backup).unwrap();
+    assert!(json.contains("\"timestamp\":1704067200"));
+    assert!(json.contains("\"date\":\"2024-01-01 00:00:00 UTC\""));
+    assert!(json.contains("\"enabled_count\":3"));
+    assert!(json.contains("\"total_count\":10"));
+    assert!(json.contains("\"size\":2048"));
+}
+
+#[test]
+fn test_mirror_backup_list_response_serialization() {
+    let response = MirrorBackupListResponse {
+        backups: vec![
+            MirrorBackup {
+                timestamp: 1704067200,
+                date: "2024-01-01 00:00:00 UTC".to_string(),
+                enabled_count: 3,
+                total_count: 10,
+                size: 2048,
+            },
+            MirrorBackup {
+                timestamp: 1704060000,
+                date: "2023-12-31 22:00:00 UTC".to_string(),
+                enabled_count: 5,
+                total_count: 8,
+                size: 1024,
+            },
+        ],
+    };
+
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(json.contains("\"backups\":["));
+    assert!(json.contains("1704067200"));
+    assert!(json.contains("1704060000"));
+}
+
+#[test]
+fn test_mirror_backup_list_response_empty() {
+    let response = MirrorBackupListResponse { backups: vec![] };
+    let json = serde_json::to_string(&response).unwrap();
+    assert_eq!(json, "{\"backups\":[]}");
+}
+
+#[test]
+fn test_restore_mirror_backup_response_serialization() {
+    let response = RestoreMirrorBackupResponse {
+        success: true,
+        backup_path: Some("/etc/pacman.d/mirrorlist.backup.1704067200".to_string()),
+        message: "Restored mirrorlist from backup".to_string(),
+    };
+
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(json.contains("\"success\":true"));
+    assert!(json.contains("\"backup_path\":\"/etc/pacman.d/mirrorlist.backup.1704067200\""));
+    assert!(json.contains("\"message\":\"Restored mirrorlist from backup\""));
+}
+
+#[test]
+fn test_restore_mirror_backup_response_no_backup_path() {
+    let response = RestoreMirrorBackupResponse {
+        success: true,
+        backup_path: None,
+        message: "Restored mirrorlist".to_string(),
+    };
+
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(json.contains("\"backup_path\":null"));
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1045,6 +1045,36 @@ export async function refreshMirrors(params: RefreshMirrorsParams = {}): Promise
   ]);
 }
 
+export interface MirrorBackup {
+  timestamp: number;
+  date: string;
+  enabled_count: number;
+  total_count: number;
+  size: number;
+}
+
+export interface MirrorBackupListResponse {
+  backups: MirrorBackup[];
+}
+
+export interface RestoreMirrorBackupResponse {
+  success: boolean;
+  backup_path: string | null;
+  message: string;
+}
+
+export async function listMirrorBackups(): Promise<MirrorBackupListResponse> {
+  return runBackend<MirrorBackupListResponse>("list-mirror-backups");
+}
+
+export async function restoreMirrorBackup(timestamp: number): Promise<RestoreMirrorBackupResponse> {
+  return runBackend<RestoreMirrorBackupResponse>("restore-mirror-backup", [String(timestamp)], { superuser: "require" });
+}
+
+export async function deleteMirrorBackup(timestamp: number): Promise<RestoreMirrorBackupResponse> {
+  return runBackend<RestoreMirrorBackupResponse>("delete-mirror-backup", [String(timestamp)], { superuser: "require" });
+}
+
 export interface DependencyNode {
   id: string;
   name: string;

--- a/src/components/MirrorsView.test.tsx
+++ b/src/components/MirrorsView.test.tsx
@@ -11,12 +11,16 @@ vi.mock("../api", async () => {
     fetchMirrorStatus: vi.fn(),
     testMirrors: vi.fn(),
     saveMirrorlist: vi.fn(),
+    listMirrorBackups: vi.fn(),
+    restoreMirrorBackup: vi.fn(),
   };
 });
 
 const mockListMirrors = vi.mocked(api.listMirrors);
 const mockFetchMirrorStatus = vi.mocked(api.fetchMirrorStatus);
 const mockSaveMirrorlist = vi.mocked(api.saveMirrorlist);
+const mockListMirrorBackups = vi.mocked(api.listMirrorBackups);
+const mockRestoreMirrorBackup = vi.mocked(api.restoreMirrorBackup);
 
 const mockMirrorResponse: api.MirrorListResponse = {
   mirrors: [
@@ -241,5 +245,158 @@ describe("MirrorsView", () => {
     expect(moveUpButtons[0]).toBeDisabled();
     // Last mirror's move down should be disabled
     expect(moveDownButtons[moveDownButtons.length - 1]).toBeDisabled();
+  });
+
+  it("shows backup history section", async () => {
+    render(<MirrorsView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Backup history")).toBeInTheDocument();
+  });
+
+  it("loads backups when expanding backup history", async () => {
+    mockListMirrorBackups.mockResolvedValue({
+      backups: [
+        {
+          timestamp: 1704067200,
+          date: "2024-01-01 00:00:00 UTC",
+          enabled_count: 3,
+          total_count: 10,
+          size: 2048,
+        },
+      ],
+    });
+
+    render(<MirrorsView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Backup history"));
+    });
+
+    await waitFor(() => {
+      expect(mockListMirrorBackups).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("2024-01-01 00:00:00 UTC")).toBeInTheDocument();
+      expect(screen.getByText("3 enabled / 10 total")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no backups exist", async () => {
+    mockListMirrorBackups.mockResolvedValue({ backups: [] });
+
+    render(<MirrorsView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Backup history"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No backups found/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows restore confirmation modal", async () => {
+    mockListMirrorBackups.mockResolvedValue({
+      backups: [
+        {
+          timestamp: 1704067200,
+          date: "2024-01-01 00:00:00 UTC",
+          enabled_count: 3,
+          total_count: 10,
+          size: 2048,
+        },
+      ],
+    });
+
+    render(<MirrorsView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Backup history"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("2024-01-01 00:00:00 UTC")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Restore/ }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Restore mirrorlist backup?")).toBeInTheDocument();
+    });
+  });
+
+  it("restores backup and reloads mirrors", async () => {
+    mockListMirrorBackups.mockResolvedValue({
+      backups: [
+        {
+          timestamp: 1704067200,
+          date: "2024-01-01 00:00:00 UTC",
+          enabled_count: 3,
+          total_count: 10,
+          size: 2048,
+        },
+      ],
+    });
+    mockRestoreMirrorBackup.mockResolvedValue({
+      success: true,
+      backup_path: "/etc/pacman.d/mirrorlist.backup.1704067201",
+      message: "Restored",
+    });
+
+    render(<MirrorsView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Backup history"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("2024-01-01 00:00:00 UTC")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Restore/ }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Restore mirrorlist backup?")).toBeInTheDocument();
+    });
+
+    // Click the confirm Restore button in the modal
+    const modalButtons = screen.getAllByRole("button", { name: /^Restore$/ });
+    await act(async () => {
+      fireEvent.click(modalButtons[modalButtons.length - 1]);
+    });
+
+    await waitFor(() => {
+      expect(mockRestoreMirrorBackup).toHaveBeenCalledWith(1704067200);
+    });
+
+    // Should reload mirrors after restore
+    await waitFor(() => {
+      expect(mockListMirrors).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/components/MirrorsView.tsx
+++ b/src/components/MirrorsView.tsx
@@ -38,6 +38,7 @@ import {
   FormSelect,
   FormSelectOption,
   NumberInput,
+  Checkbox,
 } from "@patternfly/react-core";
 import {
   GlobeIcon,
@@ -48,6 +49,9 @@ import {
   SyncAltIcon,
   OutlinedClockIcon,
   ExclamationCircleIcon,
+  HistoryIcon,
+  UndoIcon,
+  TrashIcon,
 } from "@patternfly/react-icons";
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from "@patternfly/react-table";
 import { StatBox } from "./StatBox";
@@ -60,13 +64,18 @@ import {
   RefreshMirrorsResponse,
   RefreshMirrorsProtocol,
   RefreshMirrorsSortBy,
+  MirrorBackup,
   listMirrors,
   fetchMirrorStatus,
   testMirrors,
   saveMirrorlist,
   refreshMirrors,
+  listMirrorBackups,
+  restoreMirrorBackup,
+  deleteMirrorBackup,
   formatNumber,
   formatDate,
+  formatSize,
 } from "../api";
 import { sanitizeErrorMessage } from "../utils";
 
@@ -186,6 +195,14 @@ export const MirrorsView: React.FC = () => {
   const [refreshSortBy, setRefreshSortBy] = useState<RefreshMirrorsSortBy>("score");
   const [refreshError, setRefreshError] = useState<string | null>(null);
   useBackdropClose(refreshModalOpen, () => { if (!refreshLoading) setRefreshModalOpen(false); });
+  const [backups, setBackups] = useState<MirrorBackup[]>([]);
+  const [backupsExpanded, setBackupsExpanded] = useState(false);
+  const [backupsLoading, setBackupsLoading] = useState(false);
+  const [restoringTimestamp, setRestoringTimestamp] = useState<number | null>(null);
+  const [selectedBackups, setSelectedBackups] = useState<Set<number>>(new Set());
+  const [deletingBackups, setDeletingBackups] = useState(false);
+  const [restoreConfirmTimestamp, setRestoreConfirmTimestamp] = useState<number | null>(null);
+  useBackdropClose(restoreConfirmTimestamp !== null, () => setRestoreConfirmTimestamp(null));
   const cancelRef = useRef<(() => void) | null>(null);
   const logContainerRef = useRef<HTMLDivElement | null>(null);
   const initialStatusFetchedRef = useRef(false);
@@ -269,6 +286,69 @@ export const MirrorsView: React.FC = () => {
       setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
     }
+  };
+
+  const loadBackups = useCallback(async () => {
+    setBackupsLoading(true);
+    try {
+      const response = await listMirrorBackups();
+      setBackups(response.backups);
+    } catch {
+      setBackups([]);
+    } finally {
+      setBackupsLoading(false);
+    }
+  }, []);
+
+  const handleBackupsToggle = (_event: React.MouseEvent | undefined, expanded: boolean) => {
+    setBackupsExpanded(expanded);
+    if (expanded && backups.length === 0) {
+      loadBackups();
+    }
+  };
+
+  const handleRestore = async (timestamp: number) => {
+    setRestoreConfirmTimestamp(null);
+    setRestoringTimestamp(timestamp);
+    setError(null);
+    try {
+      await restoreMirrorBackup(timestamp);
+      await loadMirrors();
+      await loadBackups();
+    } catch (ex) {
+      setError(ex instanceof Error ? ex.message : String(ex));
+    } finally {
+      setRestoringTimestamp(null);
+    }
+  };
+
+  const toggleBackupSelection = (timestamp: number) => {
+    setSelectedBackups(prev => {
+      const next = new Set(prev);
+      if (next.has(timestamp)) next.delete(timestamp);
+      else next.add(timestamp);
+      return next;
+    });
+  };
+
+  const selectAllBackups = () => setSelectedBackups(new Set(backups.map(b => b.timestamp)));
+  const deselectAllBackups = () => setSelectedBackups(new Set());
+  const allBackupsSelected = backups.length > 0 && selectedBackups.size === backups.length;
+  const someBackupsSelected = selectedBackups.size > 0 && selectedBackups.size < backups.length;
+
+  const handleDeleteSelected = async () => {
+    if (selectedBackups.size === 0) return;
+    setDeletingBackups(true);
+    const results = await Promise.allSettled(
+      Array.from(selectedBackups).map(ts => deleteMirrorBackup(ts))
+    );
+    const failed = results.filter(r => r.status === "rejected").length;
+    if (failed > 0) {
+      setError(`Failed to delete ${failed} of ${selectedBackups.size} backup${selectedBackups.size !== 1 ? "s" : ""}`);
+    }
+    await loadBackups();
+    setSelectedBackups(new Set());
+    setDeletingBackups(false);
   };
 
   const handleTestMirrors = () => {
@@ -834,6 +914,94 @@ export const MirrorsView: React.FC = () => {
           </Tbody>
         </Table>
 
+        <ExpandableSection
+          toggleText={backupsExpanded ? "Hide backup history" : "Backup history"}
+          onToggle={handleBackupsToggle}
+          isExpanded={backupsExpanded}
+          className="pf-v6-u-mt-lg"
+        >
+          {backupsLoading ? (
+            <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }} className="pf-v6-u-py-md">
+              <FlexItem><Spinner size="md" /></FlexItem>
+              <FlexItem>Loading backups...</FlexItem>
+            </Flex>
+          ) : backups.length === 0 ? (
+            <Content component={ContentVariants.p} className="pf-v6-u-py-md" style={{ color: "var(--pf-t--global--text--color--subtle)" }}>
+              No backups found. Backups are created automatically when saving the mirrorlist.
+            </Content>
+          ) : (
+            <>
+            <Flex className="pf-v6-u-mb-sm" spaceItems={{ default: "spaceItemsSm" }}>
+              <FlexItem>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  icon={<TrashIcon />}
+                  onClick={handleDeleteSelected}
+                  isDisabled={selectedBackups.size === 0 || deletingBackups || restoringTimestamp !== null}
+                  isLoading={deletingBackups}
+                >
+                  Delete {selectedBackups.size > 0 ? `(${selectedBackups.size})` : "selected"}
+                </Button>
+              </FlexItem>
+            </Flex>
+            <Table aria-label="Mirrorlist backups" variant="compact">
+              <Thead>
+                <Tr>
+                  <Th screenReaderText="Select">
+                    <Checkbox
+                      id="select-all-backups"
+                      isChecked={allBackupsSelected ? true : someBackupsSelected ? null : false}
+                      onChange={(_event, checked) => checked ? selectAllBackups() : deselectAllBackups()}
+                      aria-label="Select all backups"
+                    />
+                  </Th>
+                  <Th>Date</Th>
+                  <Th>Mirrors</Th>
+                  <Th>Size</Th>
+                  <Th width={10}>Actions</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {backups.map((backup) => (
+                  <Tr key={backup.timestamp}>
+                    <Td
+                      select={{
+                        rowIndex: backup.timestamp,
+                        onSelect: () => toggleBackupSelection(backup.timestamp),
+                        isSelected: selectedBackups.has(backup.timestamp),
+                      }}
+                    />
+                    <Td dataLabel="Date">
+                      <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }}>
+                        <FlexItem><HistoryIcon /></FlexItem>
+                        <FlexItem>{backup.date}</FlexItem>
+                      </Flex>
+                    </Td>
+                    <Td dataLabel="Mirrors">
+                      {backup.enabled_count} enabled / {backup.total_count} total
+                    </Td>
+                    <Td dataLabel="Size">{formatSize(backup.size)}</Td>
+                    <Td dataLabel="Actions">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        icon={<UndoIcon />}
+                        onClick={() => setRestoreConfirmTimestamp(backup.timestamp)}
+                        isDisabled={restoringTimestamp !== null || deletingBackups}
+                        isLoading={restoringTimestamp === backup.timestamp}
+                      >
+                        Restore
+                      </Button>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+            </>
+          )}
+        </ExpandableSection>
+
         {statusData && (
           <div className="pf-v6-u-mt-md" style={{ fontSize: "0.75rem", color: "var(--pf-t--global--text--color--subtle)" }}>
             Mirror status from archlinux.org: {statusData.last_check || "Unknown"}
@@ -995,6 +1163,38 @@ export const MirrorsView: React.FC = () => {
             onClick={() => setRefreshModalOpen(false)}
             isDisabled={refreshLoading}
           >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      <Modal
+        variant={ModalVariant.small}
+        isOpen={restoreConfirmTimestamp !== null}
+        onClose={() => setRestoreConfirmTimestamp(null)}
+      >
+        <ModalHeader title="Restore mirrorlist backup?" />
+        <ModalBody>
+          <Content>
+            <Content component={ContentVariants.p}>
+              This will replace the current <code>/etc/pacman.d/mirrorlist</code> with the selected backup.
+              A backup of the current state will be created first.
+            </Content>
+            {restoreConfirmTimestamp !== null && (() => {
+              const b = backups.find(x => x.timestamp === restoreConfirmTimestamp);
+              return b ? (
+                <Content component={ContentVariants.p} className="pf-v6-u-mt-md">
+                  Backup from <strong>{b.date}</strong> with {b.enabled_count} enabled mirrors.
+                </Content>
+              ) : null;
+            })()}
+          </Content>
+        </ModalBody>
+        <ModalFooter>
+          <Button key="confirm" variant="primary" onClick={() => restoreConfirmTimestamp !== null && handleRestore(restoreConfirmTimestamp)}>
+            Restore
+          </Button>
+          <Button key="cancel" variant="link" onClick={() => setRestoreConfirmTimestamp(null)}>
             Cancel
           </Button>
         </ModalFooter>


### PR DESCRIPTION
list-mirror-backups reads `/etc/pacman.d/mirrorlist.backup.*` files, returns them sorted newest-first with mirror counts and timestamps. restore-mirror-backup copies a backup over the active mirrorlist (backing up the current state first). delete-mirror-backup removes a specific backup file.