### PR TITLE
fix: detect broken IPv6 for HTTP requests

### DIFF
--- a/backend/crates/arch-security-client/src/lib.rs
+++ b/backend/crates/arch-security-client/src/lib.rs
@@ -15,14 +15,15 @@ pub struct SecurityClient {
 }
 
 impl SecurityClient {
-    pub fn new() -> Self {
-        Self::with_base_url(DEFAULT_BASE_URL)
+    pub fn new(ip_family: ureq::config::IpFamily) -> Self {
+        Self::with_base_url(DEFAULT_BASE_URL, ip_family)
     }
 
-    pub fn with_base_url(url: &str) -> Self {
+    pub fn with_base_url(url: &str, ip_family: ureq::config::IpFamily) -> Self {
         let config = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(15)))
             .timeout_connect(Some(Duration::from_secs(5)))
+            .ip_family(ip_family)
             .build();
         Self {
             agent: ureq::Agent::new_with_config(config),
@@ -59,12 +60,6 @@ impl SecurityClient {
             .take(MAX_RESPONSE_BYTES)
             .read_to_end(&mut buf)?;
         String::from_utf8(buf).context("response is not valid UTF-8")
-    }
-}
-
-impl Default for SecurityClient {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/backend/crates/archweb-client/src/lib.rs
+++ b/backend/crates/archweb-client/src/lib.rs
@@ -17,13 +17,19 @@ pub struct SignoffSession {
 }
 
 impl SignoffSession {
-    pub fn login(username: &str, password: &str, base_url: &str) -> Result<Self> {
+    pub fn login(
+        username: &str,
+        password: &str,
+        base_url: &str,
+        ip_family: ureq::config::IpFamily,
+    ) -> Result<Self> {
         let config = ureq::Agent::config_builder()
             .timeout_global(Some(std::time::Duration::from_secs(20)))
             .timeout_connect(Some(std::time::Duration::from_secs(10)))
             .timeout_send_body(Some(std::time::Duration::from_secs(10)))
             .timeout_recv_body(Some(std::time::Duration::from_secs(15)))
             .max_redirects(3)
+            .ip_family(ip_family)
             .build();
         let agent = ureq::Agent::new_with_config(config);
         let mut session = Self {

--- a/backend/src/handlers/mirrors.rs
+++ b/backend/src/handlers/mirrors.rs
@@ -126,6 +126,7 @@ pub fn fetch_mirror_status() -> Result<()> {
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(30)))
+            .ip_family(crate::util::detected_ip_family())
             .build(),
     );
 
@@ -168,6 +169,7 @@ pub fn refresh_mirrors(
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(30)))
+            .ip_family(crate::util::detected_ip_family())
             .build(),
     );
 
@@ -250,6 +252,7 @@ pub fn test_mirrors(urls: &[String], timeout_secs: u64) -> Result<()> {
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(10)))
+            .ip_family(crate::util::detected_ip_family())
             .build(),
     );
 

--- a/backend/src/handlers/news.rs
+++ b/backend/src/handlers/news.rs
@@ -19,6 +19,7 @@ fn fetch_news_items(days: u32) -> Result<Vec<NewsItem>> {
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(15)))
+            .ip_family(crate::util::detected_ip_family())
             .build(),
     );
 

--- a/backend/src/handlers/security.rs
+++ b/backend/src/handlers/security.rs
@@ -9,7 +9,7 @@ use crate::models::{PackageSecurityAdvisory, SecurityInfoResponse, SecurityRespo
 use crate::util::emit_json;
 
 pub fn check_security() -> Result<()> {
-    let client = SecurityClient::new();
+    let client = SecurityClient::new(crate::util::detected_ip_family());
     let avgs = match client.fetch_vulnerable() {
         Ok(v) => v,
         Err(e) => {
@@ -84,7 +84,7 @@ pub fn check_security() -> Result<()> {
 }
 
 pub fn security_info(name: &str) -> Result<()> {
-    let client = SecurityClient::new();
+    let client = SecurityClient::new(crate::util::detected_ip_family());
     let info = client.fetch_package(name)?;
 
     let advisories: Vec<_> = info

--- a/backend/src/handlers/signoff.rs
+++ b/backend/src/handlers/signoff.rs
@@ -40,7 +40,12 @@ fn get_local_version(handle: &alpm::Alpm, pkgbase: &str, pkgnames: &[String]) ->
 
 pub fn signoff_list(creds_b64: &str) -> Result<()> {
     let (username, password) = resolve_credentials(creds_b64)?;
-    let session = SignoffSession::login(&username, &password, DEFAULT_BASE_URL)?;
+    let session = SignoffSession::login(
+        &username,
+        &password,
+        DEFAULT_BASE_URL,
+        crate::util::detected_ip_family(),
+    )?;
     let groups = session.get_signoffs()?;
     session.logout();
 
@@ -105,7 +110,12 @@ fn run_signoff_action(
     let pkgbase = &args[1];
 
     let (username, password) = resolve_credentials(&args[0])?;
-    let session = SignoffSession::login(&username, &password, DEFAULT_BASE_URL)?;
+    let session = SignoffSession::login(
+        &username,
+        &password,
+        DEFAULT_BASE_URL,
+        crate::util::detected_ip_family(),
+    )?;
     let spec = SignoffSpec {
         repo: args[2].clone(),
         arch: args[3].clone(),

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -2,10 +2,34 @@ use anyhow::Result;
 use serde::Serialize;
 use std::cmp::Ordering;
 use std::io::{self, Write};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant};
+use ureq::config::IpFamily;
 
 use crate::models::StreamEvent;
+
+static DETECTED_IP_FAMILY: LazyLock<IpFamily> = LazyLock::new(|| {
+    // Resolve archlinux.org and probe its AAAA record with a short TCP connect.
+    let ipv6_addr = ("archlinux.org", 443)
+        .to_socket_addrs()
+        .ok()
+        .and_then(|addrs| addrs.into_iter().find(SocketAddr::is_ipv6));
+
+    let Some(addr) = ipv6_addr else {
+        return IpFamily::Any;
+    };
+
+    match TcpStream::connect_timeout(&addr, Duration::from_millis(500)) {
+        Ok(_) => IpFamily::Any,
+        Err(_) => IpFamily::Ipv4Only,
+    }
+});
+
+pub fn detected_ip_family() -> IpFamily {
+    *DETECTED_IP_FAMILY
+}
 
 static CANCELLED: AtomicBool = AtomicBool::new(false);
 


### PR DESCRIPTION
ureq defaults to IpFamily::Any, which resolves AAAA records first on dual-stack systems. On networks with broken IPv6 routing (packets black-holed rather than rejected), every HTTP request hangs until the 15-30s connect timeout expires.