### PR TITLE
feat(offline): classify network failures and degrade gracefully

### DIFF
--- a/backend/src/handlers/news.rs
+++ b/backend/src/handlers/news.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use std::fs::{File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs::OpenOptions;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -41,43 +41,8 @@ where
     f()
 }
 
-fn write_json_atomic<T: Serialize>(path: &Path, state: &T) -> Result<()> {
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| anyhow::anyhow!("Invalid state path: {:?}", path))?;
-
-    let content = serde_json::to_string_pretty(state).context("Failed to serialize state")?;
-
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or(Duration::ZERO)
-        .as_nanos();
-    let tid: String = format!("{:?}", std::thread::current().id())
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric())
-        .collect();
-    let base = file_name.to_string_lossy();
-    let tmp_path = path.with_file_name(format!("{base}.{nanos}.{tid}.tmp"));
-
-    let write_result = (|| -> Result<()> {
-        let mut tmp = File::create(&tmp_path)
-            .with_context(|| format!("Failed to create temp file {:?}", tmp_path))?;
-        tmp.write_all(content.as_bytes())
-            .with_context(|| format!("Failed to write temp file {:?}", tmp_path))?;
-        let _ = tmp.sync_all();
-        std::fs::rename(&tmp_path, path)
-            .with_context(|| format!("Failed to rename {:?} to {:?}", tmp_path, path))?;
-        Ok(())
-    })();
-
-    if write_result.is_err() {
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-    write_result
-}
-
 use crate::models::{NewsItem, NewsResponse};
-use crate::util::emit_json;
+use crate::util::{emit_json, write_json_atomic};
 
 const ARCH_NEWS_URL: &str = "https://archlinux.org/feeds/news/";
 const MAX_RSS_BYTES: u64 = 512 * 1024;
@@ -104,8 +69,51 @@ pub struct PacnewDismissal {
 
 pub fn fetch_news(days: u32) -> Result<()> {
     let days = days.min(365);
-    let items = fetch_news_items(days)?;
-    emit_json(&NewsResponse { items })
+    match fetch_news_items(days) {
+        Ok(items) => {
+            let response = NewsResponse {
+                items,
+                stale: false,
+            };
+            if let Ok(path) = news_cache_path() {
+                let _ = write_json_atomic(&path, &response);
+            }
+            emit_json(&response)
+        }
+        Err(e) => match news_cache_path().ok().and_then(read_news_cache) {
+            Some(items) => emit_json(&NewsResponse {
+                items: filter_items_within_days(items, days),
+                stale: true,
+            }),
+            None => Err(e),
+        },
+    }
+}
+
+/// Keep only items published within the last `days`. The cache is written from
+/// whatever lookback the last live fetch used, so an offline response is
+/// re-filtered to honour the caller's requested window.
+pub(crate) fn filter_items_within_days(items: Vec<NewsItem>, days: u32) -> Vec<NewsItem> {
+    let cutoff = Utc::now() - chrono::Duration::days(i64::from(days));
+    items
+        .into_iter()
+        .filter(|item| {
+            chrono::DateTime::parse_from_rfc3339(&item.published)
+                .map(|d| d.with_timezone(&Utc) >= cutoff)
+                .unwrap_or(true)
+        })
+        .collect()
+}
+
+fn news_cache_path() -> Result<PathBuf> {
+    let home = std::env::var("HOME").context("HOME environment variable is not set")?;
+    Ok(PathBuf::from(home).join(".config/cockpit-pacman/news-cache.json"))
+}
+
+fn read_news_cache(path: PathBuf) -> Option<Vec<NewsItem>> {
+    let content = std::fs::read_to_string(&path).ok()?;
+    let cached: NewsResponse = serde_json::from_str(&content).ok()?;
+    Some(cached.items)
 }
 
 fn fetch_news_items(days: u32) -> Result<Vec<NewsItem>> {

--- a/backend/src/handlers/security.rs
+++ b/backend/src/handlers/security.rs
@@ -1,22 +1,48 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use arch_security_client::SecurityClient;
 use arch_security_client::models::{AvgStatus, Severity};
 
 use crate::alpm::get_handle;
 use crate::models::{PackageSecurityAdvisory, SecurityInfoResponse, SecurityResponse};
-use crate::util::emit_json;
+use crate::util::{emit_json, write_json_atomic};
+
+fn security_cache_path() -> Result<PathBuf> {
+    let home = std::env::var("HOME").context("HOME environment variable is not set")?;
+    Ok(PathBuf::from(home).join(".config/cockpit-pacman/security-cache.json"))
+}
+
+fn read_security_cache(path: PathBuf) -> Option<Vec<PackageSecurityAdvisory>> {
+    let content = std::fs::read_to_string(&path).ok()?;
+    let cached: SecurityResponse = serde_json::from_str(&content).ok()?;
+    Some(cached.advisories)
+}
+
+fn write_security_cache(path: &Path, response: &SecurityResponse) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_json_atomic(path, response)
+}
 
 pub fn check_security() -> Result<()> {
     let client = SecurityClient::new(crate::util::detected_ip_family());
     let avgs = match client.fetch_vulnerable() {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("Warning: failed to fetch security data: {:#}", e);
-            return emit_json(&SecurityResponse {
-                advisories: Vec::new(),
-            });
+            // Serve cached advisories (marked stale) if we have them. With no
+            // cache, propagate the error: an empty list would be
+            // indistinguishable from "no known vulnerabilities", a false
+            // sense of safety. The frontend renders this as "unavailable".
+            if let Some(advisories) = security_cache_path().ok().and_then(read_security_cache) {
+                return emit_json(&SecurityResponse {
+                    advisories,
+                    stale: true,
+                });
+            }
+            return Err(e);
         }
     };
 
@@ -80,7 +106,14 @@ pub fn check_security() -> Result<()> {
         sev_b.cmp(&sev_a).then(a.package.cmp(&b.package))
     });
 
