### PR TITLE
feat: show per-repository mirrors from pacman.conf

### DIFF
--- a/backend/src/handlers/mirrors.rs
+++ b/backend/src/handlers/mirrors.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use crate::check_cancel_early;
 use crate::models::{
     MirrorBackup, MirrorBackupListResponse, MirrorEntry, MirrorListResponse, MirrorStatus,
-    MirrorStatusResponse, MirrorTestResult, RefreshMirrorsResponse, RestoreMirrorBackupResponse,
-    SaveMirrorlistResponse, StreamEvent,
+    MirrorStatusResponse, MirrorTestResult, RefreshMirrorsResponse, RepoConfig, RepoDirective,
+    RepoMirrorsResponse, RestoreMirrorBackupResponse, SaveMirrorlistResponse, StreamEvent,
 };
 use crate::util::{TimeoutGuard, emit_event, emit_json, setup_signal_handler};
 use crate::validation::validate_mirror_url;
@@ -559,4 +559,58 @@ fn cleanup_old_backups() -> Result<()> {
     }
 
     Ok(())
+}
+
+const PACMAN_CONF_PATH: &str = "/etc/pacman.conf";
+
+pub fn list_repo_mirrors() -> Result<()> {
+    let path = Path::new(PACMAN_CONF_PATH);
+    if !path.exists() {
+        anyhow::bail!("pacman.conf not found at {}", PACMAN_CONF_PATH);
+    }
+
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut repos: Vec<RepoConfig> = Vec::new();
+    let mut in_repo = false;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let section = &trimmed[1..trimmed.len() - 1];
+            if section == "options" {
+                in_repo = false;
+            } else {
+                in_repo = true;
+                repos.push(RepoConfig {
+                    name: section.to_string(),
+                    directives: Vec::new(),
+                });
+            }
+        } else if in_repo && let Some(repo_config) = repos.last_mut() {
+            if let Some(value) = trimmed
+                .strip_prefix("Server")
+                .and_then(|s| s.trim_start().strip_prefix('='))
+                .map(|s| s.trim())
+            {
+                repo_config.directives.push(RepoDirective {
+                    directive_type: "Server".to_string(),
+                    value: value.to_string(),
+                });
+            } else if let Some(value) = trimmed
+                .strip_prefix("Include")
+                .and_then(|s| s.trim_start().strip_prefix('='))
+                .map(|s| s.trim())
+            {
+                repo_config.directives.push(RepoDirective {
+                    directive_type: "Include".to_string(),
+                    value: value.to_string(),
+                });
+            }
+        }
+    }
+
+    emit_json(&RepoMirrorsResponse { repos })
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -22,8 +22,8 @@ pub use keyring::{init_keyring, keyring_status, refresh_keyring};
 pub use lock::{check_lock, remove_stale_lock};
 pub use log::{get_grouped_history, get_history};
 pub use mirrors::{
-    delete_mirror_backup, fetch_mirror_status, list_mirror_backups, list_mirrors, refresh_mirrors,
-    restore_mirror_backup, save_mirrorlist, test_mirrors,
+    delete_mirror_backup, fetch_mirror_status, list_mirror_backups, list_mirrors,
+    list_repo_mirrors, refresh_mirrors, restore_mirror_backup, save_mirrorlist, test_mirrors,
 };
 pub use mutation::{
     install_package, preflight_upgrade, remove_orphans, remove_package, run_upgrade, sync_database,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,11 +5,11 @@ use cockpit_pacman_backend::handlers::{
     downgrade_package, fetch_mirror_status, fetch_news, get_cache_info, get_dependency_tree,
     get_grouped_history, get_history, get_reboot_status, get_schedule_config, get_scheduled_runs,
     init_keyring, install_package, keyring_status, list_downgrades, list_ignored, list_installed,
-    list_mirror_backups, list_mirrors, list_orphans, local_package_info, preflight_upgrade,
-    refresh_keyring, refresh_mirrors, remove_ignored, remove_orphans, remove_package,
-    remove_stale_lock, restore_mirror_backup, run_upgrade, save_mirrorlist, scheduled_run, search,
-    security_info, set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
-    sync_package_info, test_mirrors,
+    list_mirror_backups, list_mirrors, list_orphans, list_repo_mirrors, local_package_info,
+    preflight_upgrade, refresh_keyring, refresh_mirrors, remove_ignored, remove_orphans,
+    remove_package, remove_stale_lock, restore_mirror_backup, run_upgrade, save_mirrorlist,
+    scheduled_run, search, security_info, set_schedule_config, signoff_list, signoff_revoke,
+    signoff_sign, sync_database, sync_package_info, test_mirrors,
 };
 use cockpit_pacman_backend::models::MirrorEntry;
 use cockpit_pacman_backend::validation::{
@@ -96,6 +96,7 @@ fn print_usage() {
     eprintln!("  scheduled-run          Execute scheduled operation (called by systemd)");
     eprintln!("  reboot-status          Check if system reboot is recommended");
     eprintln!("  list-mirrors           List mirrors from /etc/pacman.d/mirrorlist");
+    eprintln!("  list-repo-mirrors      List per-repository mirror servers from pacman.conf");
     eprintln!("  fetch-mirror-status    Fetch mirror status from archlinux.org API");
     eprintln!("  refresh-mirrors [count] [country] [protocol] [sort_by]");
     eprintln!("                         Generate a ranked mirrorlist from archlinux.org API");
@@ -363,6 +364,7 @@ fn main() {
         "scheduled-run" => scheduled_run(),
         "reboot-status" => get_reboot_status(),
         "list-mirrors" => list_mirrors(),
+        "list-repo-mirrors" => list_repo_mirrors(),
         "fetch-mirror-status" => fetch_mirror_status(),
         "refresh-mirrors" => {
             let count = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(20usize);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -453,6 +453,23 @@ pub struct RestoreMirrorBackupResponse {
     pub message: String,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct RepoDirective {
+    pub directive_type: String,
+    pub value: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RepoConfig {
+    pub name: String,
+    pub directives: Vec<RepoDirective>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RepoMirrorsResponse {
+    pub repos: Vec<RepoConfig>,
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct DependencyNode {
     pub id: String,

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::models::{
     MirrorBackup, MirrorBackupListResponse, NewsItem, NewsResponse, Package, PackageDetails,
-    PackageListResponse, RestoreMirrorBackupResponse, SearchResult, UpdateInfo, UpdatesResponse,
+    PackageListResponse, RepoConfig, RepoDirective, RepoMirrorsResponse,
+    RestoreMirrorBackupResponse, SearchResult, UpdateInfo, UpdatesResponse,
 };
 use crate::util::parse_package_filename;
 use crate::validation::{
@@ -1082,4 +1083,49 @@ fn test_restore_mirror_backup_response_no_backup_path() {
 
     let json = serde_json::to_string(&response).unwrap();
     assert!(json.contains("\"backup_path\":null"));
+}
+
+#[test]
+fn test_repo_mirrors_response_serialization() {
+    let response = RepoMirrorsResponse {
+        repos: vec![
+            RepoConfig {
+                name: "core".to_string(),
+                directives: vec![RepoDirective {
+                    directive_type: "Include".to_string(),
+                    value: "/etc/pacman.d/mirrorlist".to_string(),
+                }],
+            },
+            RepoConfig {
+                name: "multilib".to_string(),
+                directives: vec![
+                    RepoDirective {
+                        directive_type: "Server".to_string(),
+                        value: "https://geo.mirror.pkgbuild.com/$repo/os/$arch".to_string(),
+                    },
+                    RepoDirective {
+                        directive_type: "Include".to_string(),
+                        value: "/etc/pacman.d/mirrorlist".to_string(),
+                    },
+                ],
+            },
+        ],
+    };
+
+    let json = serde_json::to_string(&response).unwrap();
+    let parsed: RepoMirrorsResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.repos.len(), 2);
+    assert_eq!(parsed.repos[0].name, "core");
+    assert_eq!(parsed.repos[0].directives.len(), 1);
+    assert_eq!(parsed.repos[0].directives[0].directive_type, "Include");
+    assert_eq!(parsed.repos[1].name, "multilib");
+    assert_eq!(parsed.repos[1].directives.len(), 2);
+    assert_eq!(parsed.repos[1].directives[0].directive_type, "Server");
+}
+
+#[test]
+fn test_repo_mirrors_response_empty() {
+    let response = RepoMirrorsResponse { repos: vec![] };
+    let json = serde_json::to_string(&response).unwrap();
+    assert_eq!(json, "{\"repos\":[]}");
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1075,6 +1075,24 @@ export async function deleteMirrorBackup(timestamp: number): Promise<RestoreMirr
   return runBackend<RestoreMirrorBackupResponse>("delete-mirror-backup", [String(timestamp)], { superuser: "require" });
 }
 
+export interface RepoDirective {
+  directive_type: "Server" | "Include";
+  value: string;
+}
+
+export interface RepoConfig {
+  name: string;
+  directives: RepoDirective[];
+}
+
+export interface RepoMirrorsResponse {
+  repos: RepoConfig[];
+}
+
+export async function listRepoMirrors(): Promise<RepoMirrorsResponse> {
+  return runBackend<RepoMirrorsResponse>("list-repo-mirrors");
+}
+
 export interface DependencyNode {
   id: string;
   name: string;

--- a/src/components/MirrorsView.test.tsx
+++ b/src/components/MirrorsView.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../api", async () => {
 
 const mockListMirrors = vi.mocked(api.listMirrors);
 const mockFetchMirrorStatus = vi.mocked(api.fetchMirrorStatus);
+const mockTestMirrors = vi.mocked(api.testMirrors);
 const mockSaveMirrorlist = vi.mocked(api.saveMirrorlist);
 const mockListMirrorBackups = vi.mocked(api.listMirrorBackups);
 const mockRestoreMirrorBackup = vi.mocked(api.restoreMirrorBackup);
@@ -54,8 +55,11 @@ describe("MirrorsView", () => {
       total: 0,
       last_check: null,
     });
-    // Pre-populate status cache so the auto-fetch effect uses the cache
-    // instead of calling fetchMirrorStatus (which transitions to "fetching_status" state)
+    mockTestMirrors.mockImplementation((callbacks) => {
+      setTimeout(() => callbacks.onComplete?.(), 0);
+      return { cancel: vi.fn() };
+    });
+    // Pre-populate status cache so the auto-fetch effect uses the cache path
     const cached = {
       data: { mirrors: [], total: 0, last_check: null },
       timestamp: Date.now(),
@@ -449,5 +453,67 @@ describe("MirrorsView", () => {
     });
 
     expect(screen.queryByText("Repo overrides")).not.toBeInTheDocument();
+  });
+
+  it("auto-runs mirror test on mount and shows sort suggestion", async () => {
+    let capturedCallbacks: Parameters<typeof api.testMirrors>[0] | null = null;
+    mockTestMirrors.mockImplementation((callbacks) => {
+      capturedCallbacks = callbacks;
+      return { cancel: vi.fn() };
+    });
+
+    render(<MirrorsView />);
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockTestMirrors).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText(/Starting mirror tests/)).toBeInTheDocument();
+
+    await act(async () => {
+      capturedCallbacks!.onTestResult!(
+        { url: "https://mirror1.example.com/$repo/os/$arch", success: true, latency_ms: 42, speed_bps: null, error: null },
+        1, 1
+      );
+    });
+
+    expect(screen.getByText("42ms")).toBeInTheDocument();
+
+    await act(async () => {
+      capturedCallbacks!.onComplete!();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Tested 1 mirror\b/)).toBeInTheDocument();
+      expect(screen.getByText("Sort by latency")).toBeInTheDocument();
+    });
+  });
+
+  it("re-runs auto-test after retry from error state", async () => {
+    mockListMirrors.mockRejectedValueOnce(new Error("network error"));
+
+    render(<MirrorsView />);
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading mirrors/)).toBeInTheDocument();
+    });
+
+    mockListMirrors.mockResolvedValue(mockMirrorResponse);
+    mockTestMirrors.mockImplementation((callbacks) => {
+      setTimeout(() => callbacks.onComplete?.(), 0);
+      return { cancel: vi.fn() };
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockTestMirrors).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/MirrorsView.test.tsx
+++ b/src/components/MirrorsView.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../api", async () => {
     saveMirrorlist: vi.fn(),
     listMirrorBackups: vi.fn(),
     restoreMirrorBackup: vi.fn(),
+    listRepoMirrors: vi.fn(),
   };
 });
 
@@ -21,6 +22,7 @@ const mockFetchMirrorStatus = vi.mocked(api.fetchMirrorStatus);
 const mockSaveMirrorlist = vi.mocked(api.saveMirrorlist);
 const mockListMirrorBackups = vi.mocked(api.listMirrorBackups);
 const mockRestoreMirrorBackup = vi.mocked(api.restoreMirrorBackup);
+const mockListRepoMirrors = vi.mocked(api.listRepoMirrors);
 
 const mockMirrorResponse: api.MirrorListResponse = {
   mirrors: [
@@ -46,6 +48,7 @@ describe("MirrorsView", () => {
     vi.clearAllMocks();
     window.localStorage.clear();
     mockListMirrors.mockResolvedValue(mockMirrorResponse);
+    mockListRepoMirrors.mockResolvedValue({ repos: [] });
     mockFetchMirrorStatus.mockResolvedValue({
       mirrors: [],
       total: 0,
@@ -398,5 +401,53 @@ describe("MirrorsView", () => {
     await waitFor(() => {
       expect(mockListMirrors).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("shows repo override rows with pills in unified table", async () => {
+    mockListRepoMirrors.mockResolvedValue({
+      repos: [
+        { name: "core", directives: [
+          { directive_type: "Include" as const, value: "/etc/pacman.d/mirrorlist" },
+        ] },
+        { name: "multilib", directives: [
+          { directive_type: "Server" as const, value: "https://geo.mirror.pkgbuild.com/$repo/os/$arch" },
+          { directive_type: "Include" as const, value: "/etc/pacman.d/mirrorlist" },
+        ] },
+      ],
+    });
+
+    render(<MirrorsView />);
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("multilib")).toBeInTheDocument();
+      expect(screen.getByText("geo.mirror.pkgbuild.com")).toBeInTheDocument();
+    });
+  });
+
+  it("shows no repo rows when all repos use standard mirrorlist", async () => {
+    mockListRepoMirrors.mockResolvedValue({
+      repos: [
+        { name: "core", directives: [
+          { directive_type: "Include" as const, value: "/etc/pacman.d/mirrorlist" },
+        ] },
+        { name: "extra", directives: [
+          { directive_type: "Include" as const, value: "/etc/pacman.d/mirrorlist" },
+        ] },
+      ],
+    });
+
+    render(<MirrorsView />);
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockListRepoMirrors).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByText("Repo overrides")).not.toBeInTheDocument();
   });
 });

--- a/src/components/MirrorsView.tsx
+++ b/src/components/MirrorsView.tsx
@@ -39,6 +39,10 @@ import {
   FormSelectOption,
   NumberInput,
   Checkbox,
+  Label,
+  ToggleGroup,
+  ToggleGroupItem,
+  Badge,
 } from "@patternfly/react-core";
 import {
   GlobeIcon,
@@ -65,7 +69,9 @@ import {
   RefreshMirrorsProtocol,
   RefreshMirrorsSortBy,
   MirrorBackup,
+  RepoMirrorsResponse,
   listMirrors,
+  listRepoMirrors,
   fetchMirrorStatus,
   testMirrors,
   saveMirrorlist,
@@ -78,6 +84,22 @@ import {
   formatSize,
 } from "../api";
 import { sanitizeErrorMessage } from "../utils";
+
+const STANDARD_MIRRORLIST = "/etc/pacman.d/mirrorlist";
+
+function extractHostname(serverUrl: string): string {
+  try {
+    return new URL(serverUrl.replace("$repo", "_").replace("$arch", "_")).hostname;
+  } catch {
+    return serverUrl;
+  }
+}
+
+type SourceFilter = "all" | "mirrorlist" | "repo";
+
+type UnifiedRow =
+  | { kind: "mirror"; mirror: MirrorWithStatus; index: number }
+  | { kind: "repo"; repoName: string; url: string };
 
 type ViewState = "loading" | "ready" | "testing" | "saving" | "fetching_status" | "success" | "error";
 
@@ -203,6 +225,8 @@ export const MirrorsView: React.FC = () => {
   const [deletingBackups, setDeletingBackups] = useState(false);
   const [restoreConfirmTimestamp, setRestoreConfirmTimestamp] = useState<number | null>(null);
   useBackdropClose(restoreConfirmTimestamp !== null, () => setRestoreConfirmTimestamp(null));
+  const [repoMirrors, setRepoMirrors] = useState<RepoMirrorsResponse | null>(null);
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
   const cancelRef = useRef<(() => void) | null>(null);
   const logContainerRef = useRef<HTMLDivElement | null>(null);
   const initialStatusFetchedRef = useRef(false);
@@ -306,6 +330,10 @@ export const MirrorsView: React.FC = () => {
       loadBackups();
     }
   };
+
+  useEffect(() => {
+    listRepoMirrors().then(setRepoMirrors).catch(() => {});
+  }, []);
 
   const handleRestore = async (timestamp: number) => {
     setRestoreConfirmTimestamp(null);
@@ -601,6 +629,35 @@ export const MirrorsView: React.FC = () => {
     };
   };
 
+  const repoRows: UnifiedRow[] = useMemo(() => {
+    if (!repoMirrors) return [];
+    const rows: UnifiedRow[] = [];
+    for (const repo of repoMirrors.repos) {
+      for (const d of repo.directives) {
+        if (d.directive_type === "Server") {
+          rows.push({ kind: "repo", repoName: repo.name, url: d.value });
+        } else if (d.directive_type === "Include" && d.value !== STANDARD_MIRRORLIST) {
+          rows.push({ kind: "repo", repoName: repo.name, url: d.value });
+        }
+      }
+    }
+    return rows.sort((a, b) => {
+      if (a.kind !== "repo" || b.kind !== "repo") return 0;
+      return a.repoName.localeCompare(b.repoName);
+    });
+  }, [repoMirrors]);
+
+  const unifiedRows: UnifiedRow[] = useMemo(() => {
+    const mirrorRows: UnifiedRow[] = sortedMirrors.map(m => ({
+      kind: "mirror",
+      mirror: m,
+      index: mirrorIndexMap.get(m.url) ?? -1,
+    }));
+
+    if (sourceFilter === "mirrorlist") return mirrorRows;
+    if (sourceFilter === "repo") return repoRows;
+    return [...mirrorRows, ...repoRows];
+  }, [sortedMirrors, repoRows, mirrorIndexMap, sourceFilter]);
 
   if (state === "loading") {
     return (
@@ -771,6 +828,27 @@ export const MirrorsView: React.FC = () => {
                 aria-label="Search mirrors"
               />
             </ToolbarItem>
+            {repoRows.length > 0 && (
+              <ToolbarItem>
+                <ToggleGroup aria-label="Source filter">
+                  <ToggleGroupItem
+                    text={<>All <Badge isRead>{mirrors.length + repoRows.length}</Badge></>}
+                    isSelected={sourceFilter === "all"}
+                    onChange={() => setSourceFilter("all")}
+                  />
+                  <ToggleGroupItem
+                    text={<>Mirrorlist <Badge isRead>{mirrors.length}</Badge></>}
+                    isSelected={sourceFilter === "mirrorlist"}
+                    onChange={() => setSourceFilter("mirrorlist")}
+                  />
+                  <ToggleGroupItem
+                    text={<>Repo overrides <Badge isRead>{repoRows.length}</Badge></>}
+                    isSelected={sourceFilter === "repo"}
+                    onChange={() => setSourceFilter("repo")}
+                  />
+                </ToggleGroup>
+              </ToolbarItem>
+            )}
             {countries.length > 0 && (
               <ToolbarItem>
                 <Select
@@ -857,83 +935,113 @@ export const MirrorsView: React.FC = () => {
             </Tr>
           </Thead>
           <Tbody>
-            {sortedMirrors.map((mirror) => {
-              const actualIndex = mirrorIndexMap.get(mirror.url) ?? -1;
-              return (
-                <Tr key={mirror.url}>
-                  <Td dataLabel="Enabled">
-                    <Switch
-                      id={`switch-${actualIndex}`}
-                      isChecked={mirror.enabled}
-                      onChange={() => handleToggleEnabled(mirror.url)}
-                      aria-label={`Enable mirror ${mirror.url}`}
-                    />
-                  </Td>
-                  <Td dataLabel="URL">
-                    <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }}>
-                      {mirror.testResult && (
+            {unifiedRows.map((row) => {
+              if (row.kind === "mirror") {
+                const { mirror, index: actualIndex } = row;
+                return (
+                  <Tr key={`mirror-${mirror.url}`}>
+                    <Td dataLabel="Enabled">
+                      <Switch
+                        id={`switch-${actualIndex}`}
+                        isChecked={mirror.enabled}
+                        onChange={() => handleToggleEnabled(mirror.url)}
+                        aria-label={`Enable mirror ${mirror.url}`}
+                      />
+                    </Td>
+                    <Td dataLabel="URL">
+                      <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }}>
+                        {mirror.testResult && (
+                          <FlexItem>
+                            {mirror.testResult.success ? (
+                              <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />
+                            ) : (
+                              <TimesCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
+                            )}
+                          </FlexItem>
+                        )}
                         <FlexItem>
-                          {mirror.testResult.success ? (
-                            <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />
-                          ) : (
-                            <TimesCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
+                          <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }}>
+                            <FlexItem>
+                              <span style={{ fontFamily: "var(--pf-t--global--font--family--mono)", fontSize: "0.875rem" }}>
+                                {mirror.url}
+                              </span>
+                            </FlexItem>
+                            <FlexItem>
+                              <Label color="blue" variant="outline" isCompact>mirrorlist</Label>
+                            </FlexItem>
+                          </Flex>
+                          {mirror.comment && (
+                            <div style={{ fontSize: "0.75rem", color: "var(--pf-t--global--text--color--subtle)" }}>
+                              {mirror.comment}
+                            </div>
                           )}
                         </FlexItem>
+                      </Flex>
+                    </Td>
+                    <Td dataLabel="Country">
+                      {mirror.status?.country || "-"}
+                      {mirror.status?.country_code && (
+                        <span style={{ marginLeft: "0.5rem", color: "var(--pf-t--global--text--color--subtle)" }}>
+                          ({mirror.status.country_code})
+                        </span>
                       )}
+                    </Td>
+                    <Td dataLabel="Latency">
+                      {mirror.testResult?.latency_ms !== undefined && mirror.testResult?.latency_ms !== null
+                        ? `${mirror.testResult.latency_ms}ms`
+                        : "-"}
+                    </Td>
+                    <Td dataLabel="Score">
+                      {mirror.status?.score !== undefined && mirror.status?.score !== null
+                        ? mirror.status.score.toFixed(2)
+                        : "-"}
+                    </Td>
+                    <Td dataLabel="Actions">
+                      <Flex spaceItems={{ default: "spaceItemsXs" }}>
+                        <FlexItem>
+                          <Button
+                            variant="plain"
+                            aria-label="Move up"
+                            onClick={() => handleMoveUp(actualIndex)}
+                            isDisabled={actualIndex === 0}
+                          >
+                            <ArrowUpIcon />
+                          </Button>
+                        </FlexItem>
+                        <FlexItem>
+                          <Button
+                            variant="plain"
+                            aria-label="Move down"
+                            onClick={() => handleMoveDown(actualIndex)}
+                            isDisabled={actualIndex === mirrors.length - 1}
+                          >
+                            <ArrowDownIcon />
+                          </Button>
+                        </FlexItem>
+                      </Flex>
+                    </Td>
+                  </Tr>
+                );
+              }
+              return (
+                <Tr key={`repo-${row.repoName}-${row.url}`}>
+                  <Td dataLabel="Enabled">{"-"}</Td>
+                  <Td dataLabel="URL">
+                    <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }}>
                       <FlexItem>
                         <span style={{ fontFamily: "var(--pf-t--global--font--family--mono)", fontSize: "0.875rem" }}>
-                          {mirror.url}
+                          {extractHostname(row.url)}
                         </span>
-                        {mirror.comment && (
-                          <div style={{ fontSize: "0.75rem", color: "var(--pf-t--global--text--color--subtle)" }}>
-                            {mirror.comment}
-                          </div>
-                        )}
+                      </FlexItem>
+                      <FlexItem>
+                        <Label color="orange" isCompact>{row.repoName}</Label>
                       </FlexItem>
                     </Flex>
                   </Td>
-                  <Td dataLabel="Country">
-                    {mirror.status?.country || "-"}
-                    {mirror.status?.country_code && (
-                      <span style={{ marginLeft: "0.5rem", color: "var(--pf-t--global--text--color--subtle)" }}>
-                        ({mirror.status.country_code})
-                      </span>
-                    )}
-                  </Td>
-                  <Td dataLabel="Latency">
-                    {mirror.testResult?.latency_ms !== undefined && mirror.testResult?.latency_ms !== null
-                      ? `${mirror.testResult.latency_ms}ms`
-                      : "-"}
-                  </Td>
-                  <Td dataLabel="Score">
-                    {mirror.status?.score !== undefined && mirror.status?.score !== null
-                      ? mirror.status.score.toFixed(2)
-                      : "-"}
-                  </Td>
-                  <Td dataLabel="Actions">
-                    <Flex spaceItems={{ default: "spaceItemsXs" }}>
-                      <FlexItem>
-                        <Button
-                          variant="plain"
-                          aria-label="Move up"
-                          onClick={() => handleMoveUp(actualIndex)}
-                          isDisabled={actualIndex === 0}
-                        >
-                          <ArrowUpIcon />
-                        </Button>
-                      </FlexItem>
-                      <FlexItem>
-                        <Button
-                          variant="plain"
-                          aria-label="Move down"
-                          onClick={() => handleMoveDown(actualIndex)}
-                          isDisabled={actualIndex === mirrors.length - 1}
-                        >
-                          <ArrowDownIcon />
-                        </Button>
-                      </FlexItem>
-                    </Flex>
-                  </Td>
+                  <Td dataLabel="Country">{"-"}</Td>
+                  <Td dataLabel="Latency">{"-"}</Td>
+                  <Td dataLabel="Score">{"-"}</Td>
+                  <Td dataLabel="Actions" />
                 </Tr>
               );
             })}
@@ -1027,6 +1135,7 @@ export const MirrorsView: React.FC = () => {
             </>
           )}
         </ExpandableSection>
+
 
         {statusData && (
           <div className="pf-v6-u-mt-md" style={{ fontSize: "0.75rem", color: "var(--pf-t--global--text--color--subtle)" }}>

--- a/src/components/MirrorsView.tsx
+++ b/src/components/MirrorsView.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useBackdropClose } from "../hooks/useBackdropClose";
-import { LOG_CONTAINER_HEIGHT, MAX_LOG_SIZE_BYTES } from "../constants";
 import {
   Card,
   CardBody,
@@ -12,8 +11,6 @@ import {
   EmptyStateActions,
   EmptyStateFooter,
   Spinner,
-  CodeBlock,
-  CodeBlockCode,
   Flex,
   FlexItem,
   ExpandableSection,
@@ -50,8 +47,6 @@ import {
   TimesCircleIcon,
   ArrowUpIcon,
   ArrowDownIcon,
-  SyncAltIcon,
-  OutlinedClockIcon,
   ExclamationCircleIcon,
   HistoryIcon,
   UndoIcon,
@@ -101,7 +96,7 @@ type UnifiedRow =
   | { kind: "mirror"; mirror: MirrorWithStatus; index: number }
   | { kind: "repo"; repoName: string; url: string };
 
-type ViewState = "loading" | "ready" | "testing" | "saving" | "fetching_status" | "success" | "error";
+type ViewState = "loading" | "ready" | "saving" | "success" | "error";
 
 interface MirrorWithStatus extends MirrorEntry {
   status?: MirrorStatus;
@@ -198,8 +193,6 @@ export const MirrorsView: React.FC = () => {
   const [mirrors, setMirrors] = useState<MirrorWithStatus[]>([]);
   const [statusData, setStatusData] = useState<MirrorStatusResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [log, setLog] = useState("");
-  const [isDetailsExpanded, setIsDetailsExpanded] = useState(false);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   useBackdropClose(confirmModalOpen, () => setConfirmModalOpen(false));
   const [hasChanges, setHasChanges] = useState(false);
@@ -227,9 +220,11 @@ export const MirrorsView: React.FC = () => {
   useBackdropClose(restoreConfirmTimestamp !== null, () => setRestoreConfirmTimestamp(null));
   const [repoMirrors, setRepoMirrors] = useState<RepoMirrorsResponse | null>(null);
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [isFetchingStatus, setIsFetchingStatus] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [testProgress, setTestProgress] = useState<{ current: number; total: number } | null>(null);
   const cancelRef = useRef<(() => void) | null>(null);
-  const logContainerRef = useRef<HTMLDivElement | null>(null);
-  const initialStatusFetchedRef = useRef(false);
+  const initialAutoRunRef = useRef(false);
 
   const applyStatusToMirrors = useCallback((mirrorList: MirrorEntry[], status: MirrorStatusResponse): MirrorWithStatus[] => {
     const statusByUrl = new Map(status.mirrors.map(s => [normalizeMirrorUrl(s.url), s]));
@@ -240,6 +235,7 @@ export const MirrorsView: React.FC = () => {
   }, []);
 
   const loadMirrors = useCallback(async () => {
+    initialAutoRunRef.current = false;
     setState("loading");
     setError(null);
     try {
@@ -275,18 +271,14 @@ export const MirrorsView: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (logContainerRef.current) {
-      logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight;
-    }
-  }, [log]);
-
-  useEffect(() => {
-    if (state === "ready" && !statusData && !initialStatusFetchedRef.current) {
-      initialStatusFetchedRef.current = true;
-      handleFetchStatus(false);
+    if (state === "ready" && !initialAutoRunRef.current) {
+      initialAutoRunRef.current = true;
+      handleFetchStatus(false).then(() => {
+        handleTestMirrors();
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state, statusData]);
+  }, [state]);
 
   const handleFetchStatus = async (forceRefresh = false) => {
     if (!forceRefresh) {
@@ -298,17 +290,16 @@ export const MirrorsView: React.FC = () => {
       }
     }
 
-    setState("fetching_status");
-    setError(null);
+    setIsFetchingStatus(true);
     try {
       const response = await fetchMirrorStatus();
       setCachedStatus(response);
       setStatusData(response);
       setMirrors(prev => applyStatusToMirrors(prev, response));
-      setState("ready");
     } catch (ex) {
-      setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
+    } finally {
+      setIsFetchingStatus(false);
     }
   };
 
@@ -381,42 +372,25 @@ export const MirrorsView: React.FC = () => {
 
   const handleTestMirrors = () => {
     const enabledMirrors = mirrors.filter(m => m.enabled).map(m => m.url);
-    if (enabledMirrors.length === 0) {
-      setError("No enabled mirrors to test");
-      return;
-    }
+    if (enabledMirrors.length === 0) return;
 
-    setState("testing");
-    setLog("");
-    setIsDetailsExpanded(true);
+    setIsTesting(true);
+    setTestProgress(null);
 
     const { cancel } = testMirrors(
       {
         onTestResult: (result, current, total) => {
+          setTestProgress({ current, total });
           setMirrors(prev => prev.map(m =>
             m.url === result.url ? { ...m, testResult: result } : m
           ));
-          setLog(prev => {
-            const newLog = prev + `[${current}/${total}] ${result.url}: ${result.success ? `${result.latency_ms}ms` : result.error}\n`;
-            return newLog.length > MAX_LOG_SIZE_BYTES ? newLog.slice(-MAX_LOG_SIZE_BYTES) : newLog;
-          });
         },
         onComplete: () => {
-          setState("ready");
+          setIsTesting(false);
           cancelRef.current = null;
-          setMirrors(prev => {
-            const sorted = [...prev].sort((a, b) => {
-              if (!a.testResult?.success && !b.testResult?.success) return 0;
-              if (!a.testResult?.success) return 1;
-              if (!b.testResult?.success) return -1;
-              return (a.testResult.latency_ms ?? Infinity) - (b.testResult.latency_ms ?? Infinity);
-            });
-            return sorted;
-          });
-          setHasChanges(true);
         },
         onError: (err) => {
-          setState("error");
+          setIsTesting(false);
           setError(err);
           cancelRef.current = null;
         },
@@ -431,8 +405,23 @@ export const MirrorsView: React.FC = () => {
     if (cancelRef.current) {
       cancelRef.current();
       cancelRef.current = null;
-      setState("ready");
+      setIsTesting(false);
+      setTestProgress(null);
     }
+  };
+
+  const handleSortByLatency = () => {
+    setMirrors(prev => {
+      const sorted = [...prev].sort((a, b) => {
+        if (!a.testResult?.success && !b.testResult?.success) return 0;
+        if (!a.testResult?.success) return 1;
+        if (!b.testResult?.success) return -1;
+        return (a.testResult.latency_ms ?? Infinity) - (b.testResult.latency_ms ?? Infinity);
+      });
+      return sorted;
+    });
+    setHasChanges(true);
+    setTestProgress(null);
   };
 
   const handleSave = () => {
@@ -647,6 +636,17 @@ export const MirrorsView: React.FC = () => {
     });
   }, [repoMirrors]);
 
+  const filteredRepoRows = useMemo(() => {
+    if (!searchFilter) return repoRows;
+    const lower = searchFilter.toLowerCase();
+    return repoRows.filter(r =>
+      r.kind === "repo" && (
+        extractHostname(r.url).toLowerCase().includes(lower) ||
+        r.repoName.toLowerCase().includes(lower)
+      )
+    );
+  }, [repoRows, searchFilter]);
+
   const unifiedRows: UnifiedRow[] = useMemo(() => {
     const mirrorRows: UnifiedRow[] = sortedMirrors.map(m => ({
       kind: "mirror",
@@ -655,9 +655,9 @@ export const MirrorsView: React.FC = () => {
     }));
 
     if (sourceFilter === "mirrorlist") return mirrorRows;
-    if (sourceFilter === "repo") return repoRows;
-    return [...mirrorRows, ...repoRows];
-  }, [sortedMirrors, repoRows, mirrorIndexMap, sourceFilter]);
+    if (sourceFilter === "repo") return filteredRepoRows;
+    return [...mirrorRows, ...filteredRepoRows];
+  }, [sortedMirrors, filteredRepoRows, mirrorIndexMap, sourceFilter]);
 
   if (state === "loading") {
     return (
@@ -682,53 +682,6 @@ export const MirrorsView: React.FC = () => {
                 <Button variant="primary" onClick={loadMirrors}>Retry</Button>
               </EmptyStateActions>
             </EmptyStateFooter>
-          </EmptyState>
-        </CardBody>
-      </Card>
-    );
-  }
-
-  if (state === "testing") {
-    return (
-      <Card>
-        <CardBody>
-          <Flex justifyContent={{ default: "justifyContentSpaceBetween" }} alignItems={{ default: "alignItemsCenter" }}>
-            <FlexItem>
-              <CardTitle className="pf-v6-u-m-0">Testing Mirrors</CardTitle>
-            </FlexItem>
-            <FlexItem>
-              <Button variant="danger" onClick={handleCancel}>
-                Cancel
-              </Button>
-            </FlexItem>
-          </Flex>
-
-          <div className="pf-v6-u-mt-md pf-v6-u-mb-md">
-            <Spinner size="md" /> Testing mirror latency...
-          </div>
-
-          <ExpandableSection
-            toggleText={isDetailsExpanded ? "Hide details" : "Show details"}
-            onToggle={(_event, expanded) => setIsDetailsExpanded(expanded)}
-            isExpanded={isDetailsExpanded}
-          >
-            <div ref={logContainerRef} style={{ maxHeight: LOG_CONTAINER_HEIGHT, overflow: "auto" }}>
-              <CodeBlock>
-                <CodeBlockCode>{log || "Starting tests..."}</CodeBlockCode>
-              </CodeBlock>
-            </div>
-          </ExpandableSection>
-        </CardBody>
-      </Card>
-    );
-  }
-
-  if (state === "fetching_status") {
-    return (
-      <Card>
-        <CardBody>
-          <EmptyState headingLevel="h2" icon={Spinner} titleText="Fetching mirror status">
-            <EmptyStateBody>Retrieving mirror information from archlinux.org...</EmptyStateBody>
           </EmptyState>
         </CardBody>
       </Card>
@@ -884,29 +837,9 @@ export const MirrorsView: React.FC = () => {
             <ToolbarItem>
               <Button
                 variant="secondary"
-                icon={<SyncAltIcon />}
-                onClick={() => handleFetchStatus(true)}
-                isDisabled={state !== "ready"}
-              >
-                {statusData ? "Refresh Status" : "Fetch Status"}
-              </Button>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Button
-                variant="secondary"
-                icon={<OutlinedClockIcon />}
-                onClick={handleTestMirrors}
-                isDisabled={state !== "ready" || mirrors.filter(m => m.enabled).length === 0}
-              >
-                Test Mirrors
-              </Button>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Button
-                variant="secondary"
                 icon={<GlobeIcon />}
                 onClick={handleOpenRefreshModal}
-                isDisabled={state !== "ready"}
+                isDisabled={state !== "ready" || isTesting || isFetchingStatus}
               >
                 Refresh Mirrorlist
               </Button>
@@ -915,13 +848,44 @@ export const MirrorsView: React.FC = () => {
               <Button
                 variant="primary"
                 onClick={handleSave}
-                isDisabled={!hasChanges || state !== "ready"}
+                isDisabled={!hasChanges || state !== "ready" || isTesting || isFetchingStatus}
               >
                 Save Changes
               </Button>
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
+
+        {(isFetchingStatus || isTesting) && (
+          <Flex alignItems={{ default: "alignItemsCenter" }} spaceItems={{ default: "spaceItemsSm" }} className="pf-v6-u-mb-sm">
+            <FlexItem><Spinner size="sm" /></FlexItem>
+            <FlexItem>
+              {isFetchingStatus && "Fetching mirror status..."}
+              {isTesting && testProgress
+                ? `Testing mirrors (${testProgress.current}/${testProgress.total})...`
+                : isTesting ? "Starting mirror tests..." : null}
+            </FlexItem>
+            {isTesting && (
+              <FlexItem>
+                <Button variant="link" isInline onClick={handleCancel}>Cancel</Button>
+              </FlexItem>
+            )}
+          </Flex>
+        )}
+
+        {!isTesting && testProgress && (
+          <Alert
+            variant="info"
+            title={`Tested ${testProgress.total} mirror${testProgress.total !== 1 ? "s" : ""}`}
+            isInline
+            className="pf-v6-u-mb-sm"
+            actionLinks={
+              <Button variant="link" isInline onClick={handleSortByLatency}>
+                Sort by latency
+              </Button>
+            }
+          />
+        )}
 
         <Table aria-label="Mirror list" variant="compact">
           <Thead>
@@ -989,7 +953,9 @@ export const MirrorsView: React.FC = () => {
                     <Td dataLabel="Latency">
                       {mirror.testResult?.latency_ms !== undefined && mirror.testResult?.latency_ms !== null
                         ? `${mirror.testResult.latency_ms}ms`
-                        : "-"}
+                        : isTesting && mirror.enabled && !mirror.testResult
+                          ? <Spinner size="sm" />
+                          : "-"}
                     </Td>
                     <Td dataLabel="Score">
                       {mirror.status?.score !== undefined && mirror.status?.score !== null
@@ -1135,7 +1101,6 @@ export const MirrorsView: React.FC = () => {
             </>
           )}
         </ExpandableSection>
-
 
         {statusData && (
           <div className="pf-v6-u-mt-md" style={{ fontSize: "0.75rem", color: "var(--pf-t--global--text--color--subtle)" }}>

--- a/src/test/contract.test.ts
+++ b/src/test/contract.test.ts
@@ -71,6 +71,7 @@ import {
   fetchNews,
   getScheduledRuns,
   getSyncPackageInfo,
+  listRepoMirrors,
 } from "../api";
 
 // JSON fixtures — vitest resolves these at build time via Vite's JSON import support
@@ -97,6 +98,7 @@ import securityInfoFixture from "../../test/fixtures/security-info.json";
 import newsFixture from "../../test/fixtures/news.json";
 import scheduledRunsFixture from "../../test/fixtures/scheduled-runs.json";
 import syncPackageDetailFixture from "../../test/fixtures/sync-package-detail.json";
+import repoMirrorsFixture from "../../test/fixtures/repo-mirrors.json";
 
 function spawnReturns(data: unknown): void {
   mockSpawn.mockReturnValue(
@@ -417,6 +419,38 @@ describe("listMirrors contract", () => {
     spawnReturns({ ...mirrorListFixture, last_modified: null });
     const withNull = await listMirrors();
     expect(withNull.last_modified).toBeNull();
+  });
+});
+
+
+describe("listRepoMirrors contract", () => {
+  it("parses repo-mirrors fixture into RepoMirrorsResponse shape", async () => {
+    spawnReturns(repoMirrorsFixture);
+    const result = await listRepoMirrors();
+
+    expect(Array.isArray(result.repos)).toBe(true);
+    expect(result.repos.length).toBe(3);
+  });
+
+  it("each repo has name and directives array", async () => {
+    spawnReturns(repoMirrorsFixture);
+    const result = await listRepoMirrors();
+
+    for (const repo of result.repos) {
+      expect(typeof repo.name).toBe("string");
+      expect(Array.isArray(repo.directives)).toBe(true);
+      for (const d of repo.directives) {
+        expect(["Server", "Include"]).toContain(d.directive_type);
+        expect(typeof d.value).toBe("string");
+      }
+    }
+  });
+
+  it("handles empty repos list", async () => {
+    spawnReturns({ repos: [] });
+    const result = await listRepoMirrors();
+
+    expect(result.repos).toEqual([]);
   });
 });
 

--- a/test/fixtures/repo-mirrors.json
+++ b/test/fixtures/repo-mirrors.json
@@ -1,0 +1,23 @@
+{
+  "repos": [
+    {
+      "name": "core",
+      "directives": [
+        { "directive_type": "Include", "value": "/etc/pacman.d/mirrorlist" }
+      ]
+    },
+    {
+      "name": "extra",
+      "directives": [
+        { "directive_type": "Include", "value": "/etc/pacman.d/mirrorlist" }
+      ]
+    },
+    {
+      "name": "multilib",
+      "directives": [
+        { "directive_type": "Server", "value": "https://geo.mirror.pkgbuild.com/$repo/os/$arch" },
+        { "directive_type": "Include", "value": "/etc/pacman.d/mirrorlist" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The Mirrors tab only read /etc/pacman.d/mirrorlist, missing per-repo
Server= directives in pacman.conf. Add a list-repo-mirrors backend
command that reads resolved server lists from alpm syncdbs, and
display them in a lazy-loaded expandable section.

Closes: #36 