### PR TITLE
feat(backend): propagate checked keyring path on validation fail

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "pacman-key"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89bbede6aad4792406ebeff29ce48fcd4ed3ed0fa66ca93bb948debd09e7bfc"
+checksum = "0d32cc14a804d210d38d0d12b0f89d6ad44a0e9dab685d855b0ee64cd17db5af"
 dependencies = [
  "chrono",
  "thiserror",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1"
 ctrlc = { version = "3", features = ["termination"] }
 chrono = "0.4"
 libc = "0.2"
-pacman-key = "0.2.0"
+pacman-key = "0.3.0"
 pacman-log = "0.2.1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 rss = "2"

--- a/backend/src/handlers/keyring.rs
+++ b/backend/src/handlers/keyring.rs
@@ -23,24 +23,32 @@ pub fn keyring_status() -> Result<()> {
                 false
             }
             Ok(InitializationStatus::PathIsSymlink) => {
-                warnings.push(
-                    "Security warning: keyring path is a symlink. This may be unsafe.".to_string(),
-                );
+                warnings.push(format!(
+                    "Security warning: keyring path ({}) is a symlink. This may be unsafe.",
+                    keyring.get_homedir()
+                ));
                 false
             }
             Ok(InitializationStatus::IncorrectPermissions { actual }) => {
                 warnings.push(format!(
-                    "Keyring directory has incorrect permissions: {:o} (expected 700)",
+                    "Keyring directory ({}) has incorrect permissions: {:o} (expected 700)",
+                    keyring.get_homedir(),
                     actual
                 ));
                 true
             }
             Ok(InitializationStatus::NoKeyringFiles) => {
-                warnings.push("Keyring directory exists but contains no keys.".to_string());
+                warnings.push(format!(
+                    "Keyring directory ({}) exists but contains no keys.",
+                    keyring.get_homedir(),
+                ));
                 false
             }
             Ok(InitializationStatus::NoTrustDb) => {
-                warnings.push("Keyring missing trust database.".to_string());
+                warnings.push(format!(
+                    "Keyring directory ({}) missing trust database.",
+                    keyring.get_homedir(),
+                ));
                 false
             }
             Ok(status) => {


### PR DESCRIPTION
dep: pfeifferj/pacman-key.rs/pull/6