### PR TITLE
feat(manifest): preload index page at shell init

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,6 +11,7 @@
     }
   },
   "overview-health": ["pacman"],
+  "preload": ["index"],
   "content-security-policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'",
   "conditions": [
     {


### PR DESCRIPTION
Without preload, the Overview Health row only appears after the user visits the plugin once per session. Match packagekit's manifest by preloading "index" so the shell mounts the page in a hidden iframe at startup and publishHealth fires before first navigation.