-    emit_json(&SecurityResponse { advisories })
+    let response = SecurityResponse {
+        advisories,
+        stale: false,
+    };
+    if let Ok(path) = security_cache_path() {
+        let _ = write_security_cache(&path, &response);
+    }
+    emit_json(&response)
 }
 
 pub fn security_info(name: &str) -> Result<()> {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -15,7 +15,8 @@ use cockpit_pacman_backend::handlers::{
     set_schedule_config, signoff_list, signoff_revoke, signoff_sign, sync_database,
     sync_package_info, test_mirrors,
 };
-use cockpit_pacman_backend::models::{MirrorEntry, RepoEntry};
+use cockpit_pacman_backend::models::{MirrorEntry, RepoEntry, StructuredError};
+use cockpit_pacman_backend::util::{classify_error, emit_json};
 use cockpit_pacman_backend::validation::{
     validate_archive_filename, validate_depth, validate_direction, validate_json_payload_size,
     validate_keep_versions, validate_mirror_timeout, validate_mirror_url, validate_package_name,
@@ -591,6 +592,19 @@ fn main() {
     };
 
     if let Err(e) = result {
+        // The structured envelope + exit 0 is for commands whose stdout the
+        // frontend parses. scheduled-run is invoked by a systemd oneshot unit
+        // with no such consumer, so it must exit non-zero on failure for the
+        // unit result to reflect reality.
+        let emit_envelope = args[1] != "scheduled-run";
+        if emit_envelope && let Some(code) = classify_error(&e) {
+            let _ = emit_json(&StructuredError {
+                code: code.to_string(),
+                message: format!("{}", e),
+                details: Some(format!("{:#}", e)),
+            });
+            std::process::exit(0);
+        }
         eprintln!("Error: {:#}", e);
         std::process::exit(1);
     }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -12,6 +12,9 @@ pub struct NewsItem {
 #[derive(Serialize, Deserialize)]
 pub struct NewsResponse {
     pub items: Vec<NewsItem>,
+    /// True when served from the on-disk cache because the live fetch failed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stale: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -197,6 +200,16 @@ pub struct PreflightState {
     pub removals: Vec<String>,
     pub providers: Vec<ProviderChoice>,
     pub import_keys: Vec<KeyInfo>,
+}
+
+/// Error envelope emitted to stdout for classified failures, consumed by the
+/// frontend as an authoritative error code (see runBackend in api.ts).
+#[derive(Serialize, Deserialize)]
+pub struct StructuredError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -595,6 +608,9 @@ pub struct PackageSecurityAdvisory {
 #[derive(Serialize, Deserialize)]
 pub struct SecurityResponse {
     pub advisories: Vec<PackageSecurityAdvisory>,
+    /// True when served from the on-disk cache because the live fetch failed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stale: bool,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -893,9 +893,45 @@ fn test_news_item_serialization() {
 
 #[test]
 fn test_news_response_serialization_empty() {
-    let response = NewsResponse { items: vec![] };
+    let response = NewsResponse {
+        items: vec![],
+        stale: false,
+    };
     let json = serde_json::to_string(&response).unwrap();
     assert_eq!(json, "{\"items\":[]}");
+
+    let stale = NewsResponse {
+        items: vec![],
+        stale: true,
+    };
+    let json = serde_json::to_string(&stale).unwrap();
+    assert_eq!(json, "{\"items\":[],\"stale\":true}");
+}
+
+#[test]
+fn test_filter_items_within_days_honours_lookback() {
+    use crate::handlers::news::filter_items_within_days;
+    let now = chrono::Utc::now();
+    let mk = |days_ago: i64| NewsItem {
+        title: "t".into(),
+        link: format!("https://archlinux.org/news/{days_ago}/"),
+        published: (now - chrono::Duration::days(days_ago)).to_rfc3339(),
+        summary: "s".into(),
+    };
+
+    let within_7 = filter_items_within_days(vec![mk(1), mk(10), mk(40)], 7);
+    assert_eq!(
+        within_7.len(),
+        1,
+        "only the 1-day-old item is within 7 days"
+    );
+
+    let within_30 = filter_items_within_days(vec![mk(1), mk(10), mk(40)], 30);
+    assert_eq!(
+        within_30.len(),
+        2,
+        "1- and 10-day-old items are within 30 days"
+    );
 }
 
 #[test]
@@ -915,6 +951,7 @@ fn test_news_response_serialization_with_items() {
                 summary: "Summary B".to_string(),
             },
         ],
+        stale: false,
     };
 
     let json = serde_json::to_string(&response).unwrap();
@@ -1559,4 +1596,70 @@ fn test_build_update_stats_map_counts_per_package() {
     let git = stats.get("git").expect("git stats missing");
     assert_eq!(git.update_count, 1);
     assert!(git.first_installed.is_some());
+}
+
+#[test]
+fn test_classify_message_buckets() {
+    use crate::util::classify_message;
+    assert_eq!(classify_message("operation timed out"), Some("timeout"));
+    assert_eq!(
+        classify_message("unable to lock database"),
+        Some("database_locked")
+    );
+    assert_eq!(
+        classify_message("failed retrieving file 'core.db' from mirror"),
+        Some("network_error")
+    );
+    assert_eq!(
+        classify_message("could not connect to server"),
+        Some("network_error")
+    );
+    assert_eq!(classify_message("some unrelated failure"), None);
+}
+
+#[test]
+fn test_classify_error_downcasts_ureq() {
+    use crate::util::classify_error;
+
+    let host: anyhow::Error =
+        anyhow::Error::new(ureq::Error::HostNotFound).context("fetching news feed");
+    assert_eq!(classify_error(&host), Some("network_error"));
+
+    let conn: anyhow::Error = anyhow::Error::new(ureq::Error::ConnectionFailed);
+    assert_eq!(classify_error(&conn), Some("network_error"));
+
+    let io_err = ureq::Error::Io(std::io::Error::from(std::io::ErrorKind::ConnectionRefused));
+    assert_eq!(
+        classify_error(&anyhow::Error::new(io_err)),
+        Some("network_error")
+    );
+
+    let not_found = anyhow::Error::new(ureq::Error::StatusCode(404));
+    assert_eq!(classify_error(&not_found), Some("not_found"));
+}
+
+#[test]
+fn test_classify_error_top_level_io() {
+    use crate::util::classify_error;
+
+    let timed_out =
+        anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::TimedOut)).context("syncing");
+    assert_eq!(classify_error(&timed_out), Some("timeout"));
+
+    let refused = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::ConnectionReset));
+    assert_eq!(classify_error(&refused), Some("network_error"));
+
+    // A non-network io kind with no matching keyword stays unclassified.
+    let other = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+    assert_eq!(classify_error(&other), None);
+}
+
+#[test]
+fn test_classify_error_falls_back_to_message() {
+    use crate::util::classify_error;
+    let plain = anyhow::anyhow!("connection refused while syncing");
+    assert_eq!(classify_error(&plain), Some("network_error"));
+
+    let unknown = anyhow::anyhow!("package conflict detected");
+    assert_eq!(classify_error(&unknown), None);
 }

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -1,8 +1,10 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Serialize;
 use std::cmp::Ordering;
+use std::fs::File;
 use std::io::{self, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::path::Path;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 use std::time::{Duration, Instant};
@@ -99,6 +101,110 @@ pub fn emit_event(event: &StreamEvent) {
 pub fn emit_json<T: Serialize>(response: &T) -> Result<()> {
     println!("{}", serde_json::to_string(response)?);
     Ok(())
+}
+
+/// Serialize `state` to `path` via a temp file and atomic rename, so a crash
+/// mid-write can't leave a partially-written file. Shared by state and cache
+/// writers across handlers.
+pub fn write_json_atomic<T: Serialize>(path: &Path, state: &T) -> Result<()> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("Invalid state path: {:?}", path))?;
+
+    let content = serde_json::to_string_pretty(state).context("Failed to serialize state")?;
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    let tid: String = format!("{:?}", std::thread::current().id())
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect();
+    let base = file_name.to_string_lossy();
+    let tmp_path = path.with_file_name(format!("{base}.{nanos}.{tid}.tmp"));
+
+    let write_result = (|| -> Result<()> {
+        let mut tmp = File::create(&tmp_path)
+            .with_context(|| format!("Failed to create temp file {:?}", tmp_path))?;
+        tmp.write_all(content.as_bytes())
+            .with_context(|| format!("Failed to write temp file {:?}", tmp_path))?;
+        let _ = tmp.sync_all();
+        std::fs::rename(&tmp_path, path)
+            .with_context(|| format!("Failed to rename {:?} to {:?}", tmp_path, path))?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+    write_result
+}
+
+/// Classify an error message into a frontend ErrorCode by keyword. Returns None
+/// when nothing matches confidently. Mirrors parseErrorCode in api.ts so both
+/// ends agree on the same buckets.
+pub fn classify_message(message: &str) -> Option<&'static str> {
+    let lower = message.to_lowercase();
+    if lower.contains("timed out") || lower.contains("timeout") {
+        return Some("timeout");
+    }
+    if lower.contains("unable to lock database") || lower.contains("database is locked") {
+        return Some("database_locked");
+    }
+    if lower.contains("network")
+        || lower.contains("connection")
+        || lower.contains("could not connect")
+        || lower.contains("connection refused")
+        || lower.contains("resolve host")
+        || lower.contains("host not found")
+        || lower.contains("name resolution")
+        || lower.contains("failed retrieving file")
+        || lower.contains("download library error")
+        || lower.contains("temporary failure in name resolution")
+    {
+        return Some("network_error");
+    }
+    None
+}
+
+/// Classify an anyhow error chain into a frontend ErrorCode. Inspects ureq and
+/// io errors in the chain first (authoritative), then falls back to keyword
+/// matching on the rendered message.
+pub fn classify_error(err: &anyhow::Error) -> Option<&'static str> {
+    for cause in err.chain() {
+        if let Some(ureq_err) = cause.downcast_ref::<ureq::Error>() {
+            return Some(classify_ureq(ureq_err));
+        }
+        if let Some(io_err) = cause.downcast_ref::<io::Error>()
+            && let Some(code) = classify_io(io_err.kind())
+        {
+            return Some(code);
+        }
+    }
+    classify_message(&format!("{:#}", err))
+}
+
+fn classify_ureq(err: &ureq::Error) -> &'static str {
+    use ureq::Error;
+    match err {
+        Error::Timeout(_) => "timeout",
+        Error::HostNotFound | Error::ConnectionFailed => "network_error",
+        Error::Io(io_err) => classify_io(io_err.kind()).unwrap_or("network_error"),
+        Error::StatusCode(404) => "not_found",
+        Error::Tls(_) => "network_error",
+        _ => "network_error",
+    }
+}
+
+fn classify_io(kind: io::ErrorKind) -> Option<&'static str> {
+    use io::ErrorKind::*;
+    match kind {
+        TimedOut => Some("timeout"),
+        ConnectionRefused | ConnectionReset | ConnectionAborted | NotConnected
+        | HostUnreachable | NetworkUnreachable | AddrNotAvailable => Some("network_error"),
+        _ => None,
+    }
 }
 
 pub fn sort_with_direction<T, F>(items: &mut [T], ascending: bool, cmp_fn: F)

