### PR TITLE
feat: publish page_status to cockpit overview health

### DIFF
--- a/src/cockpit.d.ts
+++ b/src/cockpit.d.ts
@@ -43,4 +43,7 @@ declare const cockpit: {
   ): CockpitDBusClient;
   variant(type: string, value: unknown): { t: string; v: unknown };
   user(): Promise<CockpitUserInfo>;
+  transport: {
+    control(command: string, options: Record<string, unknown>): void;
+  };
 };

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent, act, cleanup, within } from "@testing-library/react";
 import { UpdatesView } from "./UpdatesView";
 import * as api from "../api";
+import { mockTransportControl } from "../test/setup";
 import {
   mockUpdatesResponse,
   mockPreflightResponse,
@@ -141,6 +142,74 @@ describe("UpdatesView", () => {
       await waitFor(() => {
         expect(screen.getByText("System is up to date")).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Overview Health page_status", () => {
+    const notifyCalls = () =>
+      mockTransportControl.mock.calls.filter(([command]) => command === "notify");
+
+    it("publishes 'up to date' when checkUpdates returns no updates", async () => {
+      mockCheckUpdates.mockResolvedValue({ updates: [], warnings: [] });
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(
+          notifyCalls().some(([, payload]) => {
+            const status = (payload as { page_status?: { title?: string } }).page_status;
+            return status?.title === "System is up to date";
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it("publishes update count when updates are available", async () => {
+      mockCheckUpdates.mockResolvedValue({
+        updates: [
+          mockUpdatesResponse.updates[0],
+          { ...mockUpdatesResponse.updates[0], name: "glibc" },
+          { ...mockUpdatesResponse.updates[0], name: "curl" },
+        ],
+        warnings: [],
+      });
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(
+          notifyCalls().some(([, payload]) => {
+            const status = (payload as { page_status?: { type?: string; title?: string } }).page_status;
+            return status?.type === "info" && status?.title === "3 updates available";
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it("publishes error status when checkUpdates throws", async () => {
+      mockCheckUpdates.mockRejectedValue(new Error("backend offline"));
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(
+          notifyCalls().some(([, payload]) => {
+            const status = (payload as { page_status?: { type?: string; title?: string } }).page_status;
+            return (
+              status?.type === "error" &&
+              status?.title === "Failed to check for package updates"
+            );
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it("error payload never leaks exception message", async () => {
+      mockCheckUpdates.mockRejectedValue(new Error("secret internal detail"));
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(notifyCalls().length).toBeGreaterThan(0);
+      });
+      for (const [, payload] of notifyCalls()) {
+        const status = (payload as { page_status?: { title?: string } }).page_status;
+        if (status?.title) {
+          expect(status.title).not.toContain("secret internal detail");
+        }
+      }
     });
   });
 

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -126,6 +126,16 @@ function severityColor(severity: string): SeverityColor {
   }
 }
 
+type PageStatus = {
+  type?: "info" | "warning" | "error" | null;
+  title: string;
+  details?: { pficon?: string; link?: false };
+};
+
+function publishPageStatus(status: PageStatus | null): void {
+  cockpit.transport.control("notify", { page_status: status });
+}
+
 interface UpgradeProgress {
   phase: "preparing" | "downloading" | "installing" | "hooks";
   current: number;
@@ -533,15 +543,38 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     setState("checking");
     setError(null);
     setWarnings([]);
+    publishPageStatus({
+      type: null,
+      title: "Checking for package updates\u2026",
+      details: { pficon: "spinner", link: false },
+    });
     try {
       const response = await checkUpdates();
       setUpdates(response.updates);
       setWarnings(response.warnings);
       setState(response.updates.length > 0 ? "available" : "uptodate");
       loadSecurityData();
+      const count = response.updates.length;
+      if (count === 0) {
+        publishPageStatus({
+          type: null,
+          title: "System is up to date",
+          details: { pficon: "check", link: false },
+        });
+      } else {
+        publishPageStatus({
+          type: "info",
+          title: `${count} ${count === 1 ? "update" : "updates"} available`,
+          details: { pficon: "enhancement" },
+        });
+      }
     } catch (ex) {
       setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
+      publishPageStatus({
+        type: "error",
+        title: "Failed to check for package updates",
+      });
     }
   }, [loadSecurityData]);
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
       "order": 50
     }
   },
+  "overview-health": ["pacman"],
   "content-security-policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'",
   "conditions": [
     {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -26,11 +26,15 @@ Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
 // Mock cockpit global
 const mockSpawn = vi.fn();
+const mockTransportControl = vi.fn();
 
 const cockpitMock = {
   spawn: mockSpawn,
+  transport: {
+    control: mockTransportControl,
+  },
 };
 
 vi.stubGlobal("cockpit", cockpitMock);
 
-export { mockSpawn };
+export { mockSpawn, mockTransportControl };


### PR DESCRIPTION
Registers the pacman page as an overview-health source and emits page_status via cockpit.transport.control so the Overview page can surface update counts, up-to-date state, and check errors.