### PR TITLE
feat(pacnew): notify about config files needing merge after upgrade

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod log;
 pub mod mirrors;
 pub mod mutation;
 pub mod news;
+pub mod pacnew;
 pub mod query;
 pub mod reboot;
 pub mod repos;
@@ -31,9 +32,11 @@ pub use mutation::{
     install_package, preflight_upgrade, remove_orphans, remove_package, run_upgrade, sync_database,
 };
 pub use news::{
-    fetch_news, mark_news_read, mark_reboot_dismissed, mark_services_dismissed, read_news_state,
-    read_reboot_dismissal, read_services_dismissal,
+    fetch_news, mark_news_read, mark_pacnew_dismissed, mark_reboot_dismissed,
+    mark_services_dismissed, read_news_state, read_pacnew_dismissal, read_reboot_dismissal,
+    read_services_dismissal,
 };
+pub use pacnew::get_pacnew_status;
 pub use query::{
     check_updates, list_installed, list_orphans, local_package_info, search, sync_package_info,
 };

--- a/backend/src/handlers/news.rs
+++ b/backend/src/handlers/news.rs
@@ -97,6 +97,11 @@ pub struct RebootDismissal {
     pub signature: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Default)]
+pub struct PacnewDismissal {
+    pub signature: Option<String>,
+}
+
 pub fn fetch_news(days: u32) -> Result<()> {
     let days = days.min(365);
     let items = fetch_news_items(days)?;
@@ -195,6 +200,11 @@ fn services_dismissal_path() -> Result<PathBuf> {
 fn reboot_dismissal_path() -> Result<PathBuf> {
     let home = std::env::var("HOME").context("HOME environment variable is not set")?;
     Ok(PathBuf::from(home).join(".config/cockpit-pacman/reboot-dismissed.json"))
+}
+
+fn pacnew_dismissal_path() -> Result<PathBuf> {
+    let home = std::env::var("HOME").context("HOME environment variable is not set")?;
+    Ok(PathBuf::from(home).join(".config/cockpit-pacman/pacnew-dismissed.json"))
 }
 
 pub fn read_news_state() -> Result<()> {
@@ -303,6 +313,54 @@ pub fn mark_reboot_dismissed(signature: &str) -> Result<()> {
     }
     let path = reboot_dismissal_path()?;
     let state = write_reboot_dismissal_to(&path, signature)?;
+    emit_json(&state)
+}
+
+pub fn read_pacnew_dismissal_from(path: &Path) -> Result<PacnewDismissal> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => {
+            if content.trim().is_empty() {
+                return Ok(PacnewDismissal::default());
+            }
+            let state: PacnewDismissal = serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse pacnew dismissal from {:?}", path))?;
+            Ok(state)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PacnewDismissal::default()),
+        Err(e) => {
+            Err(e).with_context(|| format!("Failed to read pacnew dismissal from {:?}", path))
+        }
+    }
+}
+
+pub fn write_pacnew_dismissal_to(path: &Path, signature: &str) -> Result<PacnewDismissal> {
+    with_state_lock(path, || {
+        let state = PacnewDismissal {
+            signature: Some(signature.to_string()),
+        };
+        write_json_atomic(path, &state)?;
+        Ok(state)
+    })
+}
+
+pub fn read_pacnew_dismissal() -> Result<()> {
+    let path = pacnew_dismissal_path()?;
+    let state = read_pacnew_dismissal_from(&path)?;
+    emit_json(&state)
+}
+
+pub fn mark_pacnew_dismissed(signature: &str) -> Result<()> {
+    if signature.is_empty() {
+        anyhow::bail!("Signature must not be empty");
+    }
+    if signature.len() > 4096 {
+        anyhow::bail!("Signature length {} exceeds 4096", signature.len());
+    }
+    if signature.chars().any(|c| c.is_control()) {
+        anyhow::bail!("Signature contains control characters");
+    }
+    let path = pacnew_dismissal_path()?;
+    let state = write_pacnew_dismissal_to(&path, signature)?;
     emit_json(&state)
 }
 

