### PR TITLE
feat(downgrade): pull versions from the Arch Linux Archive

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "pacman-key",
  "pacman-log",
  "pacmanconf",
+ "percent-encoding",
  "rss",
  "serde",
  "serde_json",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 rss = "2"
 html2text = "0.17"
 ureq = "3"
+percent-encoding = "2"
 arch-security-client = { path = "crates/arch-security-client" }
 archweb-client = { path = "crates/archweb-client" }
 base64 = "0.22"

--- a/backend/src/handlers/archive.rs
+++ b/backend/src/handlers/archive.rs
@@ -1,0 +1,365 @@
+use anyhow::Result;
+use std::io::Read;
+use std::time::Duration;
+
+use crate::alpm::get_handle;
+use crate::handlers::downgrade::{
+    compare_versions, get_installed_version, is_version_older, run_pacman_upgrade,
+};
+use crate::models::{CachedVersion, DowngradeResponse};
+use crate::util::{emit_json, parse_package_filename};
+use crate::validation::{validate_archive_filename, validate_package_name};
+
+const ARCHIVE_BASE_URL: &str = "https://archive.archlinux.org/packages";
+const MAX_LISTING_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_ARCHIVE_VERSIONS: usize = 100;
+
+fn archive_dir_url(name: &str) -> Option<String> {
+    let first = name.chars().next()?;
+    Some(format!("{}/{}/{}/", ARCHIVE_BASE_URL, first, name))
+}
+
+fn archive_file_url(name: &str, filename: &str) -> Option<String> {
+    let first = name.chars().next()?;
+    Some(format!(
+        "{}/{}/{}/{}",
+        ARCHIVE_BASE_URL, first, name, filename
+    ))
+}
+
+/// Extract (filename, size) pairs (excluding signatures) from an archive
+/// directory listing. Hrefs are percent-decoded so epoch packages (served as
+/// `%3A`) surface with a literal `:`. Size is the autoindex column (rounded,
+/// e.g. `2M`); 0 when it can't be parsed.
+fn parse_listing(html: &str) -> Vec<(String, i64)> {
+    let mut files = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for line in html.lines() {
+        let Some(href_pos) = line.find("href=\"") else {
+            continue;
+        };
+        let rest = &line[href_pos + 6..];
+        let Some(end) = rest.find('"') else { continue };
+        let href = percent_encoding::percent_decode_str(&rest[..end])
+            .decode_utf8_lossy()
+            .into_owned();
+        if href.contains('/') || href.contains('\\') {
+            continue;
+        }
+        if !href.ends_with(".pkg.tar.zst")
+            && !href.ends_with(".pkg.tar.xz")
+            && !href.ends_with(".pkg.tar.gz")
+        {
+            continue;
+        }
+        let size = parse_listing_size(&rest[end + 1..]);
+        if seen.insert(href.clone()) {
+            files.push((href, size));
+        }
+    }
+    files
+}
+
+/// Parse the trailing autoindex size column (`2M`, `512K`, `1.2G`, or raw
+/// bytes). Returns 0 when absent or unparseable.
+fn parse_listing_size(tail: &str) -> i64 {
+    let Some(tok) = tail.split_whitespace().next_back() else {
+        return 0;
+    };
+    let (digits, mult) = match tok.chars().last() {
+        Some('K') | Some('k') => (&tok[..tok.len() - 1], 1024.0),
+        Some('M') | Some('m') => (&tok[..tok.len() - 1], 1024.0 * 1024.0),
+        Some('G') | Some('g') => (&tok[..tok.len() - 1], 1024.0 * 1024.0 * 1024.0),
+        Some('T') | Some('t') => (&tok[..tok.len() - 1], 1024.0_f64.powi(4)),
+        Some(c) if c.is_ascii_digit() => (tok, 1.0),
+        _ => return 0,
+    };
+    digits
+        .parse::<f64>()
+        .ok()
+        .map(|n| (n * mult) as i64)
+        .unwrap_or(0)
+}
+
+fn system_arch() -> &'static str {
+    std::env::consts::ARCH
+}
+
+pub fn list_archive_versions(name: &str, query: Option<&str>) -> Result<()> {
+    validate_package_name(name)?;
+    let alpm = get_handle()?;
+    let installed_version = get_installed_version(&alpm, name);
+    let arch = system_arch();
+
+    let url = archive_dir_url(name).ok_or_else(|| anyhow::anyhow!("Invalid package name"))?;
+
+    let agent = ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_secs(30)))
+            .ip_family(crate::util::detected_ip_family())
+            .build(),
+    );
+
+    let resp = match agent.get(&url).call() {
+        Ok(r) => r,
+        Err(ureq::Error::StatusCode(404)) => {
+            return emit_json(&DowngradeResponse {
+                packages: vec![],
+                total: 0,
+            });
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut body = resp.into_body();
+    let mut buf = Vec::new();
+    body.as_reader()
+        .take(MAX_LISTING_BYTES)
+        .read_to_end(&mut buf)?;
+    let html = String::from_utf8_lossy(&buf);
+
+    let packages = build_archive_versions(&html, name, arch, installed_version.as_deref(), query);
+    let total = packages.len();
+    emit_json(&DowngradeResponse { packages, total })
+}
+
+/// Turn an archive directory listing into the package versions for `name`,
+/// filtered to `arch` (plus `any`) and an optional case-insensitive version
+/// substring, newest first, capped at MAX_ARCHIVE_VERSIONS.
+fn build_archive_versions(
+    html: &str,
+    name: &str,
+    arch: &str,
+    installed_version: Option<&str>,
+    query: Option<&str>,
+) -> Vec<CachedVersion> {
+    let query = query.map(str::to_lowercase);
+    let mut packages: Vec<CachedVersion> = Vec::new();
+    for (filename, size) in parse_listing(html) {
+        let Some((pkg_name, version, pkg_arch)) = parse_package_filename(&filename) else {
+            continue;
+        };
+        if pkg_name != name {
+            continue;
+        }
+        if pkg_arch != arch && pkg_arch != "any" {
+            continue;
+        }
+        if let Some(q) = &query
+            && !version.to_lowercase().contains(q)
+        {
+            continue;
+        }
+        let is_older = installed_version
+            .map(|iv| is_version_older(&version, iv))
+            .unwrap_or(false);
+        packages.push(CachedVersion {
+            name: pkg_name,
+            version,
+            filename,
+            size,
+            installed_version: installed_version.map(str::to_string),
+            is_older,
+        });
+    }
+
+    packages.sort_by(|a, b| compare_versions(&b.version, &a.version));
+    packages.truncate(MAX_ARCHIVE_VERSIONS);
+    packages
+}
+
+pub fn downgrade_from_archive(name: &str, filename: &str, timeout: Option<u64>) -> Result<()> {
+    crate::util::setup_signal_handler();
+    validate_package_name(name)?;
+    validate_archive_filename(filename, name)?;
+
+    let (_, version, _) = parse_package_filename(filename)
+        .ok_or_else(|| anyhow::anyhow!("Invalid package filename"))?;
+    let url =
+        archive_file_url(name, filename).ok_or_else(|| anyhow::anyhow!("Invalid package name"))?;
+
+    run_pacman_upgrade(&url, name, &version, timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_listing_skipping_sigs_and_dirs() {
+        let html = r#"
+            <a href="../">../</a>
+            <a href="bash-5.1.016-1-x86_64.pkg.tar.zst">bash-5.1.016-1-x86_64.pkg.tar.zst</a>
+            <a href="bash-5.1.016-1-x86_64.pkg.tar.zst.sig">sig</a>
+            <a href="bash-5.2.015-1-x86_64.pkg.tar.zst">x</a>
+            <a href="bash-5.0.018-1-x86_64.pkg.tar.xz">old</a>
+        "#;
+        let names: Vec<String> = parse_listing(html).into_iter().map(|(f, _)| f).collect();
+        assert_eq!(names.len(), 3);
+        assert!(names.contains(&"bash-5.1.016-1-x86_64.pkg.tar.zst".to_string()));
+        assert!(names.contains(&"bash-5.0.018-1-x86_64.pkg.tar.xz".to_string()));
+        assert!(!names.iter().any(|f| f.ends_with(".sig")));
+    }
+
+    #[test]
+    fn parse_listing_reads_the_autoindex_size_column() {
+        let html = "<a href=\"bash-5.1-1-x86_64.pkg.tar.zst\">bash-5.1-1-x86_64.pkg.tar.zst</a>     09-Mar-2019 07:17      2M\r\n";
+        let files = parse_listing(html);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].1, 2 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parses_human_and_byte_size_tokens() {
+        assert_eq!(parse_listing_size("  date   512K"), 512 * 1024);
+        assert_eq!(
+            parse_listing_size("  date   1.5G"),
+            (1.5 * 1024.0 * 1024.0 * 1024.0) as i64
+        );
+        assert_eq!(parse_listing_size("  date   4096"), 4096);
+        assert_eq!(parse_listing_size("</a>"), 0);
+    }
+
+    #[test]
+    fn parses_filename_with_epoch() {
+        let (name, version, arch) =
+            parse_package_filename("grub-2:2.04-1-x86_64.pkg.tar.zst").unwrap();
+        assert_eq!(name, "grub");
+        assert_eq!(version, "2:2.04-1");
+        assert_eq!(arch, "x86_64");
+    }
+
+    #[test]
+    fn parse_listing_decodes_percent_encoded_epoch() {
+        // The archive serves epoch packages with the colon escaped as %3A.
+        let html = listing(&["grub-2%3A2.04-1-x86_64.pkg.tar.zst"]);
+        let names: Vec<String> = parse_listing(&html).into_iter().map(|(f, _)| f).collect();
+        assert_eq!(names, ["grub-2:2.04-1-x86_64.pkg.tar.zst"]);
+    }
+
+    #[test]
+    fn parse_listing_drops_encoded_path_separators() {
+        let html = listing(&["%2e%2e%2fevil-1-1-x86_64.pkg.tar.zst"]);
+        assert!(parse_listing(&html).is_empty());
+    }
+
+    #[test]
+    fn build_archive_versions_surfaces_epoch_packages() {
+        let html = listing(&["grub-2%3A2.04-1-x86_64.pkg.tar.zst"]);
+        let versions = build_archive_versions(&html, "grub", "x86_64", None, None);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "2:2.04-1");
+        assert_eq!(versions[0].filename, "grub-2:2.04-1-x86_64.pkg.tar.zst");
+    }
+
+    fn listing(filenames: &[&str]) -> String {
+        filenames
+            .iter()
+            .map(|f| format!("<a href=\"{f}\">{f}</a>\n"))
+            .collect()
+    }
+
+    #[test]
+    fn keeps_system_arch_and_any_drops_others() {
+        let html = listing(&[
+            "bash-5.1-1-x86_64.pkg.tar.zst",
+            "bash-5.1-1-i686.pkg.tar.zst",
+            "bash-5.1-1-any.pkg.tar.zst",
+            "bash-5.1-1-aarch64.pkg.tar.zst",
+        ]);
+        let versions = build_archive_versions(&html, "bash", "x86_64", None, None);
+        let archs: Vec<&str> = versions
+            .iter()
+            .map(|v| v.filename.rsplit('-').nth(0).unwrap())
+            .collect();
+        assert_eq!(versions.len(), 2);
+        assert!(
+            archs
+                .iter()
+                .all(|a| a.starts_with("x86_64") || a.starts_with("any"))
+        );
+    }
+
+    #[test]
+    fn filters_to_requested_package_only() {
+        let html = listing(&[
+            "bash-5.1-1-x86_64.pkg.tar.zst",
+            "bash-completion-2.11-1-any.pkg.tar.zst",
+        ]);
+        let versions = build_archive_versions(&html, "bash", "x86_64", None, None);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "5.1-1");
+    }
+
+    #[test]
+    fn sorts_newest_first() {
+        let html = listing(&[
+            "bash-5.0-1-x86_64.pkg.tar.zst",
+            "bash-5.2-1-x86_64.pkg.tar.zst",
+            "bash-5.1-1-x86_64.pkg.tar.zst",
+        ]);
+        let versions = build_archive_versions(&html, "bash", "x86_64", None, None);
+        let order: Vec<&str> = versions.iter().map(|v| v.version.as_str()).collect();
+        assert_eq!(order, ["5.2-1", "5.1-1", "5.0-1"]);
+    }
+
+    #[test]
+    fn caps_at_max_versions() {
+        let files: Vec<String> = (0..MAX_ARCHIVE_VERSIONS + 25)
+            .map(|i| format!("bash-1.{i}-1-x86_64.pkg.tar.zst"))
+            .collect();
+        let refs: Vec<&str> = files.iter().map(String::as_str).collect();
+        let versions = build_archive_versions(&listing(&refs), "bash", "x86_64", None, None);
+        assert_eq!(versions.len(), MAX_ARCHIVE_VERSIONS);
+    }
+
+    #[test]
+    fn marks_older_versions_against_installed() {
+        let html = listing(&[
+            "bash-5.2-1-x86_64.pkg.tar.zst",
+            "bash-5.0-1-x86_64.pkg.tar.zst",
+        ]);
+        let versions = build_archive_versions(&html, "bash", "x86_64", Some("5.1-1"), None);
+        let older: Vec<bool> = versions.iter().map(|v| v.is_older).collect();
+        assert_eq!(older, [false, true]);
+        assert!(
+            versions
+                .iter()
+                .all(|v| v.installed_version.as_deref() == Some("5.1-1"))
+        );
+    }
+
+    #[test]
+    fn query_filters_versions_before_the_cap() {
+        let mut files: Vec<String> = (0..MAX_ARCHIVE_VERSIONS + 5)
+            .map(|i| format!("bash-9.{i}-1-x86_64.pkg.tar.zst"))
+            .collect();
+        files.push("bash-1.2.3-1-x86_64.pkg.tar.zst".to_string());
+        let refs: Vec<&str> = files.iter().map(String::as_str).collect();
+        let versions =
+            build_archive_versions(&listing(&refs), "bash", "x86_64", None, Some("1.2.3"));
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "1.2.3-1");
+    }
+
+    #[test]
+    fn not_installed_yields_no_older_flag() {
+        let html = listing(&["bash-5.0-1-x86_64.pkg.tar.zst"]);
+        let versions = build_archive_versions(&html, "bash", "x86_64", None, None);
+        assert_eq!(versions.len(), 1);
+        assert!(!versions[0].is_older);
+        assert_eq!(versions[0].installed_version, None);
+    }
+
+    #[test]
+    fn builds_urls_from_first_char() {
+        assert_eq!(
+            archive_dir_url("bash").unwrap(),
+            "https://archive.archlinux.org/packages/b/bash/"
+        );
+        assert_eq!(
+            archive_file_url("bash", "bash-5.1.016-1-x86_64.pkg.tar.zst").unwrap(),
+            "https://archive.archlinux.org/packages/b/bash/bash-5.1.016-1-x86_64.pkg.tar.zst"
+        );
+    }
+}