--- a/backend/tests/contract_tests.rs
+++ b/backend/tests/contract_tests.rs
@@ -1517,6 +1517,7 @@ fn news_response_shape() {
             published: "2024-02-01T00:00:00+00:00".into(),
             summary: "Users of grub need to reinstall grub.".into(),
         }],
+        stale: false,
     };
     let v = to_json(&resp);
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -20,6 +20,8 @@ import {
   listArchiveVersions,
   downgradeFromArchive,
   StreamEvent,
+  BackendError,
+  isNetworkErrorCode,
 } from "./api";
 
 describe("formatSize", () => {
@@ -146,6 +148,47 @@ describe("listInstalled", () => {
 
     await expect(listInstalled()).rejects.toThrow("Permission denied");
   });
+
+  it("parses a structured error envelope into a coded BackendError", async () => {
+    mockSpawn.mockReturnValue(
+      createMockSpawnPromise(
+        JSON.stringify({
+          code: "network_error",
+          message: "could not resolve host",
+          details: "ureq: host not found",
+        })
+      )
+    );
+
+    await expect(listInstalled()).rejects.toMatchObject({
+      name: "BackendError",
+      code: "network_error",
+      message: "could not resolve host",
+    });
+  });
+
+  it("does not treat a success response with an unknown code value as an error", async () => {
+    mockSpawn.mockReturnValue(
+      createMockSpawnPromise(
+        JSON.stringify({ code: "ok", message: "done", packages: [], total: 0 })
+      )
+    );
+
+    await expect(listInstalled()).resolves.toMatchObject({ total: 0 });
+  });
+});
+
+describe("isNetworkErrorCode", () => {
+  it("treats network_error and timeout as connectivity failures", () => {
+    expect(isNetworkErrorCode("network_error")).toBe(true);
+    expect(isNetworkErrorCode("timeout")).toBe(true);
+  });
+
+  it("treats other codes as non-connectivity", () => {
+    expect(isNetworkErrorCode("database_locked")).toBe(false);
+    expect(isNetworkErrorCode("internal_error")).toBe(false);
+    expect(BackendError.name).toBe("BackendError");
+  });
 });
 
 describe("checkUpdates", () => {
@@ -271,7 +314,28 @@ describe("runUpgrade", () => {
     };
     mockProc._emit(JSON.stringify(completeEvent) + "\n");
 
-    expect(callbacks.onError).toHaveBeenCalledWith("Package conflict");
+    expect(callbacks.onError).toHaveBeenCalledWith("Package conflict", "internal_error");
+    expect(callbacks.onComplete).not.toHaveBeenCalled();
+  });
+
+  it("treats a structured error envelope on stdout as a terminal error with its code", () => {
+    const mockProc = createMockStreamingProcess();
+    mockSpawn.mockReturnValue(mockProc);
+
+    const callbacks = {
+      onComplete: vi.fn(),
+      onError: vi.fn(),
+    };
+
+    runUpgrade(callbacks);
+
+    // A handler that returns Err makes main.rs print this envelope (no `type`)
+    // instead of a complete event.
+    mockProc._emit(
+      JSON.stringify({ code: "network_error", message: "failed retrieving file" }) + "\n"
+    );
+
+    expect(callbacks.onError).toHaveBeenCalledWith("failed retrieving file", "network_error");
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });
 
@@ -396,7 +460,7 @@ describe("runUpgrade", () => {
 
     mockProc._fail({ message: "Permission denied" });
 
-    expect(callbacks.onError).toHaveBeenCalledWith("Permission denied");
+    expect(callbacks.onError).toHaveBeenCalledWith("Permission denied", "permission_denied");
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });
 
@@ -468,7 +532,8 @@ describe("runUpgrade", () => {
     mockProc._complete();
 
     expect(callbacks.onError).toHaveBeenCalledWith(
-      "Backend process ended without sending completion status"
+      "Backend process ended without sending completion status",
+      "internal_error"
     );
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });

--- a/src/api.ts
+++ b/src/api.ts
@@ -185,6 +185,22 @@ export type ErrorCode =
   | "permission_denied"
   | "internal_error";
 
+const KNOWN_ERROR_CODES: ReadonlySet<string> = new Set<ErrorCode>([
+  "timeout",
+  "database_locked",
+  "network_error",
+  "transaction_failed",
+  "validation_error",
+  "cancelled",
+  "not_found",
+  "permission_denied",
+  "internal_error",
+]);
+
+export function isNetworkErrorCode(code: ErrorCode): boolean {
+  return code === "network_error" || code === "timeout";
+}
+
 export interface StructuredError {
   code: ErrorCode;
   message: string;
@@ -216,7 +232,16 @@ function parseErrorCode(message: string): ErrorCode {
   if (lower.includes("unable to lock database") || lower.includes("database is locked")) {
     return "database_locked";
   }
-  if (lower.includes("connection") || lower.includes("network") || lower.includes("resolve host")) {
+  if (
+    lower.includes("connection") ||
+    lower.includes("network") ||
+    lower.includes("could not connect") ||
+    lower.includes("resolve host") ||
+    lower.includes("host not found") ||
+    lower.includes("name resolution") ||
+    lower.includes("failed retrieving file") ||
+    lower.includes("download library error")
+  ) {
     return "network_error";
   }
   if (lower.includes("transaction") || lower.includes("commit")) {
@@ -285,7 +310,13 @@ async function runBackend<T>(command: string, args: string[] = [], options?: { s
 
   try {
     const parsed = JSON.parse(output);
-    if (parsed && typeof parsed === "object" && "code" in parsed && "message" in parsed) {
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "message" in parsed &&
+      typeof (parsed as Record<string, unknown>).code === "string" &&
+      KNOWN_ERROR_CODES.has((parsed as Record<string, unknown>).code as string)
+    ) {
       throw BackendError.fromStructured(parsed as StructuredError);
     }
     return parsed as T;
@@ -351,6 +382,8 @@ export interface PackageSecurityAdvisory {
 
 export interface SecurityResponse {
   advisories: PackageSecurityAdvisory[];
+  /** True when served from the on-disk cache because the live fetch failed. */
+  stale?: boolean;
 }
 
 export interface SecurityInfoAdvisory {
@@ -471,8 +504,8 @@ export interface UpgradeCallbacks {
   onData?: (data: string) => void;
   /** Called when the operation completes successfully */
   onComplete: () => void;
-  /** Called when the operation fails with an error message */
-  onError: (error: string) => void;
+  /** Called when the operation fails with an error message and a classified code */
+  onError: (error: string, code?: ErrorCode) => void;
   /** Timeout in seconds for the operation (default: 300) */
   timeout?: number;
   /** Superuser mode for cockpit.spawn (default: "require") */
@@ -502,7 +535,7 @@ function runStreamingBackend(
   let buffer = "";
   let completionHandled = false;
 
-  const markComplete = (success: boolean, message?: string) => {
+  const markComplete = (success: boolean, message?: string, code?: ErrorCode) => {
     // Guard against duplicate callbacks from concurrent paths (stream, then, catch)
     // Set flag immediately before any other work to prevent re-entry
     if (completionHandled) return;
@@ -513,11 +546,28 @@ function runStreamingBackend(
       if (success) {
         callbacks.onComplete();
       } else {
-        callbacks.onError(message || "Operation failed");
+        const msg = message || "Operation failed";
+        callbacks.onError(msg, code ?? parseErrorCode(msg));
       }
     } catch (callbackError) {
       console.error("Callback error in markComplete:", callbackError);
     }
+  };
+
+  // A handler that returns Err (rather than emitting a complete event) makes
+  // main.rs print a structured error envelope on stdout. It has a known code
+  // and message but no StreamEvent `type`; treat it as a terminal error so the
+  // backend's classification is not lost as an unknown event.
+  const asErrorEnvelope = (parsed: Record<string, unknown>): { code: ErrorCode; message: string } | null => {
+    if (
+      !("type" in parsed) &&
+      typeof parsed.message === "string" &&
+      typeof parsed.code === "string" &&
+      KNOWN_ERROR_CODES.has(parsed.code)
+    ) {
+      return { code: parsed.code as ErrorCode, message: parsed.message };
+    }
+    return null;
   };
 
   const proc = cockpit.spawn(
@@ -536,6 +586,12 @@ function runStreamingBackend(
         const parsed = JSON.parse(line) as Record<string, unknown>;
 
         if (callbacks.onRawEvent?.(parsed)) continue;
+
+        const envelope = asErrorEnvelope(parsed);
+        if (envelope) {
+          markComplete(false, envelope.message, envelope.code);
+          continue;
+        }
 
         const event = parsed as unknown as StreamEvent;
         callbacks.onEvent?.(event);
@@ -568,7 +624,13 @@ function runStreamingBackend(
     // Process any remaining buffer
     if (buffer.trim()) {
       try {
-        const event = JSON.parse(buffer) as StreamEvent;
+        const parsed = JSON.parse(buffer) as Record<string, unknown>;
+        const envelope = asErrorEnvelope(parsed);
+        if (envelope) {
+          markComplete(false, envelope.message, envelope.code);
+          return;
+        }
+        const event = parsed as unknown as StreamEvent;
         if (event.type === "complete") {
           markComplete(event.success, event.message);
           return;
@@ -1064,7 +1126,7 @@ export interface MirrorTestCallbacks {
   onTestResult?: (result: MirrorTestResult, current: number, total: number) => void;
   onData?: (data: string) => void;
   onComplete: () => void;
-  onError: (error: string) => void;
+  onError: (error: string, code?: ErrorCode) => void;
   timeout?: number;
 }
 
@@ -1215,6 +1277,8 @@ export interface NewsItem {
 
 export interface NewsResponse {
   items: NewsItem[];
+  /** True when served from the on-disk cache because the live fetch failed. */
+  stale?: boolean;
 }
 
 export async function fetchNews(days: number = 30): Promise<NewsResponse> {

--- a/src/components/DowngradeModal.test.tsx
+++ b/src/components/DowngradeModal.test.tsx
@@ -67,6 +67,31 @@ describe("DowngradeModal", () => {
     expect(screen.getByText("5.1.016-1")).toBeInTheDocument();
   });
 
+  it("shows the offline network error state when the archive load fails with a network code", async () => {
+    mockListArchiveVersions.mockRejectedValue(
+      new api.BackendError("could not resolve host", "network_error")
+    );
+
+    render(
+      <DowngradeModal
+        packageName="bash"
+        currentVersion="5.2.015-1"
+        isOpen={true}
+        onClose={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockListDowngrades).toHaveBeenCalled());
+    await act(async () => {
+      fireEvent.click(screen.getByText("Archive"));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Can't reach Arch Linux services")).toBeInTheDocument()
+    );
+    expect(screen.getByRole("link", { name: "Arch Linux status page" })).toBeInTheDocument();
+  });
+
   it("switching to the Archive tab fetches archive versions", async () => {
     render(
       <DowngradeModal

--- a/src/components/DowngradeModal.tsx
+++ b/src/components/DowngradeModal.tsx
@@ -33,7 +33,11 @@ import {
   listArchiveVersions,
   downgradeFromArchive,
   formatSize,
+  BackendError,
 } from "../api";
+import type { ErrorCode } from "../api";
+import { isNetworkError } from "../offline";
+import { NetworkErrorState } from "./NetworkErrorState";
 import { sanitizeErrorMessage } from "../utils";
 
 type ModalState = "loading" | "select" | "confirm" | "downgrading" | "success" | "error";
@@ -58,6 +62,7 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
   const [versions, setVersions] = useState<CachedVersion[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<CachedVersion | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<ErrorCode | undefined>(undefined);
   const [log, setLog] = useState("");
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(false);
   const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
@@ -73,6 +78,7 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
     const loadId = ++loadIdRef.current;
     setState("loading");
     setError(null);
+    setErrorCode(undefined);
     try {
       const response = src === "archive"
         ? await listArchiveVersions(packageName)
@@ -84,6 +90,7 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
       if (loadId !== loadIdRef.current) return;
       setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
+      setErrorCode(ex instanceof BackendError ? ex.code : undefined);
     }
   }, [packageName]);
 
@@ -139,9 +146,10 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
         setState("success");
         cancelRef.current = null;
       },
-      onError: (err: string) => {
+      onError: (err: string, code?: ErrorCode) => {
         setState("error");
         setError(err);
+        setErrorCode(code);
         cancelRef.current = null;
       },
     };
@@ -247,6 +255,15 @@ export const DowngradeModal: React.FC<DowngradeModalProps> = ({
         );
 
       case "error":
+        if (isNetworkError(null, errorCode)) {
+          return (
+            <NetworkErrorState
+              resource={source === "archive" ? "archive versions" : "package versions"}
+              onRetry={() => loadVersions(source)}
+              headingLevel="h3"
+            />
+          );
+        }
         return (
           <Alert variant="danger" title="Error">
             {sanitizeErrorMessage(error)}

--- a/src/components/KeyringView.tsx
+++ b/src/components/KeyringView.tsx
@@ -40,7 +40,11 @@ import {
   getKeyringStatus,
   refreshKeyring,
   initKeyring,
+  BackendError,
 } from "../api";
+import type { ErrorCode } from "../api";
+import { isNetworkError } from "../offline";
+import { NetworkErrorState } from "./NetworkErrorState";
 import { TimeAgo } from "./TimeAgo";
 import { sanitizeErrorMessage } from "../utils";
 
@@ -50,6 +54,7 @@ export const KeyringView: React.FC = () => {
   const [state, setState] = useState<ViewState>("loading");
   const [keyringData, setKeyringData] = useState<KeyringStatusResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<ErrorCode | undefined>(undefined);
   const [log, setLog] = useState("");
   const [searchFilter, setSearchFilter] = useState("");
   const [trustFilter, setTrustFilter] = useState("all");
@@ -67,6 +72,7 @@ export const KeyringView: React.FC = () => {
   const loadKeyringStatus = useCallback(async () => {
     setState("loading");
     setError(null);
+    setErrorCode(undefined);
     try {
       const response = await getKeyringStatus();
       setKeyringData(response);
@@ -74,6 +80,7 @@ export const KeyringView: React.FC = () => {
     } catch (ex) {
       setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
+      setErrorCode(ex instanceof BackendError ? ex.code : undefined);
     }
   }, []);
 
@@ -89,6 +96,7 @@ export const KeyringView: React.FC = () => {
         if (cancelled) return;
         setState("error");
         setError(ex instanceof Error ? ex.message : String(ex));
+        setErrorCode(ex instanceof BackendError ? ex.code : undefined);
       });
     return () => { cancelled = true; };
   }, []);
@@ -115,9 +123,10 @@ export const KeyringView: React.FC = () => {
         cancelRef.current = null;
         loadKeyringStatus();
       },
-      onError: (err) => {
+      onError: (err, code) => {
         setState("error");
         setError(err);
+        setErrorCode(code);
         cancelRef.current = null;
       },
     });
@@ -137,9 +146,10 @@ export const KeyringView: React.FC = () => {
         cancelRef.current = null;
         loadKeyringStatus();
       },
-      onError: (err) => {
+      onError: (err, code) => {
         setState("error");
         setError(err);
+        setErrorCode(code);
         cancelRef.current = null;
       },
     });
@@ -262,14 +272,23 @@ export const KeyringView: React.FC = () => {
     return (
       <Card>
         <CardBody>
-          <Alert variant="danger" title="Error loading keyring status">
-            {sanitizeErrorMessage(error)}
-          </Alert>
-          <div className="pf-v6-u-mt-md">
-            <Button variant="primary" onClick={loadKeyringStatus}>
-              Retry
-            </Button>
-          </div>
+          {isNetworkError(null, errorCode) ? (
+            <NetworkErrorState
+              resource="the keyring"
+              onRetry={loadKeyringStatus}
+            />
+          ) : (
+            <>
+              <Alert variant="danger" title="Error loading keyring status">
+                {sanitizeErrorMessage(error)}
+              </Alert>
+              <div className="pf-v6-u-mt-md">
+                <Button variant="primary" onClick={loadKeyringStatus}>
+                  Retry
+                </Button>
+              </div>
+            </>
+          )}
         </CardBody>
       </Card>
     );

--- a/src/components/MirrorsView.tsx
+++ b/src/components/MirrorsView.tsx
@@ -76,9 +76,13 @@ import {
   deleteMirrorBackup,
   formatNumber,
   formatSize,
+  BackendError,
 } from "../api";
+import type { ErrorCode } from "../api";
+import { isNetworkError } from "../offline";
 import { TimeAgo } from "./TimeAgo";
 import { sanitizeErrorMessage } from "../utils";
+import { ARCH_STATUS_URL } from "../constants";
 
 type ViewState = "loading" | "ready" | "saving" | "success" | "error";
 
@@ -116,12 +120,25 @@ function getCachedStatus(): MirrorStatusResponse | null {
       return null;
     }
     if (Date.now() - parsed.timestamp > STATUS_CACHE_TTL_MS) {
-      window.localStorage.removeItem(STATUS_CACHE_KEY);
+      // Keep the entry so it can be served as a stale fallback when a live
+      // fetch fails (offline), but treat it as a miss for the fresh path.
       return null;
     }
     return parsed.data;
   } catch {
     window.localStorage.removeItem(STATUS_CACHE_KEY);
+    return null;
+  }
+}
+
+function getStaleCachedStatus(): MirrorStatusResponse | null {
+  try {
+    const cached = window.localStorage.getItem(STATUS_CACHE_KEY);
+    if (!cached) return null;
+    const parsed: unknown = JSON.parse(cached);
+    if (!isValidCachedStatus(parsed)) return null;
+    return parsed.data;
+  } catch {
     return null;
   }
 }
@@ -176,6 +193,7 @@ export const MirrorsView: React.FC = () => {
   const [mirrorData, setMirrorData] = useState<MirrorListResponse | null>(null);
   const [mirrors, setMirrors] = useState<MirrorWithStatus[]>([]);
   const [statusData, setStatusData] = useState<MirrorStatusResponse | null>(null);
+  const [statusStale, setStatusStale] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   useBackdropClose(confirmModalOpen, () => setConfirmModalOpen(false));
@@ -193,6 +211,7 @@ export const MirrorsView: React.FC = () => {
   const [refreshProtocol, setRefreshProtocol] = useState<RefreshMirrorsProtocol>("https");
   const [refreshSortBy, setRefreshSortBy] = useState<RefreshMirrorsSortBy>("score");
   const [refreshError, setRefreshError] = useState<string | null>(null);
+  const [refreshErrorCode, setRefreshErrorCode] = useState<ErrorCode | undefined>(undefined);
   useBackdropClose(refreshModalOpen, () => { if (!refreshLoading) setRefreshModalOpen(false); });
   const [backups, setBackups] = useState<MirrorBackup[]>([]);
   const [backupsExpanded, setBackupsExpanded] = useState(false);
@@ -267,9 +286,17 @@ export const MirrorsView: React.FC = () => {
       const response = await fetchMirrorStatus();
       setCachedStatus(response);
       setStatusData(response);
+      setStatusStale(false);
       setMirrors(prev => applyStatusToMirrors(prev, response));
     } catch (ex) {
-      setError(ex instanceof Error ? ex.message : String(ex));
+      const stale = getStaleCachedStatus();
+      if (stale) {
+        setStatusData(stale);
+        setStatusStale(true);
+        setMirrors(prev => applyStatusToMirrors(prev, stale));
+      } else {
+        setError(ex instanceof Error ? ex.message : String(ex));
+      }
     } finally {
       setIsFetchingStatus(false);
     }
@@ -445,6 +472,7 @@ export const MirrorsView: React.FC = () => {
     setRefreshLoading(true);
     setRefreshPreview(null);
     setRefreshError(null);
+    setRefreshErrorCode(undefined);
     try {
       const result = await refreshMirrors({
         count: refreshCount,
@@ -455,6 +483,7 @@ export const MirrorsView: React.FC = () => {
       setRefreshPreview(result);
     } catch (ex) {
       setRefreshError(ex instanceof Error ? ex.message : String(ex));
+      setRefreshErrorCode(ex instanceof BackendError ? ex.code : undefined);
     } finally {
       setRefreshLoading(false);
     }
@@ -990,6 +1019,7 @@ export const MirrorsView: React.FC = () => {
           <div className="pf-v6-u-mt-md" style={{ fontSize: "0.75rem", color: "var(--pf-t--global--text--color--subtle)" }}>
             Mirror status from archlinux.org: {statusData.last_check || "Unknown"}
             {getCacheAge() !== null && ` (cached ${formatCacheAge(getCacheAge()!)})`}
+            {statusStale && " - couldn't refresh, may be outdated"}
           </div>
         )}
       </CardBody>
@@ -1109,7 +1139,19 @@ export const MirrorsView: React.FC = () => {
           </div>
 
           {refreshError && (
-            <Alert variant="danger" isInline isPlain title={refreshError} className="pf-v6-u-mt-md" />
+            isNetworkError(null, refreshErrorCode) ? (
+              <Alert
+                variant="warning"
+                isInline
+                title="Can't reach the Arch mirror status service"
+                className="pf-v6-u-mt-md"
+              >
+                The host may be offline. Check its network connection or the{" "}
+                <a href={ARCH_STATUS_URL} target="_blank" rel="noopener noreferrer">Arch Linux status page</a>.
+              </Alert>
+            ) : (
+              <Alert variant="danger" isInline isPlain title={refreshError} className="pf-v6-u-mt-md" />
+            )
           )}
 
           {refreshPreview && refreshDiff && (

--- a/src/components/NetworkErrorState.test.tsx
+++ b/src/components/NetworkErrorState.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { NetworkErrorState } from "./NetworkErrorState";
+import { ARCH_STATUS_URL } from "../constants";
+
+describe("NetworkErrorState", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("names the resource and links the Arch status page", () => {
+    render(<NetworkErrorState resource="mirror status" />);
+    expect(
+      screen.getByText(/Couldn't load mirror status/)
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Arch Linux status page" });
+    expect(link).toHaveAttribute("href", ARCH_STATUS_URL);
+  });
+
+  it("wires retry and dismiss actions", () => {
+    const onRetry = vi.fn();
+    const onDismiss = vi.fn();
+    render(<NetworkErrorState onRetry={onRetry} onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the footer when no actions are given", () => {
+    render(<NetworkErrorState />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/NetworkErrorState.tsx
+++ b/src/components/NetworkErrorState.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+} from "@patternfly/react-core";
+import { DisconnectedIcon } from "@patternfly/react-icons";
+import { ARCH_STATUS_URL } from "../constants";
+
+interface NetworkErrorStateProps {
+  /** What couldn't be loaded, e.g. "updates", "mirror status". */
+  resource?: string;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+  headingLevel?: "h1" | "h2" | "h3" | "h4";
+}
+
+/**
+ * Unified empty state for connectivity failures reaching Arch Linux services.
+ * Network calls run on the managed host, so this means the host is offline or
+ * the upstream service is down, not the browser.
+ */
+export const NetworkErrorState: React.FunctionComponent<NetworkErrorStateProps> = ({
+  resource,
+  onRetry,
+  onDismiss,
+  headingLevel = "h2",
+}) => (
+  <EmptyState
+    headingLevel={headingLevel}
+    icon={DisconnectedIcon}
+    titleText="Can't reach Arch Linux services"
+    status="warning"
+  >
+    <EmptyStateBody>
+      {resource ? `Couldn't load ${resource}. ` : null}
+      Check the host&apos;s network connection or the{" "}
+      <a href={ARCH_STATUS_URL} target="_blank" rel="noopener noreferrer">
+        Arch Linux status page
+      </a>
+      .
+    </EmptyStateBody>
+    {(onRetry || onDismiss) && (
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          {onRetry && (
+            <Button variant="primary" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
+          {onDismiss && (
+            <Button variant="link" onClick={onDismiss}>
+              Dismiss
+            </Button>
+          )}
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    )}
+  </EmptyState>
+);

--- a/src/components/SignoffsView.tsx
+++ b/src/components/SignoffsView.tsx
@@ -45,16 +45,20 @@ import type {
   KeyringCredentials,
   SignoffGroupWithLocal,
   SignoffListResponse,
+  ErrorCode,
 } from "../api";
 import {
   getSignoffList,
   signoffPackage,
   revokeSignoff,
+  BackendError,
 } from "../api";
+import { isNetworkError } from "../offline";
 import { usePackageDetails } from "../hooks/usePackageDetails";
 import { usePagination } from "../hooks/usePagination";
 import { useSortableTable } from "../hooks/useSortableTable";
 import { PackageDetailsModal } from "./PackageDetailsModal";
+import { NetworkErrorState } from "./NetworkErrorState";
 import { sanitizeErrorMessage } from "../utils";
 import { PER_PAGE_OPTIONS } from "../constants";
 
@@ -77,6 +81,7 @@ export const SignoffsView: React.FC<SignoffsViewProps> = ({ credentials }) => {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<SignoffListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<ErrorCode | undefined>(undefined);
   const [search, setSearch] = useState("");
   const [filters, setFilters] = useState<Set<SignoffFilter>>(new Set(["installed"]));
   const [actionInProgress, setActionInProgress] = useState<string | null>(null);
@@ -95,18 +100,24 @@ export const SignoffsView: React.FC<SignoffsViewProps> = ({ credentials }) => {
     defaultDirection: "asc",
   });
 
+  const reportError = useCallback((err: unknown) => {
+    setError(sanitizeErrorMessage(err instanceof Error ? err.message : null));
+    setErrorCode(err instanceof BackendError ? err.code : undefined);
+  }, []);
+
   const fetchSignoffs = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setErrorCode(undefined);
     try {
       const result = await getSignoffList(credentials);
       setData(result);
     } catch (err) {
-      setError(sanitizeErrorMessage(err instanceof Error ? err.message : null));
+      reportError(err);
     } finally {
       setLoading(false);
     }
-  }, [credentials]);
+  }, [credentials, reportError]);
 
   useEffect(() => {
     let cancelled = false;
@@ -118,11 +129,11 @@ export const SignoffsView: React.FC<SignoffsViewProps> = ({ credentials }) => {
       })
       .catch((err) => {
         if (cancelled) return;
-        setError(sanitizeErrorMessage(err instanceof Error ? err.message : null));
+        reportError(err);
         setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [credentials]);
+  }, [credentials, reportError]);
 
   const handleSignoff = async (group: SignoffGroupWithLocal) => {
     setActionInProgress(signoffKey(group));
@@ -138,7 +149,7 @@ export const SignoffsView: React.FC<SignoffsViewProps> = ({ credentials }) => {
       }
       await fetchSignoffs();
     } catch (err) {
-      setError(sanitizeErrorMessage(err instanceof Error ? err.message : null));
+      reportError(err);
     } finally {
       setActionInProgress(null);
     }
@@ -158,7 +169,7 @@ export const SignoffsView: React.FC<SignoffsViewProps> = ({ credentials }) => {
       }
       await fetchSignoffs();
     } catch (err) {
-      setError(sanitizeErrorMessage(err instanceof Error ? err.message : null));
+      reportError(err);
     } finally {
       setActionInProgress(null);
     }
@@ -300,6 +311,16 @@ export const SignoffsView: React.FC<SignoffsViewProps> = ({ credentials }) => {
   };
 
   const hasFilters = filters.size > 0 || !!search || repoFilter !== "all";
+
+  if (!data && error && isNetworkError(null, errorCode)) {
+    return (
+      <Card>
+        <CardBody>
+          <NetworkErrorState resource="the signoff list" onRetry={fetchSignoffs} />
+        </CardBody>
+      </Card>
+    );
+  }
 
   return (
     <>

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../api", async () => {
     getCacheInfo: vi.fn(),
     getKeyringStatus: vi.fn(),
     fetchNews: vi.fn(),
+    checkSecurity: vi.fn(),
     getNewsReadState: vi.fn(),
     markNewsRead: vi.fn(),
     getServicesDismissal: vi.fn(),
@@ -58,6 +59,7 @@ const mockListOrphans = vi.mocked(api.listOrphans);
 const mockGetCacheInfo = vi.mocked(api.getCacheInfo);
 const mockGetKeyringStatus = vi.mocked(api.getKeyringStatus);
 const mockFetchNews = vi.mocked(api.fetchNews);
+const mockCheckSecurity = vi.mocked(api.checkSecurity);
 const mockCheckLock = vi.mocked(api.checkLock);
 const mockRemoveStaleLock = vi.mocked(api.removeStaleLock);
 const mockAddIgnoredPackage = vi.mocked(api.addIgnoredPackage);
@@ -100,6 +102,7 @@ describe("UpdatesView", () => {
       warnings: [],
     });
     mockFetchNews.mockResolvedValue(mockNewsResponseEmpty);
+    mockCheckSecurity.mockResolvedValue({ advisories: [] });
     mockCheckLock.mockResolvedValue({ locked: true, stale: true, lock_path: "/var/lib/pacman/db.lck" });
     mockRemoveStaleLock.mockResolvedValue({ removed: true });
     mockAddIgnoredPackage.mockResolvedValue({ success: true, package: "linux", message: "Package ignored" });
@@ -687,10 +690,10 @@ describe("UpdatesView", () => {
       render(<UpdatesView />);
 
       await waitFor(() => {
-        expect(screen.getByText(/failed to retrieve some files/)).toBeInTheDocument();
+        expect(screen.getByText("Can't reach Arch Linux services")).toBeInTheDocument();
       });
       expect(screen.getByText("Arch Linux status page")).toBeInTheDocument();
-      expect(screen.getByText(/Check your network connection/)).toBeInTheDocument();
+      expect(screen.getByText(/Check the host's network connection/)).toBeInTheDocument();
     });
 
     it("does not show status page link for non-network errors", async () => {
@@ -1161,7 +1164,40 @@ describe("UpdatesView", () => {
       });
       expect(screen.queryByText("Read more on archlinux.org")).not.toBeInTheDocument();
       expect(screen.getByText("Unable to fetch Arch Linux news")).toBeInTheDocument();
-      expect(screen.getByText(/Check your network connection/)).toBeInTheDocument();
+      expect(screen.getByText(/Check the host's network connection/)).toBeInTheDocument();
+    });
+
+    it("shows the cached-news banner when news is served stale", async () => {
+      mockCheckUpdates.mockResolvedValue({ updates: [], warnings: [] });
+      mockFetchNews.mockResolvedValue({ ...mockNewsResponse, stale: true });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText("Showing cached news")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Unable to fetch Arch Linux news")).not.toBeInTheDocument();
+    });
+
+    it("shows the cached-advisories banner when security data is served stale", async () => {
+      mockCheckUpdates.mockResolvedValue({ updates: [], warnings: [] });
+      mockCheckSecurity.mockResolvedValue({ advisories: [], stale: true });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText("Showing cached security advisories")).toBeInTheDocument();
+      });
+    });
+
+    it("shows the security-unavailable banner when the check fails with no cache", async () => {
+      mockCheckUpdates.mockResolvedValue({ updates: [], warnings: [] });
+      mockCheckSecurity.mockRejectedValue(new Error("could not resolve host"));
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText("Security status unavailable")).toBeInTheDocument();
+      });
+      // Must not read as a clean "0 vulnerabilities".
+      expect(screen.getByText(/not a clean bill of health/)).toBeInTheDocument();
     });
 
     it("dismissing news error alert removes it", async () => {

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -101,8 +101,10 @@ import {
   getSignoffList,
   checkLock,
   removeStaleLock,
+  BackendError,
 } from "../api";
-import type { KeyringCredentials } from "../api";
+import type { KeyringCredentials, ErrorCode } from "../api";
+import { NetworkErrorState } from "./NetworkErrorState";
 
 import { sanitizeUrl } from "../utils";
 import { TimeAgo } from "./TimeAgo";
@@ -169,12 +171,13 @@ const SystemOverviewCard: React.FC<{
   updates: UpdateInfo[];
   securityCount: number;
   securityLoading: boolean;
+  securityUnavailable: boolean;
   orphanCount: number | null;
   cacheSize: number | null;
   keyringStatus: KeyringStatusResponse | null;
   summaryLoading: boolean;
   pendingSignoffs?: number | null;
-}> = ({ updates, securityCount, securityLoading, orphanCount, cacheSize, keyringStatus, summaryLoading, pendingSignoffs }) => {
+}> = ({ updates, securityCount, securityLoading, securityUnavailable, orphanCount, cacheSize, keyringStatus, summaryLoading, pendingSignoffs }) => {
   const { onViewOrphans, onViewCache, onViewKeyring, onViewSignoffs } = useNavigation();
   return (
   <Card className="pf-v6-u-mb-md">
@@ -191,8 +194,8 @@ const SystemOverviewCard: React.FC<{
         <FlexItem>
           <StatBox
             label="Security"
-            value={securityLoading ? "-" : formatNumber(securityCount)}
-            color={securityCount > 0 ? "danger" : "default"}
+            value={securityLoading || securityUnavailable ? "-" : formatNumber(securityCount)}
+            color={!securityUnavailable && securityCount > 0 ? "danger" : "default"}
             isLoading={securityLoading}
           />
         </FlexItem>
@@ -336,6 +339,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [updates, setUpdates] = useState<UpdateInfo[]>([]);
   const [log, setLog] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<ErrorCode | undefined>(undefined);
   const [warnings, setWarnings] = useState<string[]>([]);
   const cancelRef = useRef<(() => void) | null>(null);
   const logContainerRef = useAutoScrollLog(log);
@@ -381,8 +385,11 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [summaryLoading, setSummaryLoading] = useState(true);
   const [securityMap, setSecurityMap] = useState<Map<string, PackageSecurityAdvisory[]>>(new Map());
   const [securityLoading, setSecurityLoading] = useState(true);
+  const [securityStale, setSecurityStale] = useState(false);
+  const [securityUnavailable, setSecurityUnavailable] = useState(false);
   const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
   const [newsError, setNewsError] = useState(false);
+  const [newsStale, setNewsStale] = useState(false);
   const [dismissedNews, setDismissedNews] = useState<Set<string>>(new Set<string>());
 
   useEffect(() => {
@@ -555,8 +562,12 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         map.set(advisory.package, existing);
       }
       setSecurityMap(map);
+      setSecurityStale(response.stale ?? false);
+      setSecurityUnavailable(false);
     } catch {
       setSecurityMap(new Map());
+      setSecurityStale(false);
+      setSecurityUnavailable(true);
     } finally {
       setSecurityLoading(false);
     }
@@ -565,6 +576,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const loadUpdates = useCallback(async () => {
     setState("checking");
     setError(null);
+    setErrorCode(undefined);
     setWarnings([]);
     publishPageStatus({
       type: null,
@@ -594,6 +606,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     } catch (ex) {
       setState("error");
       setError(ex instanceof Error ? ex.message : String(ex));
+      setErrorCode(ex instanceof BackendError ? ex.code : undefined);
       publishPageStatus({
         type: "error",
         title: "Failed to check for package updates",
@@ -608,9 +621,10 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         return newLog.length > MAX_LOG_SIZE_BYTES ? newLog.slice(-MAX_LOG_SIZE_BYTES) : newLog;
       }),
       onComplete: () => loadUpdates(),
-      onError: (err) => {
+      onError: (err, code) => {
         setState("error");
         setError(err);
+        setErrorCode(code);
       },
     });
     return () => cancel();
@@ -670,13 +684,13 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
 
   useEffect(() => {
     let cancelled = false;
-    type NewsResult = { ok: true; items: NewsItem[] } | { ok: false };
+    type NewsResult = { ok: true; items: NewsItem[]; stale: boolean } | { ok: false };
     Promise.all([
       listOrphans().catch(() => null),
       getCacheInfo().catch(() => null),
       getKeyringStatus().catch(() => null),
       fetchNews(NEWS_LOOKBACK_DAYS)
-        .then((r): NewsResult => ({ ok: true, items: r.items }))
+        .then((r): NewsResult => ({ ok: true, items: r.items, stale: r.stale ?? false }))
         .catch((): NewsResult => ({ ok: false })),
     ]).then(([orphans, cache, keyring, newsResult]) => {
       if (cancelled) return;
@@ -685,9 +699,11 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       setKeyringStatus(keyring);
       if (newsResult.ok) {
         setNewsError(false);
+        setNewsStale(newsResult.stale);
         setNewsItems(newsResult.items);
       } else {
         setNewsError(true);
+        setNewsStale(false);
         setNewsItems([]);
       }
       setSummaryLoading(false);
@@ -762,9 +778,10 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         return newLog.length > MAX_LOG_SIZE_BYTES ? newLog.slice(-MAX_LOG_SIZE_BYTES) : newLog;
       }),
       onComplete: () => loadUpdates(),
-      onError: (err) => {
+      onError: (err, code) => {
         setState("error");
         setError(err);
+        setErrorCode(code);
       },
     });
     cancelRef.current = cancel;
@@ -774,6 +791,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     // Run preflight check first
     setPreflightLoading(true);
     setError(null);
+    setErrorCode(undefined);
     try {
       const preflight = await preflightUpgrade(ignoredPackages);
       setPreflightData(preflight);
@@ -809,6 +827,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     } catch (ex) {
       setPreflightLoading(false);
       setError(ex instanceof Error ? ex.message : String(ex));
+      setErrorCode(ex instanceof BackendError ? ex.code : undefined);
       setState("error");
     }
   };
@@ -883,9 +902,10 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           }
         });
       },
-      onError: (err) => {
+      onError: (err, code) => {
         setState("error");
         setError(err);
+        setErrorCode(code);
         cancelRef.current = null;
       },
     }, ignoredPackages);
@@ -943,9 +963,40 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       actionClose={<AlertActionCloseButton onClose={() => setNewsError(false)} />}
       className="pf-v6-u-mb-md"
     >
-      Could not retrieve the latest news from archlinux.org. Check your network connection or visit the{" "}
+      Could not retrieve the latest news from archlinux.org. Check the host&apos;s network connection or visit the{" "}
       <a href={ARCH_STATUS_URL} target="_blank" rel="noopener noreferrer">Arch Linux status page</a>
       {" "}for service updates.
+    </Alert>
+  ) : newsStale ? (
+    <Alert
+      variant="info"
+      isInline
+      title="Showing cached news"
+      className="pf-v6-u-mb-md"
+    >
+      Couldn&apos;t reach archlinux.org. The news below is from the last successful fetch.
+    </Alert>
+  ) : null;
+
+  const securityStaleAlert = securityStale ? (
+    <Alert
+      variant="warning"
+      isInline
+      title="Showing cached security advisories"
+      className="pf-v6-u-mb-md"
+    >
+      Couldn&apos;t reach the Arch security tracker. Advisories below are from the last successful
+      fetch and may not reflect recently disclosed or fixed issues.
+    </Alert>
+  ) : securityUnavailable ? (
+    <Alert
+      variant="warning"
+      isInline
+      title="Security status unavailable"
+      className="pf-v6-u-mb-md"
+    >
+      Couldn&apos;t reach the Arch security tracker and no cached data is available, so known
+      vulnerabilities can&apos;t be checked. This is not a clean bill of health.
     </Alert>
   ) : null;
 
@@ -1132,35 +1183,42 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
 
   if (state === "error") {
     const isLockError = error ? /unable to lock database|failed to initialize transaction/i.test(error) : false;
-    const isNetworkError = error ? /failed to retrieve|unable to connect|could not resolve|timed\s+out|timeout|dns|connection refused/i.test(error) : false;
+    // Only a genuine connectivity failure shows the offline state here. A bare
+    // operation timeout (the sync/upgrade exceeded its budget) is not an
+    // unreachable-host condition, so it keeps its specific message.
+    const networkError = !isLockError && (
+      errorCode === "network_error" ||
+      (error ? /failed to retrieve|unable to connect|could not resolve|dns|connection refused/i.test(error) : false)
+    );
     return (
       <Card>
         <CardBody>
-          <EmptyState
-            headingLevel="h2"
-            icon={ExclamationCircleIcon}
-            titleText={isLockError ? "Database is locked" : "Error checking for updates"}
-            status={isLockError ? "warning" : "danger"}
-          >
-            <EmptyStateBody>
-              {isLockError
-                ? <LockErrorBody onRetry={loadUpdates} />
-                : error}
-              {isNetworkError && !isLockError && (
-                <Content component={ContentVariants.p} className="pf-v6-u-mt-sm">
-                  Check your network connection or visit the{" "}
-                  <a href={ARCH_STATUS_URL} target="_blank" rel="noopener noreferrer">Arch Linux status page</a>
-                  {" "}for service updates.
-                </Content>
-              )}
-            </EmptyStateBody>
-            <EmptyStateFooter>
-              <EmptyStateActions>
-                <Button variant="primary" onClick={loadUpdates}>Retry</Button>
-                <Button variant="link" onClick={() => setState("uptodate")}>Dismiss</Button>
-              </EmptyStateActions>
-            </EmptyStateFooter>
-          </EmptyState>
+          {networkError ? (
+            <NetworkErrorState
+              resource="updates"
+              onRetry={loadUpdates}
+              onDismiss={() => setState("uptodate")}
+            />
+          ) : (
+            <EmptyState
+              headingLevel="h2"
+              icon={ExclamationCircleIcon}
+              titleText={isLockError ? "Database is locked" : "Error checking for updates"}
+              status={isLockError ? "warning" : "danger"}
+            >
+              <EmptyStateBody>
+                {isLockError
+                  ? <LockErrorBody onRetry={loadUpdates} />
+                  : error}
+              </EmptyStateBody>
+              <EmptyStateFooter>
+                <EmptyStateActions>
+                  <Button variant="primary" onClick={loadUpdates}>Retry</Button>
+                  <Button variant="link" onClick={() => setState("uptodate")}>Dismiss</Button>
+                </EmptyStateActions>
+              </EmptyStateFooter>
+            </EmptyState>
+          )}
         </CardBody>
       </Card>
     );
@@ -1330,6 +1388,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           </Alert>
         )}
         {newsErrorAlert}
+        {securityStaleAlert}
         {newsAlerts}
         {keyringStatus && !keyringStatus.master_key_initialized && (
           <Alert variant="warning" title="Keyring not initialized" isInline className="pf-v6-u-mb-md">
@@ -1344,6 +1403,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           updates={updates}
           securityCount={securityUpdateCount}
           securityLoading={securityLoading}
+          securityUnavailable={securityUnavailable}
           orphanCount={orphanCount}
           cacheSize={cacheSize}
           keyringStatus={keyringStatus}
@@ -1421,6 +1481,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         </Alert>
       )}
       {newsErrorAlert}
+      {securityStaleAlert}
       {newsAlerts}
       {keyringStatus && !keyringStatus.master_key_initialized && (
         <Alert variant="warning" title="Keyring not initialized" isInline className="pf-v6-u-mb-md">
@@ -1440,6 +1501,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         updates={updates}
         securityCount={securityUpdateCount}
         securityLoading={securityLoading}
+        securityUnavailable={securityUnavailable}
         orphanCount={orphanCount}
         cacheSize={cacheSize}
         keyringStatus={keyringStatus}

--- a/src/offline.test.ts
+++ b/src/offline.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isNetworkError } from "./offline";
+import { BackendError } from "./api";
+
+describe("isNetworkError", () => {
+  it("treats network_error and timeout codes as connectivity failures", () => {
+    expect(isNetworkError(null, "network_error")).toBe(true);
+    expect(isNetworkError(null, "timeout")).toBe(true);
+  });
+
+  it("treats other codes as non-connectivity", () => {
+    expect(isNetworkError(null, "database_locked")).toBe(false);
+    expect(isNetworkError(null, "internal_error")).toBe(false);
+    expect(isNetworkError(null)).toBe(false);
+  });
+
+  it("unwraps a BackendError's code when no explicit code is given", () => {
+    expect(isNetworkError(new BackendError("could not resolve host", "network_error"))).toBe(true);
+    expect(isNetworkError(new BackendError("locked", "database_locked"))).toBe(false);
+  });
+
+  it("returns false for a plain Error", () => {
+    expect(isNetworkError(new Error("network_error"))).toBe(false);
+  });
+});

--- a/src/offline.ts
+++ b/src/offline.ts
@@ -1,0 +1,19 @@
+import { BackendError, ErrorCode, isNetworkErrorCode } from "./api";
+
+/**
+ * True when an error (or an explicit streaming error code) represents a loss of
+ * connectivity to Arch services rather than an application-level failure.
+ *
+ * Network calls originate from the managed host via the backend binary, not the
+ * browser, so navigator.onLine is meaningless here: connectivity is inferred
+ * from real backend call results.
+ */
+export function isNetworkError(err: unknown, code?: ErrorCode): boolean {
+  if (code) {
+    return isNetworkErrorCode(code);
+  }
+  if (err instanceof BackendError) {
+    return isNetworkErrorCode(err.code);
+  }
+  return false;
+}


### PR DESCRIPTION
The backend leaked network failures as raw anyhow text, leaving the frontend to guess the cause with brittle regex matching. Offline behaviour was inconsistent across features (hung spinners, silent placeholders, ad-hoc error states) with no connectivity signal.

Classify failures at the source: the backend downcasts ureq/io errors and emits a structured error code that the frontend consumes authoritatively (scheduled-run keeps exit 1 so its systemd unit result stays truthful). Surface connectivity loss through one shared NetworkErrorState across the network-facing views, inferred from real call results rather than navigator.onLine (calls run on the managed host, not the browser)
Serve last-known news, security advisories, and mirror status with a stale marker when the upstream is unreachable, and render a security fetch with no cache as an explicit "unavailable" state.