--- a/backend/src/handlers/pacnew.rs
+++ b/backend/src/handlers/pacnew.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::alpm::get_handle;
+use crate::models::{PacnewFile, PacnewStatus};
+use crate::util::emit_json;
+
+const KINDS: &[&str] = &["pacnew", "pacsave"];
+
+fn merge_file_path(backup_name: &str, kind: &str) -> String {
+    format!("/{}.{}", backup_name.trim_start_matches('/'), kind)
+}
+
+// Scans the backup arrays of installed packages, matching pacdiff's default
+// db-scan mode. A .pacsave left by a fully removed package is not attributable
+// here because the package is gone from the local db. Runs as the cockpit user,
+// so files under directories it cannot traverse (e.g. 0750 /etc/sudoers.d) are
+// skipped: exists() returns false on a stat permission error.
+pub fn get_pacnew_status() -> Result<()> {
+    let handle = get_handle()?;
+    let localdb = handle.localdb();
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut files: Vec<PacnewFile> = Vec::new();
+
+    for pkg in localdb.pkgs() {
+        let pkg_name = pkg.name().to_string();
+        for backup in pkg.backup() {
+            for kind in KINDS {
+                let path = merge_file_path(backup.name(), kind);
+                if Path::new(&path).exists() && seen.insert(path.clone()) {
+                    files.push(PacnewFile {
+                        path,
+                        package: pkg_name.clone(),
+                        kind: (*kind).to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+
+    emit_json(&PacnewStatus {
+        has_pacnew: !files.is_empty(),
+        files,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_file_path() {
+        assert_eq!(
+            merge_file_path("etc/pacman.conf", "pacnew"),
+            "/etc/pacman.conf.pacnew"
+        );
+        assert_eq!(
+            merge_file_path("/etc/ssh/sshd_config", "pacsave"),
+            "/etc/ssh/sshd_config.pacsave"
+        );
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,15 +3,16 @@ use std::env;
 use cockpit_pacman_backend::handlers::{
     add_ignored, check_lock, check_security, check_updates, clean_cache, delete_mirror_backup,
     downgrade_package, fetch_mirror_status, fetch_news, get_cache_info, get_dependency_tree,
-    get_grouped_history, get_history, get_reboot_status, get_schedule_config, get_scheduled_runs,
-    get_services_status, init_keyring, install_package, keyring_status, list_downgrades,
-    list_ignored, list_installed, list_mirror_backups, list_mirrors, list_orphans,
-    list_repo_mirrors, list_repos, local_package_info, mark_news_read, mark_reboot_dismissed,
-    mark_services_dismissed, preflight_upgrade, read_news_state, read_reboot_dismissal,
-    read_services_dismissal, refresh_keyring, refresh_mirrors, remove_ignored, remove_orphans,
-    remove_package, remove_stale_lock, restore_mirror_backup, run_upgrade, save_mirrorlist,
-    save_repos, scheduled_run, search, security_info, set_schedule_config, signoff_list,
-    signoff_revoke, signoff_sign, sync_database, sync_package_info, test_mirrors,
+    get_grouped_history, get_history, get_pacnew_status, get_reboot_status, get_schedule_config,
+    get_scheduled_runs, get_services_status, init_keyring, install_package, keyring_status,
+    list_downgrades, list_ignored, list_installed, list_mirror_backups, list_mirrors, list_orphans,
+    list_repo_mirrors, list_repos, local_package_info, mark_news_read, mark_pacnew_dismissed,
+    mark_reboot_dismissed, mark_services_dismissed, preflight_upgrade, read_news_state,
+    read_pacnew_dismissal, read_reboot_dismissal, read_services_dismissal, refresh_keyring,
+    refresh_mirrors, remove_ignored, remove_orphans, remove_package, remove_stale_lock,
+    restore_mirror_backup, run_upgrade, save_mirrorlist, save_repos, scheduled_run, search,
+    security_info, set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
+    sync_package_info, test_mirrors,
 };
 use cockpit_pacman_backend::models::{MirrorEntry, RepoEntry};
 use cockpit_pacman_backend::validation::{
@@ -98,6 +99,7 @@ fn print_usage() {
     eprintln!("  scheduled-run          Execute scheduled operation (called by systemd)");
     eprintln!("  reboot-status          Check if system reboot is recommended");
     eprintln!("  services-status        List running services whose binaries were replaced");
+    eprintln!("  pacnew-status          List .pacnew/.pacsave config files needing manual merge");
     eprintln!("  list-mirrors           List mirrors from /etc/pacman.d/mirrorlist");
     eprintln!("  list-repo-mirrors      List per-repository mirror servers from pacman.conf");
     eprintln!("  fetch-mirror-status    Fetch mirror status from archlinux.org API");
@@ -367,6 +369,7 @@ fn main() {
         "scheduled-run" => scheduled_run(),
         "reboot-status" => get_reboot_status(),
         "services-status" => get_services_status(),
+        "pacnew-status" => get_pacnew_status(),
         "list-mirrors" => list_mirrors(),
         "list-repo-mirrors" => list_repo_mirrors(),
         "fetch-mirror-status" => fetch_mirror_status(),
@@ -482,6 +485,14 @@ fn main() {
                 std::process::exit(1);
             }
             mark_reboot_dismissed(&args[2])
+        }
+        "pacnew-dismissal-state" => read_pacnew_dismissal(),
+        "pacnew-mark-dismissed" => {
+            if args.len() < 3 {
+                eprintln!("Error: pacnew-mark-dismissed requires a SIGNATURE");
+                std::process::exit(1);
+            }
+            mark_pacnew_dismissed(&args[2])
         }
         "signoff-list" => {
             if args.len() < 3 {

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -374,6 +374,19 @@ pub struct RebootStatus {
     pub updated_packages: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct PacnewFile {
+    pub path: String,
+    pub package: String,
+    pub kind: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PacnewStatus {
+    pub has_pacnew: bool,
+    pub files: Vec<PacnewFile>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RestartBlocked {

--- a/backend/tests/contract_tests.rs
+++ b/backend/tests/contract_tests.rs
@@ -12,12 +12,13 @@ use cockpit_pacman_backend::models::{
     GroupedLogResponse, KeyInfo, KeyringKey, KeyringStatusResponse, LogEntry, LogGroup,
     MirrorEntry, MirrorListResponse, MirrorStatus, MirrorStatusResponse, MirrorTestResult,
     NewsItem, NewsResponse, OrphanPackage, OrphanResponse, Package, PackageDetails,
-    PackageListResponse, PackageSecurityAdvisory, PreflightResponse, PreflightWarning,
-    ProviderChoice, RebootStatus, RefreshMirrorsResponse, ReplacementInfo, RestartBlocked,
-    RestoreMirrorBackupResponse, SaveMirrorlistResponse, ScheduledRunEntry, ScheduledRunsResponse,
-    SearchResponse, SearchResult, SecurityInfoAdvisory, SecurityInfoGroup, SecurityInfoIssue,
-    SecurityInfoResponse, SecurityResponse, ServiceRestart, ServicesStatus, StreamEvent,
-    SyncPackageDetails, UpdateInfo, UpdateStats, UpdatesResponse, VersionMatch, WarningSeverity,
+    PackageListResponse, PackageSecurityAdvisory, PacnewFile, PacnewStatus, PreflightResponse,
+    PreflightWarning, ProviderChoice, RebootStatus, RefreshMirrorsResponse, ReplacementInfo,
+    RestartBlocked, RestoreMirrorBackupResponse, SaveMirrorlistResponse, ScheduledRunEntry,
+    ScheduledRunsResponse, SearchResponse, SearchResult, SecurityInfoAdvisory, SecurityInfoGroup,
+    SecurityInfoIssue, SecurityInfoResponse, SecurityResponse, ServiceRestart, ServicesStatus,
+    StreamEvent, SyncPackageDetails, UpdateInfo, UpdateStats, UpdatesResponse, VersionMatch,
+    WarningSeverity,
 };
 use serde_json::Value;
 
@@ -1173,6 +1174,58 @@ fn reboot_status_fixture_matches_struct_shape() {
     assert_array(&fixture, "updated_packages");
 }
 
+// PacnewStatus
+
+#[test]
+fn pacnew_status_shape() {
+    let status = PacnewStatus {
+        has_pacnew: true,
+        files: vec![PacnewFile {
+            path: "/etc/pacman.conf.pacnew".into(),
+            package: "pacman".into(),
+            kind: "pacnew".into(),
+        }],
+    };
+    let v = to_json(&status);
+
+    assert_bool(&v, "has_pacnew");
+    assert_array(&v, "files");
+
+    let file = &v["files"][0];
+    assert_string(file, "path");
+    assert_string(file, "package");
+    assert_string(file, "kind");
+
+    assert_eq!(v["has_pacnew"], true);
+    assert_eq!(file["kind"], "pacnew");
+}
+
+#[test]
+fn pacnew_status_empty_shape() {
+    let status = PacnewStatus {
+        has_pacnew: false,
+        files: vec![],
+    };
+    let v = to_json(&status);
+
+    assert_eq!(v["has_pacnew"], false);
+    assert_array(&v, "files");
+    assert_eq!(v["files"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn pacnew_status_fixture_matches_struct_shape() {
+    let fixture = parse_fixture(include_str!("../../test/fixtures/pacnew-status.json"));
+
+    assert_bool(&fixture, "has_pacnew");
+    assert_array(&fixture, "files");
+
+    let file = &fixture["files"][0];
+    assert_string(file, "path");
+    assert_string(file, "package");
+    assert_string(file, "kind");
+}
+
 // CacheInfo
 
 #[test]
@@ -1568,6 +1621,12 @@ fn log_history_fixture_round_trip() {
 #[test]
 fn reboot_status_fixture_round_trip() {
     serde_json::from_str::<RebootStatus>(include_str!("../../test/fixtures/reboot-status.json"))
+        .unwrap();
+}
+
+#[test]
+fn pacnew_status_fixture_round_trip() {
+    serde_json::from_str::<PacnewStatus>(include_str!("../../test/fixtures/pacnew-status.json"))
         .unwrap();
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -917,6 +917,23 @@ export async function getRebootStatus(): Promise<RebootStatus> {
   return runBackend<RebootStatus>("reboot-status");
 }
 
+export type PacnewKind = "pacnew" | "pacsave";
+
+export interface PacnewFile {
+  path: string;
+  package: string;
+  kind: PacnewKind;
+}
+
+export interface PacnewStatus {
+  has_pacnew: boolean;
+  files: PacnewFile[];
+}
+
+export async function getPacnewStatus(): Promise<PacnewStatus> {
+  return runBackend<PacnewStatus>("pacnew-status", [], { superuser: "none" });
+}
+
 export function rebootSystem(): Promise<void> {
   const client = cockpit.dbus("org.freedesktop.login1", { bus: "system", superuser: "try" });
   return client
@@ -1222,6 +1239,18 @@ export async function getRebootDismissal(): Promise<RebootDismissal> {
 
 export async function markRebootDismissed(signature: string): Promise<void> {
   await runBackend<RebootDismissal>("reboot-mark-dismissed", [signature], { superuser: "none" });
+}
+
+export interface PacnewDismissal {
+  signature: string | null;
+}
+
+export async function getPacnewDismissal(): Promise<PacnewDismissal> {
+  return runBackend<PacnewDismissal>("pacnew-dismissal-state", [], { superuser: "none" });
+}
+
+export async function markPacnewDismissed(signature: string): Promise<void> {
+  await runBackend<PacnewDismissal>("pacnew-mark-dismissed", [signature], { superuser: "none" });
 }
 
 export type DependencyDirection = "forward" | "reverse" | "both";

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -67,6 +67,7 @@ import {
   PreflightResponse,
   StreamEvent,
   RebootStatus,
+  PacnewStatus,
   ServiceRestart,
   ServicesStatus,
   KeyringStatusResponse,
@@ -93,6 +94,9 @@ import {
   markServicesDismissed,
   getRebootDismissal,
   markRebootDismissed,
+  getPacnewStatus,
+  getPacnewDismissal,
+  markPacnewDismissed,
   addIgnoredPackage,
   getSignoffList,
   checkLock,
@@ -368,6 +372,8 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [restartServicesOnComplete, setRestartServicesOnComplete] = useState(false);
   const [dismissedServicesSignature, setDismissedServicesSignature] = useState<string | null | undefined>(undefined);
   const [dismissedRebootSignature, setDismissedRebootSignature] = useState<string | null | undefined>(undefined);
+  const [pacnewStatus, setPacnewStatus] = useState<PacnewStatus | null>(null);
+  const [dismissedPacnewSignature, setDismissedPacnewSignature] = useState<string | null | undefined>(undefined);
   const [orphanCount, setOrphanCount] = useState<number | null>(null);
   const [cacheSize, setCacheSize] = useState<number | null>(null);
   const [keyringStatus, setKeyringStatus] = useState<KeyringStatusResponse | null>(null);
@@ -630,6 +636,14 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     }
   }, []);
 
+  const loadPacnewStatus = useCallback(async () => {
+    try {
+      setPacnewStatus(await getPacnewStatus());
+    } catch {
+      setPacnewStatus(null);
+    }
+  }, []);
+
   useEffect(() => {
     getServicesDismissal()
       .then((d) => setDismissedServicesSignature(d.signature))
@@ -643,9 +657,16 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   }, []);
 
   useEffect(() => {
+    getPacnewDismissal()
+      .then((d) => setDismissedPacnewSignature(d.signature))
+      .catch(() => setDismissedPacnewSignature(null));
+  }, []);
+
+  useEffect(() => {
     Promise.resolve().then(() => loadRebootStatus());
     Promise.resolve().then(() => loadServicesStatus());
-  }, [loadRebootStatus, loadServicesStatus]);
+    Promise.resolve().then(() => loadPacnewStatus());
+  }, [loadRebootStatus, loadServicesStatus, loadPacnewStatus]);
 
   useEffect(() => {
     let cancelled = false;
@@ -850,6 +871,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           return;
         }
         loadRebootStatus();
+        loadPacnewStatus();
         loadServicesStatus().then((status) => {
           if (restartServicesOnComplete && status?.restart_required) {
             const units = status.services
@@ -973,6 +995,45 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           A reboot is recommended to apply these changes.
         </>
       )}
+    </Alert>
+  ) : null;
+
+  const pacnewSignature = useMemo(
+    () => (pacnewStatus?.files ?? []).map((f) => f.path).sort().join(","),
+    [pacnewStatus],
+  );
+
+  const pacnewAlert = pacnewStatus?.has_pacnew
+    && pacnewSignature !== ""
+    && dismissedPacnewSignature !== undefined
+    && dismissedPacnewSignature !== pacnewSignature ? (
+    <Alert
+      variant="warning"
+      title="Configuration files need merging"
+      className="pf-v6-u-mb-md"
+      actionClose={
+        <AlertActionCloseButton
+          onClose={() => {
+            setDismissedPacnewSignature(pacnewSignature);
+            markPacnewDismissed(pacnewSignature).catch((err) => {
+              console.error("Failed to persist pacnew dismissal:", err);
+            });
+          }}
+        />
+      }
+    >
+      <Content component={ContentVariants.p}>
+        A package upgrade left {pacnewStatus.files.length} configuration{" "}
+        {pacnewStatus.files.length === 1 ? "file" : "files"} that differ from your local edits.
+        Review and merge them manually (e.g. with <code>pacdiff</code>).
+      </Content>
+      <List>
+        {pacnewStatus.files.map((f) => (
+          <ListItem key={f.path}>
+            <strong>{f.path}</strong> ({f.package})
+          </ListItem>
+        ))}
+      </List>
     </Alert>
   ) : null;
 
@@ -1230,6 +1291,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         <CardBody>
           {rebootAlert}
           {servicesAlert}
+          {pacnewAlert}
           <EmptyState  headingLevel="h2" icon={CheckCircleIcon}  titleText="System Updated">
             <EmptyStateBody>
               All packages have been updated successfully.
@@ -1259,6 +1321,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       <>
         {rebootAlert}
         {servicesAlert}
+        {pacnewAlert}
         {warnings.length > 0 && (
           <Alert variant="warning" title="Warnings" className="pf-v6-u-mb-md">
             <ul className="pf-v6-u-m-0 pf-v6-u-pl-lg">
@@ -1349,6 +1412,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     <>
       {rebootAlert}
       {servicesAlert}
+      {pacnewAlert}
       {warnings.length > 0 && (
         <Alert variant="warning" title="Warnings" className="pf-v6-u-mb-md">
           <ul className="pf-v6-u-m-0 pf-v6-u-pl-lg">

--- a/src/test/contract.test.ts
+++ b/src/test/contract.test.ts
@@ -34,6 +34,7 @@ import type {
   LogGroup,
   LogEntry,
   RebootStatus,
+  PacnewStatus,
   StreamEvent,
   StreamEventLog,
   StreamEventProgress,
@@ -61,6 +62,7 @@ import {
   checkSecurity,
   getGroupedHistory,
   getRebootStatus,
+  getPacnewStatus,
   getCacheInfo,
   getKeyringStatus,
   getDependencyTree,
@@ -88,6 +90,7 @@ import mirrorStatusFixture from "../../test/fixtures/mirror-status.json";
 import securityFixture from "../../test/fixtures/security-advisories.json";
 import logHistoryFixture from "../../test/fixtures/log-history.json";
 import rebootStatusFixture from "../../test/fixtures/reboot-status.json";
+import pacnewStatusFixture from "../../test/fixtures/pacnew-status.json";
 import cacheInfoFixture from "../../test/fixtures/cache-info.json";
 import keyringStatusFixture from "../../test/fixtures/keyring-status.json";
 import dependencyTreeFixture from "../../test/fixtures/dependency-tree.json";
@@ -633,6 +636,35 @@ describe("getRebootStatus contract", () => {
     expect(result.running_kernel).toBeNull();
     expect(result.installed_kernel).toBeNull();
     expect(result.kernel_package).toBeNull();
+  });
+});
+
+
+describe("getPacnewStatus contract", () => {
+  it("parses pacnew-status fixture into PacnewStatus shape", async () => {
+    spawnReturns(pacnewStatusFixture);
+    const result = await getPacnewStatus();
+
+    expect(typeof result.has_pacnew).toBe("boolean");
+    expect(Array.isArray(result.files)).toBe(true);
+  });
+
+  it("file entries have correct field types", async () => {
+    spawnReturns(pacnewStatusFixture);
+    const result = await getPacnewStatus();
+
+    expect(typeof result.files[0].path).toBe("string");
+    expect(typeof result.files[0].package).toBe("string");
+    expect(typeof result.files[0].kind).toBe("string");
+  });
+
+  it("empty status has no files", async () => {
+    const empty: PacnewStatus = { has_pacnew: false, files: [] };
+    spawnReturns(empty);
+    const result = await getPacnewStatus();
+
+    expect(result.has_pacnew).toBe(false);
+    expect(result.files).toHaveLength(0);
   });
 });
 

--- a/test/fixtures/pacnew-status.json
+++ b/test/fixtures/pacnew-status.json
@@ -1,0 +1,7 @@
+{
+  "has_pacnew": true,
+  "files": [
+    { "path": "/etc/pacman.conf.pacnew", "package": "pacman", "kind": "pacnew" },
+    { "path": "/etc/ssh/sshd_config.pacsave", "package": "openssh", "kind": "pacsave" }
+  ]
+}


### PR DESCRIPTION
Pacman writes .pacnew/.pacsave files when tracked configs diverge during a transaction, but only prints a one-line warning that is easy to miss. Scan installed packages' backup files after an upgrade and surface pending merges as a dismissable alert so they are not left unattended.