--- a/backend/src/handlers/downgrade.rs
+++ b/backend/src/handlers/downgrade.rs
@@ -75,13 +75,24 @@ pub fn downgrade_package(name: &str, version: &str, timeout: Option<u64>) -> Res
     let cache_dir = get_cache_dir();
     let cache_path = Path::new(&cache_dir);
     let target_filename = find_package_file(cache_path, name, version)?;
+    let pkg_path = cache_path.join(&target_filename);
 
+    run_pacman_upgrade(&pkg_path.to_string_lossy(), name, version, timeout)
+}
+
+/// Run `pacman -U` against a package target (a cache path or an archive URL),
+/// streaming its output as log events. Shared by cache and archive downgrades.
+pub(crate) fn run_pacman_upgrade(
+    target: &str,
+    name: &str,
+    version: &str,
+    timeout: Option<u64>,
+) -> Result<()> {
     emit_event(&StreamEvent::Event {
         event: format!("Downgrading {} to version {}", name, version),
         package: Some(name.to_string()),
     });
 
-    let pkg_path = cache_path.join(&target_filename);
     let timeout_secs = timeout.unwrap_or(DEFAULT_MUTATION_TIMEOUT_SECS);
     let timeout_duration = std::time::Duration::from_secs(timeout_secs);
     let start_time = Instant::now();
@@ -90,14 +101,13 @@ pub fn downgrade_package(name: &str, version: &str, timeout: Option<u64>) -> Res
         level: "info".to_string(),
         message: format!(
             "Running: pacman -U --noconfirm {} (timeout: {}s)",
-            pkg_path.display(),
-            timeout_secs
+            target, timeout_secs
         ),
     });
 
     let mut child = Command::new("pacman")
         .args(["-U", "--noconfirm"])
-        .arg(&pkg_path)
+        .arg(target)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -224,7 +234,7 @@ fn find_package_file(cache_path: &Path, name: &str, version: &str) -> Result<Str
         };
         let path = entry.path();
         if let Some(filename) = path.file_name().map(|s| s.to_string_lossy().to_string())
-            && let Some((pkg_name, pkg_version)) = parse_package_filename(&filename)
+            && let Some((pkg_name, pkg_version, _)) = parse_package_filename(&filename)
             && pkg_name == name
             && pkg_version == version
         {
@@ -235,17 +245,17 @@ fn find_package_file(cache_path: &Path, name: &str, version: &str) -> Result<Str
     anyhow::bail!("Package file not found in cache: {}-{}", name, version)
 }
 
-fn get_installed_version(alpm: &Alpm, name: &str) -> Option<String> {
+pub(crate) fn get_installed_version(alpm: &Alpm, name: &str) -> Option<String> {
     alpm.localdb()
         .pkg(name)
         .ok()
         .map(|p| p.version().to_string())
 }
 
-fn is_version_older(cached: &str, installed: &str) -> bool {
+pub(crate) fn is_version_older(cached: &str, installed: &str) -> bool {
     matches!(compare_versions(cached, installed), Ordering::Less)
 }
 
-fn compare_versions(a: &str, b: &str) -> Ordering {
+pub(crate) fn compare_versions(a: &str, b: &str) -> Ordering {
     alpm::vercmp(a, b)
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod archive;
 pub mod cache;
 pub mod config;
 pub mod dependency;
@@ -17,6 +18,7 @@ pub mod security;
 pub mod services;
 pub mod signoff;
 
+pub use archive::{downgrade_from_archive, list_archive_versions};
 pub use cache::{clean_cache, get_cache_info};
 pub use config::{add_ignored, list_ignored, remove_ignored};
 pub use dependency::get_dependency_tree;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,23 +2,25 @@ use std::env;
 
 use cockpit_pacman_backend::handlers::{
     add_ignored, check_lock, check_security, check_updates, clean_cache, delete_mirror_backup,
-    downgrade_package, fetch_mirror_status, fetch_news, get_cache_info, get_dependency_tree,
-    get_grouped_history, get_history, get_pacnew_status, get_reboot_status, get_schedule_config,
-    get_scheduled_runs, get_services_status, init_keyring, install_package, keyring_status,
-    list_downgrades, list_ignored, list_installed, list_mirror_backups, list_mirrors, list_orphans,
-    list_repo_mirrors, list_repos, local_package_info, mark_news_read, mark_pacnew_dismissed,
-    mark_reboot_dismissed, mark_services_dismissed, preflight_upgrade, read_news_state,
-    read_pacnew_dismissal, read_reboot_dismissal, read_services_dismissal, refresh_keyring,
-    refresh_mirrors, remove_ignored, remove_orphans, remove_package, remove_stale_lock,
-    restore_mirror_backup, run_upgrade, save_mirrorlist, save_repos, scheduled_run, search,
-    security_info, set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
+    downgrade_from_archive, downgrade_package, fetch_mirror_status, fetch_news, get_cache_info,
+    get_dependency_tree, get_grouped_history, get_history, get_pacnew_status, get_reboot_status,
+    get_schedule_config, get_scheduled_runs, get_services_status, init_keyring, install_package,
+    keyring_status, list_archive_versions, list_downgrades, list_ignored, list_installed,
+    list_mirror_backups, list_mirrors, list_orphans, list_repo_mirrors, list_repos,
+    local_package_info, mark_news_read, mark_pacnew_dismissed, mark_reboot_dismissed,
+    mark_services_dismissed, preflight_upgrade, read_news_state, read_pacnew_dismissal,
+    read_reboot_dismissal, read_services_dismissal, refresh_keyring, refresh_mirrors,
+    remove_ignored, remove_orphans, remove_package, remove_stale_lock, restore_mirror_backup,
+    run_upgrade, save_mirrorlist, save_repos, scheduled_run, search, security_info,
+    set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
     sync_package_info, test_mirrors,
 };
 use cockpit_pacman_backend::models::{MirrorEntry, RepoEntry};
 use cockpit_pacman_backend::validation::{
-    validate_depth, validate_direction, validate_json_payload_size, validate_keep_versions,
-    validate_mirror_timeout, validate_mirror_url, validate_package_name, validate_pagination,
-    validate_refresh_protocol, validate_refresh_sort, validate_search_query, validate_signoff_arg,
+    validate_archive_filename, validate_depth, validate_direction, validate_json_payload_size,
+    validate_keep_versions, validate_mirror_timeout, validate_mirror_url, validate_package_name,
+    validate_pagination, validate_refresh_protocol, validate_refresh_sort, validate_search_query,
+    validate_signoff_arg,
 };
 
 fn print_usage() {
@@ -86,6 +88,14 @@ fn print_usage() {
     eprintln!("                         NAME: optional package name to filter");
     eprintln!("  downgrade NAME VERSION [timeout]");
     eprintln!("                         Downgrade a package to a cached version (requires root)");
+    eprintln!("                         timeout: seconds (default: 300)");
+    eprintln!("  list-archive-versions NAME [QUERY]");
+    eprintln!("                         List versions available in the Arch Linux Archive");
+    eprintln!("                         filtered to the system architecture and 'any'");
+    eprintln!("                         QUERY: optional version substring, applied before the cap");
+    eprintln!("  downgrade-archive NAME FILENAME [timeout]");
+    eprintln!("                         Downgrade to an archive version via pacman -U URL");
+    eprintln!("                         (requires root; downloads and verifies the package)");
     eprintln!("                         timeout: seconds (default: 300)");
     eprintln!("  get-schedule           Get scheduled upgrade configuration");
     eprintln!("  set-schedule [enabled] [mode] [schedule] [max_packages]");
@@ -347,6 +357,31 @@ fn main() {
             let timeout = args.get(4).and_then(|s| s.parse().ok());
             validate_package_name(&args[2])
                 .and_then(|_| downgrade_package(&args[2], &args[3], timeout))
+        }
+        "list-archive-versions" => {
+            if args.len() < 3 {
+                eprintln!("Error: list-archive-versions requires a package name");
+                std::process::exit(1);
+            }
+            let query = args.get(3).map(|s| s.as_str()).filter(|s| !s.is_empty());
+            validate_package_name(&args[2])
+                .and_then(|_| {
+                    if let Some(q) = query {
+                        validate_search_query(q)?;
+                    }
+                    Ok(())
+                })
+                .and_then(|_| list_archive_versions(&args[2], query))
+        }
+        "downgrade-archive" => {
+            if args.len() < 4 {
+                eprintln!("Error: downgrade-archive requires NAME and FILENAME");
+                std::process::exit(1);
+            }
+            let timeout = args.get(4).and_then(|s| s.parse().ok());
+            validate_package_name(&args[2])
+                .and_then(|_| validate_archive_filename(&args[3], &args[2]))
+                .and_then(|_| downgrade_from_archive(&args[2], &args[3], timeout))
         }
         "get-schedule" => get_schedule_config(),
         "set-schedule" => {

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -5,9 +5,10 @@ use crate::models::{
 };
 use crate::util::parse_package_filename;
 use crate::validation::{
-    validate_depth, validate_direction, validate_json_payload_size, validate_keep_versions,
-    validate_max_packages, validate_mirror_timeout, validate_mirror_url, validate_package_name,
-    validate_pagination, validate_schedule, validate_search_query, validate_version,
+    validate_archive_filename, validate_depth, validate_direction, validate_json_payload_size,
+    validate_keep_versions, validate_max_packages, validate_mirror_timeout, validate_mirror_url,
+    validate_package_name, validate_pagination, validate_schedule, validate_search_query,
+    validate_version,
 };
 
 // --- Serialization tests ---
@@ -157,8 +158,38 @@ fn test_validate_package_name_invalid() {
     assert!(validate_package_name("foo;bar").is_err()); // shell metachar
     assert!(validate_package_name("foo/bar").is_err()); // path separator
     assert!(validate_package_name("../etc/passwd").is_err()); // path traversal
+    assert!(validate_package_name("..").is_err()); // bare traversal, no slash
     assert!(validate_package_name("foo?x=1").is_err()); // query string
     assert!(validate_package_name("foo bar").is_err()); // space
+}
+
+#[test]
+fn test_validate_archive_filename_valid() {
+    assert!(validate_archive_filename("bash-5.1.016-1-x86_64.pkg.tar.zst", "bash").is_ok());
+    assert!(
+        validate_archive_filename(
+            "ca-certificates-20240618-1-any.pkg.tar.zst",
+            "ca-certificates"
+        )
+        .is_ok()
+    );
+    assert!(validate_archive_filename("grub-2:2.06.r499-1-x86_64.pkg.tar.zst", "grub").is_ok());
+    assert!(validate_archive_filename("foo-1.0-1-x86_64.pkg.tar.xz", "foo").is_ok());
+}
+
+#[test]
+fn test_validate_archive_filename_invalid() {
+    assert!(validate_archive_filename("", "bash").is_err());
+    assert!(validate_archive_filename("bash-5.1.016-1-x86_64.pkg.tar.zst.sig", "bash").is_err());
+    assert!(validate_archive_filename("bash-5.1.016-1-x86_64.txt", "bash").is_err()); // not a pkg
+    assert!(validate_archive_filename("../bash-5.1.016-1-x86_64.pkg.tar.zst", "bash").is_err()); // traversal
+    assert!(validate_archive_filename("sub/bash-5.1.016-1-x86_64.pkg.tar.zst", "bash").is_err()); // path sep
+    assert!(validate_archive_filename("evil-1-1-x86_64.pkg.tar.zst", "bash").is_err()); // name mismatch
+    assert!(validate_archive_filename("bash 1-1-x86_64.pkg.tar.zst", "bash").is_err()); // space in charset
+    assert!(
+        validate_archive_filename(&format!("{}-1-1-x86_64.pkg.tar.zst", "a".repeat(600)), "a")
+            .is_err()
+    ); // over length cap
 }
 
 #[test]
@@ -297,7 +328,14 @@ fn test_validate_mirror_timeout_invalid() {
 #[test]
 fn test_parse_package_filename_simple() {
     let result = parse_package_filename("ada-1.0.0-1-x86_64.pkg.tar.zst");
-    assert_eq!(result, Some(("ada".to_string(), "1.0.0-1".to_string())));
+    assert_eq!(
+        result,
+        Some((
+            "ada".to_string(),
+            "1.0.0-1".to_string(),
+            "x86_64".to_string()
+        ))
+    );
 }
 
 #[test]
@@ -305,7 +343,11 @@ fn test_parse_package_filename_with_dashes_in_name() {
     let result = parse_package_filename("lib32-glibc-2.39-1-x86_64.pkg.tar.zst");
     assert_eq!(
         result,
-        Some(("lib32-glibc".to_string(), "2.39-1".to_string()))
+        Some((
+            "lib32-glibc".to_string(),
+            "2.39-1".to_string(),
+            "x86_64".to_string()
+        ))
     );
 }
 
@@ -314,20 +356,38 @@ fn test_parse_package_filename_complex_version() {
     let result = parse_package_filename("linux-6.7.0.arch1-1-x86_64.pkg.tar.zst");
     assert_eq!(
         result,
-        Some(("linux".to_string(), "6.7.0.arch1-1".to_string()))
+        Some((
+            "linux".to_string(),
+            "6.7.0.arch1-1".to_string(),
+            "x86_64".to_string()
+        ))
     );
 }
 
 #[test]
 fn test_parse_package_filename_xz_extension() {
     let result = parse_package_filename("pacman-6.0.2-7-x86_64.pkg.tar.xz");
-    assert_eq!(result, Some(("pacman".to_string(), "6.0.2-7".to_string())));
+    assert_eq!(
+        result,
+        Some((
+            "pacman".to_string(),
+            "6.0.2-7".to_string(),
+            "x86_64".to_string()
+        ))
+    );
 }
 
 #[test]
 fn test_parse_package_filename_gz_extension() {
     let result = parse_package_filename("gzip-1.13-1-x86_64.pkg.tar.gz");
-    assert_eq!(result, Some(("gzip".to_string(), "1.13-1".to_string())));
+    assert_eq!(
+        result,
+        Some((
+            "gzip".to_string(),
+            "1.13-1".to_string(),
+            "x86_64".to_string()
+        ))
+    );
 }
 
 #[test]
@@ -347,7 +407,11 @@ fn test_parse_package_filename_any_arch() {
     let result = parse_package_filename("bash-completion-2.11-2-any.pkg.tar.zst");
     assert_eq!(
         result,
-        Some(("bash-completion".to_string(), "2.11-2".to_string()))
+        Some((
+            "bash-completion".to_string(),
+            "2.11-2".to_string(),
+            "any".to_string()
+        ))
     );
 }
 

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -201,9 +201,8 @@ pub fn load_cache_packages(
         .collect()
 }
 
-/// Parse a pacman package filename into (name, version).
-/// Used by find_package_file to locate a specific cached package.
-pub(crate) fn parse_package_filename(filename: &str) -> Option<(String, String)> {
+/// Parse a pacman package filename into (name, version, arch).
+pub(crate) fn parse_package_filename(filename: &str) -> Option<(String, String, String)> {
     let base = filename
         .strip_suffix(".pkg.tar.zst")
         .or_else(|| filename.strip_suffix(".pkg.tar.xz"))
@@ -212,10 +211,10 @@ pub(crate) fn parse_package_filename(filename: &str) -> Option<(String, String)>
     // Split into [arch, pkgrel, pkgver, ...name_parts]
     let parts: Vec<&str> = base.rsplitn(4, '-').collect();
     if parts.len() >= 4 {
-        // parts[0] = arch (ignored), parts[1] = pkgrel, parts[2] = pkgver
+        let arch = parts[0].to_string();
         let version = format!("{}-{}", parts[2], parts[1]);
         let pkg_name = parts[3..].join("-");
-        Some((pkg_name, version))
+        Some((pkg_name, version, arch))
     } else {
         None
     }

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -7,6 +7,9 @@ pub fn validate_package_name(name: &str) -> Result<()> {
     if name.len() > 256 {
         anyhow::bail!("Package name too long (max 256)");
     }
+    if name.contains("..") {
+        anyhow::bail!("Package name contains invalid path sequence");
+    }
     if !name
         .bytes()
         .all(|b| b.is_ascii_alphanumeric() || b"@._+-".contains(&b))
@@ -51,6 +54,39 @@ pub fn validate_version(version: &str) -> Result<()> {
     }
     if version.chars().any(|c| c.is_control()) {
         anyhow::bail!("Version contains invalid control characters");
+    }
+    Ok(())
+}
+
+pub fn validate_archive_filename(filename: &str, expected_name: &str) -> Result<()> {
+    if filename.is_empty() {
+        anyhow::bail!("Archive filename cannot be empty");
+    }
+    if filename.len() > 512 {
+        anyhow::bail!("Archive filename too long (max 512)");
+    }
+    if filename.contains('/') || filename.contains('\\') || filename.contains("..") {
+        anyhow::bail!("Archive filename contains invalid path characters");
+    }
+    if !filename.ends_with(".pkg.tar.zst")
+        && !filename.ends_with(".pkg.tar.xz")
+        && !filename.ends_with(".pkg.tar.gz")
+    {
+        anyhow::bail!("Archive filename is not a package file");
+    }
+    if !filename
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b"@._+:-".contains(&b))
+    {
+        anyhow::bail!("Archive filename contains invalid characters");
+    }
+    let (parsed_name, _, _) = crate::util::parse_package_filename(filename)
+        .ok_or_else(|| anyhow::anyhow!("Archive filename is malformed"))?;
+    if parsed_name != expected_name {
+        anyhow::bail!(
+            "Archive filename does not match package '{}'",
+            expected_name
+        );
     }
     Ok(())
 }

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -17,6 +17,8 @@ import {
   searchPackages,
   runUpgrade,
   syncDatabase,
+  listArchiveVersions,
+  downgradeFromArchive,
   StreamEvent,
 } from "./api";
 
@@ -561,5 +563,128 @@ describe("syncDatabase", () => {
     mockProc._emit(JSON.stringify(downloadEvent) + "\n");
 
     expect(callbacks.onData).toHaveBeenCalledWith("Downloaded core.db\n");
+  });
+});
+
+describe("listArchiveVersions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the list-archive-versions backend command with the package name", async () => {
+    mockSpawn.mockReturnValue(
+      createMockSpawnPromise(JSON.stringify({ packages: [], total: 0 }))
+    );
+
+    await listArchiveVersions("bash");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      [
+        "/usr/libexec/cockpit-pacman/cockpit-pacman-backend",
+        "list-archive-versions",
+        "bash",
+      ],
+      expect.any(Object)
+    );
+  });
+
+  it("passes the version query as a fourth argument when provided", async () => {
+    mockSpawn.mockReturnValue(
+      createMockSpawnPromise(JSON.stringify({ packages: [], total: 0 }))
+    );
+
+    await listArchiveVersions("bash", "5.1");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      [
+        "/usr/libexec/cockpit-pacman/cockpit-pacman-backend",
+        "list-archive-versions",
+        "bash",
+        "5.1",
+      ],
+      expect.any(Object)
+    );
+  });
+
+  it("omits the query argument when blank", async () => {
+    mockSpawn.mockReturnValue(
+      createMockSpawnPromise(JSON.stringify({ packages: [], total: 0 }))
+    );
+
+    await listArchiveVersions("bash", "   ");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      [
+        "/usr/libexec/cockpit-pacman/cockpit-pacman-backend",
+        "list-archive-versions",
+        "bash",
+      ],
+      expect.any(Object)
+    );
+  });
+
+  it("parses the DowngradeResponse shape", async () => {
+    const response = {
+      packages: [
+        {
+          name: "bash",
+          version: "5.1.016-1",
+          filename: "bash-5.1.016-1-x86_64.pkg.tar.zst",
+          size: 0,
+          installed_version: "5.2.015-1",
+          is_older: true,
+        },
+      ],
+      total: 1,
+    };
+    mockSpawn.mockReturnValue(createMockSpawnPromise(JSON.stringify(response)));
+
+    const result = await listArchiveVersions("bash");
+
+    expect(result.total).toBe(1);
+    expect(result.packages[0].filename).toBe("bash-5.1.016-1-x86_64.pkg.tar.zst");
+    expect(result.packages[0].is_older).toBe(true);
+  });
+});
+
+describe("downgradeFromArchive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("streams the downgrade-archive command with name and filename", () => {
+    const mockProc = createMockStreamingProcess();
+    mockSpawn.mockReturnValue(mockProc);
+
+    const callbacks = {
+      onComplete: vi.fn(),
+      onError: vi.fn(),
+    };
+
+    downgradeFromArchive(callbacks, "bash", "bash-5.1.016-1-x86_64.pkg.tar.zst");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      [
+        "/usr/libexec/cockpit-pacman/cockpit-pacman-backend",
+        "downgrade-archive",
+        "bash",
+        "bash-5.1.016-1-x86_64.pkg.tar.zst",
+      ],
+      { superuser: "require", err: "out" }
+    );
+  });
+
+  it("calls onComplete on a success event", () => {
+    const mockProc = createMockStreamingProcess();
+    mockSpawn.mockReturnValue(mockProc);
+
+    const callbacks = { onComplete: vi.fn(), onError: vi.fn() };
+    downgradeFromArchive(callbacks, "bash", "bash-5.1.016-1-x86_64.pkg.tar.zst");
+
+    const completeEvent: StreamEvent = { type: "complete", success: true };
+    mockProc._emit(JSON.stringify(completeEvent) + "\n");
+
+    expect(callbacks.onComplete).toHaveBeenCalledTimes(1);
+    expect(callbacks.onError).not.toHaveBeenCalled();
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -840,6 +840,22 @@ export function downgradePackage(
   return runStreamingBackend("downgrade", [sanitizeSearchInput(name), sanitizeSearchInput(version)], callbacks);
 }
 
+export async function listArchiveVersions(packageName: string, query?: string): Promise<DowngradeResponse> {
+  const args = [sanitizeSearchInput(packageName)];
+  if (query && query.trim()) {
+    args.push(sanitizeSearchInput(query));
+  }
+  return runBackend<DowngradeResponse>("list-archive-versions", args);
+}
+
+export function downgradeFromArchive(
+  callbacks: UpgradeCallbacks,
+  name: string,
+  filename: string
+): { cancel: () => void } {
+  return runStreamingBackend("downgrade-archive", [sanitizeSearchInput(name), filename], callbacks);
+}
+
 export type ScheduleMode = "check" | "upgrade";
 
 export interface ScheduleConfig {

--- a/src/components/DowngradeModal.test.tsx
+++ b/src/components/DowngradeModal.test.tsx
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, act, cleanup } from "@testing-library/react";
+import { DowngradeModal } from "./DowngradeModal";
+import * as api from "../api";
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual("../api");
+  return {
+    ...actual,
+    listDowngrades: vi.fn(),
+    listArchiveVersions: vi.fn(),
+    downgradePackage: vi.fn(),
+    downgradeFromArchive: vi.fn(),
+  };
+});
+
+const mockListDowngrades = vi.mocked(api.listDowngrades);
+const mockListArchiveVersions = vi.mocked(api.listArchiveVersions);
+const mockDowngradePackage = vi.mocked(api.downgradePackage);
+const mockDowngradeFromArchive = vi.mocked(api.downgradeFromArchive);
+
+const cacheVersion: api.CachedVersion = {
+  name: "bash",
+  version: "5.1.016-1",
+  filename: "bash-5.1.016-1-x86_64.pkg.tar.zst",
+  size: 1024,
+  installed_version: "5.2.015-1",
+  is_older: true,
+};
+
+const archiveVersion: api.CachedVersion = {
+  name: "bash",
+  version: "5.0.018-1",
+  filename: "bash-5.0.018-1-x86_64.pkg.tar.zst",
+  size: 0,
+  installed_version: "5.2.015-1",
+  is_older: true,
+};
+
+describe("DowngradeModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListDowngrades.mockResolvedValue({ packages: [cacheVersion], total: 1 });
+    mockListArchiveVersions.mockResolvedValue({ packages: [archiveVersion], total: 1 });
+    mockDowngradePackage.mockReturnValue({ cancel: vi.fn() });
+    mockDowngradeFromArchive.mockReturnValue({ cancel: vi.fn() });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads cached versions from the cache source by default", async () => {
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockListDowngrades).toHaveBeenCalledWith("bash");
+    });
+    expect(mockListArchiveVersions).not.toHaveBeenCalled();
+    expect(screen.getByText("5.1.016-1")).toBeInTheDocument();
+  });
+
+  it("switching to the Archive tab fetches archive versions", async () => {
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+
+    await waitFor(() => {
+      expect(mockListArchiveVersions).toHaveBeenCalledWith("bash");
+    });
+    expect(screen.getByText("5.0.018-1")).toBeInTheDocument();
+  });
+
+  it("confirming a cache downgrade routes to downgradePackage", async () => {
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("5.1.016-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Downgrade/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Confirm Downgrade/i }));
+    });
+
+    expect(mockDowngradePackage).toHaveBeenCalledWith(
+      expect.any(Object),
+      "bash",
+      "5.1.016-1"
+    );
+    expect(mockDowngradeFromArchive).not.toHaveBeenCalled();
+  });
+
+  it("confirming an archive downgrade routes to downgradeFromArchive with the filename", async () => {
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+    await waitFor(() => expect(screen.getByText("5.0.018-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Downgrade/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Confirm Downgrade/i }));
+    });
+
+    expect(mockDowngradeFromArchive).toHaveBeenCalledWith(
+      expect.any(Object),
+      "bash",
+      "bash-5.0.018-1-x86_64.pkg.tar.zst"
+    );
+    expect(mockDowngradePackage).not.toHaveBeenCalled();
+  });
+
+  it("filters the version list by the search query", async () => {
+    mockListArchiveVersions.mockResolvedValue({
+      packages: [
+        { ...archiveVersion, version: "5.0.018-1", filename: "bash-5.0.018-1-x86_64.pkg.tar.zst" },
+        { ...archiveVersion, version: "4.4.023-1", filename: "bash-4.4.023-1-x86_64.pkg.tar.zst" },
+      ],
+      total: 2,
+    });
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+    await waitFor(() => expect(screen.getByText("4.4.023-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Filter versions"), {
+        target: { value: "4.4" },
+      });
+    });
+
+    expect(screen.queryByText("5.0.018-1")).not.toBeInTheDocument();
+    expect(screen.getByText("4.4.023-1")).toBeInTheDocument();
+  });
+
+  it("escalates to a backend search when nothing in the loaded page matches", async () => {
+    const serverOnly: api.CachedVersion = {
+      name: "bash",
+      version: "3.2.57-1",
+      filename: "bash-3.2.57-1-x86_64.pkg.tar.zst",
+      size: 0,
+      installed_version: "5.2.015-1",
+      is_older: true,
+    };
+    mockListArchiveVersions.mockImplementation((_name, query) =>
+      Promise.resolve(
+        query
+          ? { packages: [serverOnly], total: 1 }
+          : { packages: [archiveVersion], total: 1 }
+      )
+    );
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+    await waitFor(() => expect(screen.getByText("5.0.018-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Filter versions"), {
+        target: { value: "3.2.57" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockListArchiveVersions).toHaveBeenLastCalledWith("bash", "3.2.57")
+    );
+    await waitFor(() => expect(screen.getByText("3.2.57-1")).toBeInTheDocument());
+  });
+
+  it("shows a failure message when the escalated archive search errors", async () => {
+    mockListArchiveVersions.mockImplementation((_name, query) =>
+      query
+        ? Promise.reject(new Error("network_error"))
+        : Promise.resolve({ packages: [archiveVersion], total: 1 })
+    );
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+    await waitFor(() => expect(screen.getByText("5.0.018-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Filter versions"), {
+        target: { value: "3.2.57" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Archive search failed")).toBeInTheDocument()
+    );
+    expect(screen.queryByText("No matching versions")).not.toBeInTheDocument();
+  });
+
+  it("renders archive version sizes from the listing", async () => {
+    mockListArchiveVersions.mockResolvedValue({
+      packages: [{ ...archiveVersion, size: 2 * 1024 * 1024 }],
+      total: 1,
+    });
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+
+    await waitFor(() => expect(screen.getByText("2.0 MiB")).toBeInTheDocument());
+  });
+
+  it("discards a superseded load when a newer one resolves first", async () => {
+    let resolveStale: (v: api.DowngradeResponse) => void = () => {};
+    mockListDowngrades.mockImplementationOnce(
+      () => new Promise<api.DowngradeResponse>((r) => { resolveStale = r; })
+    );
+    mockListDowngrades.mockResolvedValue({ packages: [cacheVersion], total: 1 });
+
+    const { rerender } = render(
+      <DowngradeModal packageName="foo" currentVersion="1-1" isOpen={true} onClose={vi.fn()} />
+    );
+    // First load (package "foo") is still pending; a package change supersedes it.
+    rerender(
+      <DowngradeModal packageName="bash" currentVersion="5.2.015-1" isOpen={true} onClose={vi.fn()} />
+    );
+    await waitFor(() => expect(screen.getByText("5.1.016-1")).toBeInTheDocument());
+
+    await act(async () => {
+      resolveStale({ packages: [{ ...cacheVersion, version: "9.9.9-9" }], total: 1 });
+    });
+
+    expect(screen.queryByText("9.9.9-9")).not.toBeInTheDocument();
+    expect(screen.getByText("5.1.016-1")).toBeInTheDocument();
+  });
+
+  it("does not escalate to a backend search for the cache source", async () => {
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("5.1.016-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Filter versions"), {
+        target: { value: "9.9.9" },
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText("No matching versions")).toBeInTheDocument());
+    expect(mockListArchiveVersions).not.toHaveBeenCalled();
+  });
+
+  it("shows a no-match message when the filter excludes everything", async () => {
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("5.1.016-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Filter versions"), {
+        target: { value: "9.9.9" },
+      });
+    });
+
+    expect(screen.getByText("No matching versions")).toBeInTheDocument();
+    expect(screen.queryByText("5.1.016-1")).not.toBeInTheDocument();
+  });
+
+  it("shows no-match (not a failure) when the escalated search returns empty", async () => {
+    mockListArchiveVersions.mockImplementation((_name, query) =>
+      query
+        ? Promise.resolve({ packages: [], total: 0 })
+        : Promise.resolve({ packages: [archiveVersion], total: 1 })
+    );
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+    await waitFor(() => expect(screen.getByText("5.0.018-1")).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Filter versions"), {
+        target: { value: "3.2.57" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockListArchiveVersions).toHaveBeenLastCalledWith("bash", "3.2.57")
+    );
+    await waitFor(() => expect(screen.getByText("No matching versions")).toBeInTheDocument());
+    expect(screen.queryByText("Archive search failed")).not.toBeInTheDocument();
+  });
+
+  it("labels newer and not-installed versions with the right action", async () => {
+    mockListDowngrades.mockResolvedValue({
+      packages: [
+        { name: "bash", version: "5.3.0-1", filename: "bash-5.3.0-1-x86_64.pkg.tar.zst", size: 1024, installed_version: "5.2.015-1", is_older: false },
+        { name: "bash", version: "5.1.0-1", filename: "bash-5.1.0-1-x86_64.pkg.tar.zst", size: 1024, installed_version: null, is_older: false },
+      ],
+      total: 2,
+    });
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("5.3.0-1")).toBeInTheDocument());
+    expect(screen.getByText("newer")).toBeInTheDocument();
+    expect(screen.getByText("cached")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Upgrade/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Install/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/DowngradeModal.tsx
+++ b/src/components/DowngradeModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useBackdropClose } from "../hooks/useBackdropClose";
-import { LOG_CONTAINER_HEIGHT } from "../constants";
+import { useDebouncedValue } from "../hooks/useDebounce";
+import { LOG_CONTAINER_HEIGHT, SEARCH_DEBOUNCE_MS } from "../constants";
 import {
   Modal,
   ModalVariant,
@@ -10,6 +11,7 @@ import {
   Button,
   Spinner,
   Alert,
+  AlertActionLink,
   EmptyState,
   EmptyStateBody,
   Label,
@@ -18,18 +20,24 @@ import {
   ExpandableSection,
   Content,
   ContentVariants,
+  ToggleGroup,
+  ToggleGroupItem,
+  SearchInput,
 } from "@patternfly/react-core";
 import { Table, Thead, Tr, Th, Tbody, Td, ThProps } from "@patternfly/react-table";
-import { ArrowDownIcon, CheckCircleIcon } from "@patternfly/react-icons";
+import { ArrowDownIcon, ArrowUpIcon, DownloadIcon, CheckCircleIcon } from "@patternfly/react-icons";
 import {
   CachedVersion,
   listDowngrades,
   downgradePackage,
+  listArchiveVersions,
+  downgradeFromArchive,
   formatSize,
 } from "../api";
 import { sanitizeErrorMessage } from "../utils";
 
 type ModalState = "loading" | "select" | "confirm" | "downgrading" | "success" | "error";
+type DowngradeSource = "cache" | "archive";
 
 interface DowngradeModalProps {
   packageName: string;
@@ -46,6 +54,7 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
 }) => {
   useBackdropClose(isOpen, onClose);
   const [state, setState] = useState<ModalState>("loading");
+  const [source, setSource] = useState<DowngradeSource>("cache");
   const [versions, setVersions] = useState<CachedVersion[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<CachedVersion | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -53,18 +62,26 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(false);
   const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
   const [activeSortDirection, setActiveSortDirection] = useState<"asc" | "desc">("desc");
+  const [versionFilter, setVersionFilter] = useState("");
+  const [serverResults, setServerResults] = useState<{ query: string; packages: CachedVersion[]; failed: boolean } | null>(null);
   const cancelRef = useRef<(() => void) | null>(null);
   const logContainerRef = useRef<HTMLDivElement | null>(null);
+  const loadIdRef = useRef(0);
 
-  const loadVersions = useCallback(async () => {
+  const loadVersions = useCallback(async (src: DowngradeSource) => {
     if (!packageName) return;
+    const loadId = ++loadIdRef.current;
     setState("loading");
     setError(null);
     try {
-      const response = await listDowngrades(packageName);
+      const response = src === "archive"
+        ? await listArchiveVersions(packageName)
+        : await listDowngrades(packageName);
+      if (loadId !== loadIdRef.current) return;
       setVersions(response.packages);
       setState("select");
     } catch (ex) {
+      if (loadId !== loadIdRef.current) return;
       setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
     }
@@ -73,11 +90,23 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
   useEffect(() => {
     if (!isOpen) return;
     Promise.resolve().then(() => {
+      setSource("cache");
       setSelectedVersion(null);
       setLog("");
-      void loadVersions();
+      setVersionFilter("");
+      setServerResults(null);
+      void loadVersions("cache");
     });
   }, [isOpen, loadVersions]);
+
+  const handleSourceChange = (src: DowngradeSource) => {
+    if (src === source) return;
+    setSource(src);
+    setActiveSortIndex(null);
+    setVersionFilter("");
+    setServerResults(null);
+    void loadVersions(src);
+  };
 
   useEffect(() => {
     return () => {
@@ -104,22 +133,21 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
     setLog("");
     setIsDetailsExpanded(true);
 
-    const { cancel } = downgradePackage(
-      {
-        onData: (data) => setLog((prev) => prev + data),
-        onComplete: () => {
-          setState("success");
-          cancelRef.current = null;
-        },
-        onError: (err) => {
-          setState("error");
-          setError(err);
-          cancelRef.current = null;
-        },
+    const callbacks = {
+      onData: (data: string) => setLog((prev) => prev + data),
+      onComplete: () => {
+        setState("success");
+        cancelRef.current = null;
       },
-      packageName,
-      selectedVersion.version
-    );
+      onError: (err: string) => {
+        setState("error");
+        setError(err);
+        cancelRef.current = null;
+      },
+    };
+    const { cancel } = source === "archive"
+      ? downgradeFromArchive(callbacks, packageName, selectedVersion.filename)
+      : downgradePackage(callbacks, packageName, selectedVersion.version);
     cancelRef.current = cancel;
   };
 
@@ -174,12 +202,47 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
     });
   }, [versions, activeSortIndex, activeSortDirection]);
 
+  const filteredVersions = React.useMemo(() => {
+    const query = versionFilter.trim().toLowerCase();
+    if (!query) return sortedVersions;
+    return sortedVersions.filter((v) => v.version.toLowerCase().includes(query));
+  }, [sortedVersions, versionFilter]);
+
+  const debouncedFilter = useDebouncedValue(versionFilter, SEARCH_DEBOUNCE_MS);
+
+  // When the archive filter matches nothing in the fetched page, escalate to a
+  // backend search that filters the full archive history before the cap.
+  useEffect(() => {
+    const query = debouncedFilter.trim();
+    if (source !== "archive" || query === "") return;
+    if (serverResults?.query === query) return;
+    const clientHasMatch = versions.some((v) =>
+      v.version.toLowerCase().includes(query.toLowerCase())
+    );
+    if (clientHasMatch) return;
+    let cancelled = false;
+    listArchiveVersions(packageName, query)
+      .then((resp) => {
+        if (!cancelled) setServerResults({ query, packages: resp.packages, failed: false });
+      })
+      .catch(() => {
+        if (!cancelled) setServerResults({ query, packages: [], failed: true });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedFilter, source, versions, packageName, serverResults]);
+
   const renderContent = () => {
     switch (state) {
       case "loading":
         return (
-          <EmptyState headingLevel="h3" icon={Spinner} titleText="Loading cached versions">
-            <EmptyStateBody>Scanning package cache...</EmptyStateBody>
+          <EmptyState headingLevel="h3" icon={Spinner} titleText="Loading versions">
+            <EmptyStateBody>
+              {source === "archive"
+                ? "Fetching versions from archive.archlinux.org..."
+                : "Scanning package cache..."}
+            </EmptyStateBody>
           </EmptyState>
         );
 
@@ -190,22 +253,89 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
           </Alert>
         );
 
-      case "select":
-        if (versions.length === 0) {
-          return (
-            <EmptyState headingLevel="h3" titleText="No cached versions available">
-              <EmptyStateBody>
-                No other versions of {packageName} were found in the package cache.
-              </EmptyStateBody>
-            </EmptyState>
-          );
-        }
+      case "select": {
+        const trimmedFilter = versionFilter.trim();
+        const escalate =
+          source === "archive" && trimmedFilter !== "" && filteredVersions.length === 0;
+        const serverResolved =
+          escalate && serverResults !== null && serverResults.query === trimmedFilter;
+        const rows = escalate ? (serverResolved ? serverResults.packages : []) : filteredVersions;
+        const searchingServer = escalate && !serverResolved;
+        const serverFailed = serverResolved && serverResults.failed;
         return (
           <>
+            <ToggleGroup aria-label="Version source" className="pf-v6-u-mb-md">
+              <ToggleGroupItem
+                text="Cache"
+                isSelected={source === "cache"}
+                onChange={() => handleSourceChange("cache")}
+              />
+              <ToggleGroupItem
+                text="Archive"
+                isSelected={source === "archive"}
+                onChange={() => handleSourceChange("archive")}
+              />
+            </ToggleGroup>
+            {versions.length === 0 ? (
+              <EmptyState headingLevel="h3" titleText="No versions available">
+                <EmptyStateBody>
+                  {source === "archive"
+                    ? `No archived versions of ${packageName} were found for this architecture.`
+                    : `No other versions of ${packageName} were found in the package cache.`}
+                </EmptyStateBody>
+              </EmptyState>
+            ) : (
+              <>
             <Content component={ContentVariants.p} className="pf-v6-u-mb-md">
               Select a version to downgrade <strong>{packageName}</strong> from{" "}
               <Label isCompact variant="outline">{currentVersion}</Label>
             </Content>
+            {source === "archive" && (
+              <Content component={ContentVariants.small} className="pf-v6-u-mb-md">
+                Versions are fetched from archive.archlinux.org (sizes are approximate);
+                the package is downloaded and verified on install.
+              </Content>
+            )}
+            <SearchInput
+              placeholder="Filter by version"
+              value={versionFilter}
+              onChange={(_event, value) => setVersionFilter(value)}
+              onClear={() => setVersionFilter("")}
+              className="pf-v6-u-mb-md"
+              aria-label="Filter versions"
+            />
+            {searchingServer ? (
+              <EmptyState headingLevel="h4" icon={Spinner} titleText="Searching the archive">
+                <EmptyStateBody>
+                  Looking for <strong>{trimmedFilter}</strong> in the full archive history...
+                </EmptyStateBody>
+              </EmptyState>
+            ) : serverFailed ? (
+              <Alert
+                variant="warning"
+                title="Archive search failed"
+                isInline
+                actionLinks={
+                  <AlertActionLink onClick={() => setServerResults(null)}>
+                    Retry
+                  </AlertActionLink>
+                }
+              >
+                Could not reach archive.archlinux.org. Check your connection.
+              </Alert>
+            ) : rows.length === 0 ? (
+              <EmptyState headingLevel="h4" titleText="No matching versions">
+                <EmptyStateBody>
+                  No versions match <strong>{versionFilter}</strong>.
+                </EmptyStateBody>
+              </EmptyState>
+            ) : (
+            <>
+            {escalate && serverResolved && (
+              <Content component={ContentVariants.small} className="pf-v6-u-mb-md">
+                Showing archive search results for <strong>{trimmedFilter}</strong> from the full history.
+              </Content>
+            )}
             <Table aria-label="Available versions" variant="compact">
               <Thead>
                 <Tr>
@@ -216,7 +346,7 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
                 </Tr>
               </Thead>
               <Tbody>
-                {sortedVersions.map((v) => {
+                {rows.map((v) => {
                   const isCurrent = v.installed_version !== null && v.version === v.installed_version;
                   const isNotInstalled = v.installed_version === null;
                   return (
@@ -235,13 +365,13 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
                           <Label isCompact color="blue">newer</Label>
                         )}
                       </Td>
-                      <Td dataLabel="Size">{formatSize(v.size)}</Td>
+                      <Td dataLabel="Size">{v.size > 0 ? formatSize(v.size) : "-"}</Td>
                       <Td dataLabel="Action">
                         {!isCurrent && (
                           <Button
                             variant="secondary"
                             size="sm"
-                            icon={<ArrowDownIcon />}
+                            icon={isNotInstalled ? <DownloadIcon /> : v.is_older ? <ArrowDownIcon /> : <ArrowUpIcon />}
                             onClick={() => handleSelectVersion(v)}
                           >
                             {isNotInstalled ? "Install" : v.is_older ? "Downgrade" : "Upgrade"}
@@ -253,8 +383,13 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
                 })}
               </Tbody>
             </Table>
+            </>
+            )}
+              </>
+            )}
           </>
         );
+      }
 
       case "confirm": {
         const isDowngrade = selectedVersion?.is_older ?? true;
@@ -353,7 +488,7 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
       case "error":
         return (
           <>
-            <Button variant="primary" onClick={loadVersions}>
+            <Button variant="primary" onClick={() => loadVersions(source)}>
               Retry
             </Button>
             <Button variant="link" onClick={handleClose}>

--- a/src/test/contract.test.ts
+++ b/src/test/contract.test.ts
@@ -50,6 +50,8 @@ import type {
   NewsResponse,
   ScheduledRunEntry,
   ServicesStatus,
+  CachedVersion,
+  DowngradeResponse,
 } from "../api";
 import {
   listInstalled,
@@ -76,6 +78,7 @@ import {
   getSyncPackageInfo,
   listRepoMirrors,
   getServicesStatus,
+  listArchiveVersions,
 } from "../api";
 
 // JSON fixtures — vitest resolves these at build time via Vite's JSON import support
@@ -1194,5 +1197,46 @@ describe("getServicesStatus contract", () => {
     const noPackages = result.services.find((s) => s.affected_packages.length === 0);
     expect(noPackages).toBeDefined();
     expect(noPackages!.name).toBe("sshd.service");
+  });
+});
+
+
+describe("listArchiveVersions contract", () => {
+  const archiveResponse: DowngradeResponse = {
+    packages: [
+      {
+        name: "bash",
+        version: "5.1.016-1",
+        filename: "bash-5.1.016-1-x86_64.pkg.tar.zst",
+        size: 0,
+        installed_version: "5.2.015-1",
+        is_older: true,
+      },
+    ],
+    total: 1,
+  };
+
+  it("parses the archive listing into DowngradeResponse shape", async () => {
+    spawnReturns(archiveResponse);
+    const result = await listArchiveVersions("bash");
+
+    expect(Array.isArray(result.packages)).toBe(true);
+    expect(typeof result.total).toBe("number");
+
+    const entry: CachedVersion = result.packages[0];
+    expect(typeof entry.name).toBe("string");
+    expect(typeof entry.version).toBe("string");
+    expect(typeof entry.filename).toBe("string");
+    expect(typeof entry.size).toBe("number");
+    expect(typeof entry.is_older).toBe("boolean");
+  });
+
+  it("installed_version is null when the package is not installed", async () => {
+    spawnReturns({
+      packages: [{ ...archiveResponse.packages[0], installed_version: null }],
+      total: 1,
+    });
+    const result = await listArchiveVersions("bash");
+    expect(result.packages[0].installed_version).toBeNull();
   });
 });


### PR DESCRIPTION
The cache-only downgrade left users stuck when the target version was never cached. Add an Archive source so any historical version can be installed via pacman -U against archive.archlinux.org, which downloads, fetches the .sig, and verifies against the keyring.

Listing hrefs are percent-decoded so epoch packages (served as %3A) surface with a literal colon, filtered to the system architecture plus any and capped at 100 entries; the chosen filename is re-validated before the URL is built.

A version filter narrows the fetched list client-side; when nothing matches the cap, it escalates to a backend query that filters the full archive history before truncation. A failed escalated search reports the error with a retry action instead of a misleading empty result. Loads are guarded against stale responses when switching source.