### PR TITLE
feat(schedule): make a scheduled run report what happened

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ install:
 	install -m 755 $(BACKEND_BIN) $(DESTDIR)$(PREFIX)/libexec/cockpit-pacman/
 	install -m 644 systemd/cockpit-pacman-scheduled.service $(DESTDIR)$(PREFIX)/lib/systemd/system/
 	install -m 644 systemd/cockpit-pacman-scheduled.timer $(DESTDIR)$(PREFIX)/lib/systemd/system/
+	install -m 644 'systemd/cockpit-pacman-failure@.service' $(DESTDIR)$(PREFIX)/lib/systemd/system/
 
 devel-install: build
 	mkdir -p ~/.local/share/cockpit

--- a/backend/src/alpm/callbacks.rs
+++ b/backend/src/alpm/callbacks.rs
@@ -13,9 +13,32 @@ pub fn interrupt_if_cancelled() {
     }
 }
 
-pub fn setup_log_cb(handle: &mut Alpm) {
-    handle.set_log_cb((), |level: LogLevel, msg: &str, _: &mut ()| {
+/// A scheduled run has no client reading stdout, so events go to the journal,
+/// where alpm's per-chunk tracing would blow past journald's rate limit and
+/// drop the run's own diagnostics.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Verbosity {
+    Streaming,
+    Journal,
+}
+
+impl Verbosity {
+    fn wants_level(self, level: LogLevel) -> bool {
+        match self {
+            Verbosity::Streaming => true,
+            Verbosity::Journal => !matches!(log_level_to_string(level), "debug" | "function"),
+        }
+    }
+}
+
+pub fn setup_log_cb(handle: &mut Alpm, verbosity: Verbosity) {
+    handle.set_log_cb((), move |level: LogLevel, msg: &str, _: &mut ()| {
+        // The re-arm has to happen for every callback, including the ones whose
+        // message is dropped: it is the only cancel path during downloads.
         interrupt_if_cancelled();
+        if !verbosity.wants_level(level) {
+            return;
+        }
         emit_event(&StreamEvent::Log {
             level: log_level_to_string(level).to_string(),
             message: msg.trim().to_string(),
@@ -23,20 +46,27 @@ pub fn setup_log_cb(handle: &mut Alpm) {
     });
 }
 
-pub fn setup_dl_cb(handle: &mut Alpm) {
-    handle.set_dl_cb((), |filename: &str, event: AnyDownloadEvent, _: &mut ()| {
-        interrupt_if_cancelled();
-        let (event_str, downloaded, total) = match event.event() {
-            DownloadEvent::Init(_) => ("init", None, None),
-            DownloadEvent::Progress(p) => ("progress", Some(p.downloaded), Some(p.total)),
-            DownloadEvent::Retry(_) => ("retry", None, None),
-            DownloadEvent::Completed(c) => ("completed", None, Some(c.total)),
-        };
-        emit_event(&StreamEvent::Download {
-            filename: filename.to_string(),
-            event: event_str.to_string(),
-            downloaded,
-            total,
-        });
-    });
+pub fn setup_dl_cb(handle: &mut Alpm, verbosity: Verbosity) {
+    handle.set_dl_cb(
+        (),
+        move |filename: &str, event: AnyDownloadEvent, _: &mut ()| {
+            interrupt_if_cancelled();
+            let (event_str, downloaded, total) = match event.event() {
+                DownloadEvent::Init(_) => ("init", None, None),
+                DownloadEvent::Progress(p) => ("progress", Some(p.downloaded), Some(p.total)),
+                DownloadEvent::Retry(_) => ("retry", None, None),
+                DownloadEvent::Completed(c) => ("completed", None, Some(c.total)),
+            };
+            // Progress is per chunk; init, retry and completed are one line per file.
+            if verbosity == Verbosity::Journal && event_str == "progress" {
+                return;
+            }
+            emit_event(&StreamEvent::Download {
+                filename: filename.to_string(),
+                event: event_str.to_string(),
+                downloaded,
+                total,
+            });
+        },
+    );
 }

--- a/backend/src/alpm/mod.rs
+++ b/backend/src/alpm/mod.rs
@@ -2,7 +2,7 @@ mod callbacks;
 mod sysupgrade;
 mod transaction;
 
-pub use callbacks::{interrupt_if_cancelled, setup_dl_cb, setup_log_cb};
+pub use callbacks::{Verbosity, interrupt_if_cancelled, setup_dl_cb, setup_log_cb};
 pub use sysupgrade::{InterventionFlags, SysupgradeOutcome, run_sysupgrade};
 pub use transaction::{TransactionGuard, try_interrupt};
 

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use ts_rs::TS;
 
 const CONFIG_PATH: &str = "/etc/cockpit-pacman/config.json";
@@ -15,15 +15,35 @@ const TIMER_DROP_IN_PATH: &str =
     "/etc/systemd/system/cockpit-pacman-scheduled.timer.d/schedule.conf";
 const SYSTEMCTL_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Run `systemctl <args>` bounded by SYSTEMCTL_TIMEOUT so a wedged systemd can't
-/// hang the request.
-fn run_systemctl(args: &[&str]) -> Result<std::process::Output> {
+const SYSTEMD_APPLY_BUDGET: Duration = Duration::from_secs(20);
+
+struct Budget {
+    deadline: Instant,
+}
+
+impl Budget {
+    fn new(total: Duration) -> Self {
+        Budget {
+            deadline: Instant::now() + total,
+        }
+    }
+
+    /// Floored rather than zero, so the call that undoes a half-applied change
+    /// still gets to start.
+    fn remaining(&self) -> Duration {
+        self.deadline
+            .saturating_duration_since(Instant::now())
+            .max(Duration::from_secs(1))
+    }
+}
+
+fn run_systemctl(args: &[&str], timeout: Duration) -> Result<std::process::Output> {
     let mut cmd = Command::new("systemctl");
     cmd.args(args);
     // Pin the locale so stderr stays parseable (timer_absent matches it) and
     // errors read the same regardless of the host language.
     cmd.env("LC_ALL", "C");
-    crate::util::output_with_timeout(cmd, SYSTEMCTL_TIMEOUT)
+    crate::util::output_with_timeout(cmd, timeout)
 }
 
 /// Whether a systemctl failure just means the timer isn't installed/loaded,
@@ -34,6 +54,17 @@ fn timer_absent(stderr: &str) -> bool {
         || s.contains("not loaded")
         || s.contains("no such file")
         || s.contains("not found")
+}
+
+fn restore_drop_in(path: &Path, previous: Option<&[u8]>) {
+    match previous {
+        Some(bytes) => {
+            let _ = crate::util::write_bytes_atomic_with_mode(path, bytes, 0o644);
+        }
+        None => {
+            let _ = fs::remove_file(path);
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, TS)]
@@ -203,6 +234,7 @@ impl AppConfig {
 
     pub fn apply_schedule_to_systemd(&self) -> Result<()> {
         let schedule = &self.schedule;
+        let budget = Budget::new(SYSTEMD_APPLY_BUDGET);
 
         if schedule.enabled {
             // Create drop-in directory with proper permissions
@@ -214,6 +246,10 @@ impl AppConfig {
             })?;
             fs::set_permissions(TIMER_DROP_IN_DIR, fs::Permissions::from_mode(0o755))
                 .with_context(|| format!("Failed to set permissions on {}", TIMER_DROP_IN_DIR))?;
+
+            // Unlinking reverts the timer to the unit's own OnCalendar while
+            // config.json still names the old schedule.
+            let previous = fs::read(TIMER_DROP_IN_PATH).ok();
 
             // Write drop-in file with restrictive permissions
             let drop_in_content =
@@ -235,11 +271,11 @@ impl AppConfig {
             // Undo the drop-in we just wrote when a systemctl step fails (spawn
             // error, timeout, or non-zero exit).
             let rollback = || {
-                let _ = fs::remove_file(TIMER_DROP_IN_PATH);
-                let _ = run_systemctl(&["daemon-reload"]);
+                restore_drop_in(Path::new(TIMER_DROP_IN_PATH), previous.as_deref());
+                let _ = run_systemctl(&["daemon-reload"], budget.remaining());
             };
 
-            match run_systemctl(&["daemon-reload"]) {
+            match run_systemctl(&["daemon-reload"], budget.remaining()) {
                 Ok(o) if o.status.success() => {}
                 Ok(o) => {
                     rollback();
@@ -254,7 +290,10 @@ impl AppConfig {
                 }
             }
 
-            match run_systemctl(&["enable", "--now", "cockpit-pacman-scheduled.timer"]) {
+            match run_systemctl(
+                &["enable", "--now", "cockpit-pacman-scheduled.timer"],
+                budget.remaining(),
+            ) {
                 Ok(o) if o.status.success() => {}
                 Ok(o) => {
                     rollback();
@@ -272,7 +311,10 @@ impl AppConfig {
             // A not-enabled or absent timer is fine to "disable", but a real
             // systemctl failure must surface or the timer keeps firing while
             // config claims it's off.
-            match run_systemctl(&["disable", "--now", "cockpit-pacman-scheduled.timer"]) {
+            match run_systemctl(
+                &["disable", "--now", "cockpit-pacman-scheduled.timer"],
+                budget.remaining(),
+            ) {
                 Ok(o) if o.status.success() => {}
                 Ok(o) => {
                     let stderr = String::from_utf8_lossy(&o.stderr);
@@ -285,7 +327,7 @@ impl AppConfig {
 
             let _ = fs::remove_file(TIMER_DROP_IN_PATH);
 
-            match run_systemctl(&["daemon-reload"]) {
+            match run_systemctl(&["daemon-reload"], budget.remaining()) {
                 Ok(o) if o.status.success() => {}
                 Ok(o) => {
                     bail!(
@@ -338,11 +380,13 @@ pub struct ScheduleConfigResponse {
     pub max_packages: usize,
     pub timer_active: bool,
     pub timer_next_run: Option<String>,
+    /// What the timer is actually set to, as systemd normalises it.
+    pub timer_calendar: Option<String>,
 }
 
 impl ScheduleConfigResponse {
     pub fn from_config(config: &ScheduleConfig) -> Self {
-        let (timer_active, timer_next_run) = get_timer_status();
+        let (timer_active, timer_next_run, timer_calendar) = get_timer_status();
         Self {
             enabled: config.enabled,
             mode: config.mode.to_string(),
@@ -350,22 +394,34 @@ impl ScheduleConfigResponse {
             max_packages: config.max_packages,
             timer_active,
             timer_next_run,
+            timer_calendar,
         }
     }
 }
 
-fn get_timer_status() -> (bool, Option<String>) {
-    let output = run_systemctl(&[
-        "show",
-        "cockpit-pacman-scheduled.timer",
-        "--property=ActiveState,NextElapseUSecRealtime",
-    ]);
+/// Pull `OnCalendar=X` out of systemd's `{ OnCalendar=X ; next_elapse=Y }`.
+fn parse_timer_calendar(value: &str) -> Option<String> {
+    let rest = value.split("OnCalendar=").nth(1)?;
+    let spec = rest.split(';').next()?.trim();
+    (!spec.is_empty()).then(|| spec.to_string())
+}
+
+fn get_timer_status() -> (bool, Option<String>, Option<String>) {
+    let output = run_systemctl(
+        &[
+            "show",
+            "cockpit-pacman-scheduled.timer",
+            "--property=ActiveState,NextElapseUSecRealtime,TimersCalendar",
+        ],
+        SYSTEMCTL_TIMEOUT,
+    );
 
     match output {
         Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let mut active = false;
             let mut next_run = None;
+            let mut calendar = None;
 
             for line in stdout.lines() {
                 if let Some(state) = line.strip_prefix("ActiveState=") {
@@ -377,11 +433,14 @@ fn get_timer_status() -> (bool, Option<String>) {
                 {
                     next_run = Some(next.to_string());
                 }
+                if let Some(value) = line.strip_prefix("TimersCalendar=") {
+                    calendar = parse_timer_calendar(value);
+                }
             }
 
-            (active, next_run)
+            (active, next_run, calendar)
         }
-        Err(_) => (false, None),
+        Err(_) => (false, None, None),
     }
 }
 
@@ -394,7 +453,86 @@ pub struct ScheduleSetResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::timer_absent;
+    use super::{
+        Budget, SYSTEMD_APPLY_BUDGET, parse_timer_calendar, restore_drop_in, timer_absent,
+    };
+    use std::time::Duration;
+
+    // Must stay under BACKEND_TIMEOUT_MS in src/constants.ts, or the client
+    // aborts the spawn mid-apply.
+    #[test]
+    fn apply_budget_stays_under_the_client_abort() {
+        assert!(
+            SYSTEMD_APPLY_BUDGET < Duration::from_secs(30),
+            "the whole apply must finish before the frontend gives up on it"
+        );
+    }
+
+    #[test]
+    fn budget_shrinks_as_it_is_spent() {
+        let budget = Budget::new(Duration::from_secs(20));
+        let first = budget.remaining();
+        std::thread::sleep(Duration::from_millis(20));
+
+        assert!(
+            budget.remaining() < first,
+            "each call must draw from the same budget, not restart it"
+        );
+    }
+
+    #[test]
+    fn a_spent_budget_still_lets_a_call_start() {
+        let budget = Budget::new(Duration::from_millis(0));
+
+        assert_eq!(budget.remaining(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn timer_calendar_is_read_out_of_systemd_normalised_form() {
+        assert_eq!(
+            parse_timer_calendar("{ OnCalendar=*-*-* 00:00:00 ; next_elapse=Sat 2026-08-22 }")
+                .unwrap(),
+            "*-*-* 00:00:00"
+        );
+        assert_eq!(
+            parse_timer_calendar("{ OnCalendar=Mon *-*-* 00:00:00 ; next_elapse=n/a }").unwrap(),
+            "Mon *-*-* 00:00:00"
+        );
+        assert_eq!(parse_timer_calendar(""), None);
+        assert_eq!(parse_timer_calendar("{ }"), None);
+    }
+
+    use std::path::PathBuf;
+
+    fn temp(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("cpac-dropin-{}-{}", tag, std::process::id()))
+    }
+
+    #[test]
+    fn a_failed_apply_puts_the_previous_schedule_back() {
+        let path = temp("restore");
+        let before = b"[Timer]\nOnCalendar=\nOnCalendar=daily\n";
+        std::fs::write(&path, before).unwrap();
+
+        let previous = std::fs::read(&path).ok();
+        std::fs::write(&path, b"[Timer]\nOnCalendar=\nOnCalendar=garbage\n").unwrap();
+        restore_drop_in(&path, previous.as_deref());
+
+        assert_eq!(std::fs::read(&path).unwrap(), before);
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn a_failed_apply_removes_a_drop_in_that_was_not_there_before() {
+        let path = temp("absent");
+        let _ = std::fs::remove_file(&path);
+
+        let previous = std::fs::read(&path).ok();
+        std::fs::write(&path, b"[Timer]\nOnCalendar=\nOnCalendar=garbage\n").unwrap();
+        restore_drop_in(&path, previous.as_deref());
+
+        assert!(!path.exists(), "a drop-in we created must not survive");
+    }
 
     #[test]
     fn timer_absent_matches_missing_unit_but_not_real_failures() {

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -4,8 +4,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::alpm::{
-    SysupgradeOutcome, TransactionGuard, get_handle, interrupt_if_cancelled, progress_to_string,
-    run_sysupgrade, setup_dl_cb, setup_log_cb, try_interrupt,
+    SysupgradeOutcome, TransactionGuard, Verbosity, get_handle, interrupt_if_cancelled,
+    progress_to_string, run_sysupgrade, setup_dl_cb, setup_log_cb, try_interrupt,
 };
 use crate::check_cancel_early;
 use crate::db::invalidate_repo_map_cache;
@@ -406,8 +406,8 @@ pub fn sync_database(force: bool, timeout_secs: Option<u64>) -> Result<()> {
     check_cancel_early!(&timeout);
 
     let mut handle = get_handle()?;
-    setup_log_cb(&mut handle);
-    setup_dl_cb(&mut handle);
+    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_dl_cb(&mut handle, Verbosity::Streaming);
 
     match handle.syncdbs_mut().update(force) {
         Ok(_) => {
@@ -455,8 +455,8 @@ pub fn run_upgrade(ignore_pkgs: &[String], timeout_secs: Option<u64>) -> Result<
         })?;
     }
 
-    setup_log_cb(&mut handle);
-    setup_dl_cb(&mut handle);
+    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_dl_cb(&mut handle, Verbosity::Streaming);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Upgrade);
     setup_question_cb(&mut handle, true);
@@ -548,7 +548,7 @@ pub fn remove_orphans(timeout_secs: Option<u64>) -> Result<()> {
         return Ok(());
     }
 
-    setup_log_cb(&mut handle);
+    setup_log_cb(&mut handle, Verbosity::Streaming);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Remove);
 
@@ -595,8 +595,8 @@ pub fn install_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
     let mut handle = get_handle()?;
 
-    setup_log_cb(&mut handle);
-    setup_dl_cb(&mut handle);
+    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_dl_cb(&mut handle, Verbosity::Streaming);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Install);
     setup_question_cb(&mut handle, false);
@@ -660,7 +660,7 @@ pub fn remove_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
     let mut handle = get_handle()?;
 
-    setup_log_cb(&mut handle);
+    setup_log_cb(&mut handle, Verbosity::Streaming);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Remove);
 

--- a/backend/src/handlers/scheduled.rs
+++ b/backend/src/handlers/scheduled.rs
@@ -1,25 +1,30 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
 
 use crate::alpm::{
-    InterventionFlags, SysupgradeOutcome, find_available_updates, get_handle, run_sysupgrade,
-    setup_dl_cb, setup_log_cb,
+    InterventionFlags, SysupgradeOutcome, Verbosity, find_available_updates, get_handle,
+    run_sysupgrade, setup_dl_cb, setup_log_cb,
 };
 use crate::config::{AppConfig, ScheduleConfigResponse, ScheduleMode, ScheduleSetResponse};
 use crate::inhibit::ShutdownInhibitor;
 use crate::models::{ScheduledRunEntry, ScheduledRunsResponse};
 use crate::util::{
     CheckResult, TimeoutGuard, check_cancel, emit_json, setup_signal_handler, with_file_lock,
+    with_file_read_lock, write_bytes_atomic_with_mode,
 };
 use crate::validation::{validate_max_packages, validate_schedule};
 
 const LOG_DIR: &str = "/var/log/cockpit-pacman";
 const LOG_PATH: &str = "/var/log/cockpit-pacman/scheduled.jsonl";
 const LOG_LOCK_PATH: &str = "/var/log/cockpit-pacman/.scheduled.jsonl.lock";
+// 0644 like pacman.log: the plugin reads the run history from an unprivileged
+// session. Creation, rotation and the mode reset below must agree.
+const LOG_DIR_MODE: u32 = 0o755;
+const LOG_FILE_MODE: u32 = 0o644;
 const MAX_LOG_SIZE_BYTES: u64 = 1024 * 1024; // 1MB max log size
 const MAX_LOG_ENTRIES: usize = 1000;
 const SCHEDULED_TIMEOUT_SECS: u64 = 1800;
@@ -35,6 +40,12 @@ struct LogEntry {
     packages_upgraded: usize,
     error: Option<String>,
     details: Vec<String>,
+    // Absent on records written before it existed, and on ExecStopPost records,
+    // which never saw the run start.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    duration_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    removed_stale_lock: bool,
 }
 
 impl LogEntry {
@@ -58,7 +69,21 @@ impl LogEntry {
             packages_upgraded,
             error,
             details,
+            duration_secs: None,
+            removed_stale_lock: false,
         }
+    }
+
+    fn took(mut self, started: std::time::Instant) -> Self {
+        self.duration_secs = Some(started.elapsed().as_secs());
+        self
+    }
+
+    /// Every entry a run can write carries this, not just the successful one:
+    /// the evidence is about the previous run either way.
+    fn after_stale_lock(mut self, removed: bool) -> Self {
+        self.removed_stale_lock = removed;
+        self
     }
 }
 
@@ -80,9 +105,17 @@ fn get_timestamp() -> String {
         .to_string()
 }
 
-fn log_run(entry: &LogEntry) -> Result<()> {
+/// A failed write must not change what the process returns; returning unit
+/// stops a caller reintroducing the coupling with `?`.
+fn log_run(entry: &LogEntry) {
+    if let Err(e) = write_run(entry) {
+        eprintln!("failed to write scheduled run record: {:#}", e);
+    }
+}
+
+fn write_run(entry: &LogEntry) -> Result<()> {
     fs::create_dir_all(LOG_DIR).context("Failed to create log directory")?;
-    fs::set_permissions(LOG_DIR, fs::Permissions::from_mode(0o750))
+    fs::set_permissions(LOG_DIR, fs::Permissions::from_mode(LOG_DIR_MODE))
         .context("Failed to set log directory permissions")?;
 
     // Hold the lock across the rotate-check and the append: otherwise a
@@ -94,9 +127,14 @@ fn log_run(entry: &LogEntry) -> Result<()> {
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
-            .mode(0o640)
+            .mode(LOG_FILE_MODE)
             .open(LOG_PATH)
             .context("Failed to open log file")?;
+
+        // .mode() applies only when the file is created, so an existing log
+        // keeps whatever mode it already has otherwise.
+        file.set_permissions(fs::Permissions::from_mode(LOG_FILE_MODE))
+            .context("Failed to set log file permissions")?;
 
         let json = serde_json::to_string(entry)?;
         writeln!(file, "{}", json)?;
@@ -105,55 +143,46 @@ fn log_run(entry: &LogEntry) -> Result<()> {
 }
 
 fn rotate_if_needed() -> Result<()> {
-    let path = Path::new(LOG_PATH);
+    rotate_if_needed_at(Path::new(LOG_PATH))
+}
 
+/// Trim without parsing: a rotation run by an older build must not drop fields
+/// a newer one wrote.
+fn rotate_if_needed_at(path: &Path) -> Result<()> {
     let size = match fs::metadata(path) {
         Ok(m) => m.len(),
         Err(_) => return Ok(()),
     };
 
-    let mut entries: Vec<LogEntry> = Vec::new();
-    {
-        let file = fs::File::open(path).context("Failed to open log for rotation")?;
-        let reader = BufReader::new(file);
-        for line in reader.lines().map_while(Result::ok) {
-            if let Ok(entry) = serde_json::from_str::<LogEntry>(&line) {
-                entries.push(entry);
-            }
-        }
-    }
+    // Bytes, not text: a torn multibyte write must not make rotation fail, which
+    // would take every later append down with it.
+    let content = fs::read(path).context("Failed to read log for rotation")?;
+    let lines: Vec<&[u8]> = content
+        .split(|b| *b == b'\n')
+        .filter(|l| !l.is_empty())
+        .collect();
 
-    if size <= MAX_LOG_SIZE_BYTES && entries.len() <= MAX_LOG_ENTRIES {
+    if size <= MAX_LOG_SIZE_BYTES && lines.len() <= MAX_LOG_ENTRIES {
         return Ok(());
     }
 
-    let keep_count = MAX_LOG_ENTRIES / 2;
-    if entries.len() > keep_count {
-        entries = entries.split_off(entries.len() - keep_count);
+    // `details` is unbounded, so one run can carry the file past the byte cap
+    // with too few lines to trip the line cap.
+    let mut kept = &lines[lines.len().saturating_sub(MAX_LOG_ENTRIES / 2)..];
+    let budget = MAX_LOG_SIZE_BYTES as usize / 2;
+    let mut bytes: usize = kept.iter().map(|l| l.len() + 1).sum();
+    while kept.len() > 1 && bytes > budget {
+        bytes -= kept[0].len() + 1;
+        kept = &kept[1..];
     }
 
-    let parent = path.parent().unwrap_or(Path::new(LOG_DIR));
-    let tmp = parent.join(format!(".scheduled.jsonl.tmp.{}", std::process::id()));
-    {
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o640)
-            .open(&tmp)
-            .context("Failed to open temp log for writing")?;
-        for entry in &entries {
-            writeln!(file, "{}", serde_json::to_string(entry)?)?;
-        }
-        file.sync_all()?;
+    let mut out = Vec::with_capacity(size as usize);
+    for line in kept {
+        out.extend_from_slice(line);
+        out.push(b'\n');
     }
 
-    if let Err(e) = fs::rename(&tmp, path) {
-        let _ = fs::remove_file(&tmp);
-        return Err(e).context("Failed to replace rotated log");
-    }
-
-    Ok(())
+    write_bytes_atomic_with_mode(path, &out, LOG_FILE_MODE).context("Failed to replace rotated log")
 }
 
 use std::os::unix::fs::PermissionsExt;
@@ -178,7 +207,18 @@ pub fn set_schedule_config(
         validate_max_packages(mp)?;
     }
 
-    let config = AppConfig::update(|config| {
+    // Latch a TERM instead of dying on it: the default disposition would tear
+    // this down between the systemd apply and the config write.
+    setup_signal_handler();
+
+    // The apply reaches systemd before the config write, so a failed write
+    // leaves the timer and config.json disagreeing.
+    let mut previous = None;
+    let mut applied = None;
+
+    let result = AppConfig::update(|config| {
+        previous = Some(config.clone());
+
         if let Some(e) = enabled {
             config.schedule.enabled = e;
         }
@@ -195,8 +235,14 @@ pub fn set_schedule_config(
         // and config.json is left untouched, never claiming a timer state that
         // didn't take.
         config.apply_schedule_to_systemd()?;
+        applied = Some(config.schedule.schedule.clone());
         Ok(config.clone())
-    })?;
+    });
+
+    let config = match result {
+        Ok(config) => config,
+        Err(e) => return Err(undo_apply(previous, applied, e)),
+    };
 
     let response = ScheduleSetResponse {
         success: true,
@@ -209,28 +255,66 @@ pub fn set_schedule_config(
     emit_json(&response)
 }
 
-pub fn get_scheduled_runs(offset: usize, limit: usize) -> Result<()> {
-    let mut runs = Vec::new();
+/// `applied` is None when the failure came before the apply, leaving nothing to
+/// undo. A failed undo is the one case where the timer and config.json really
+/// do disagree.
+fn undo_apply(
+    previous: Option<AppConfig>,
+    applied: Option<String>,
+    cause: anyhow::Error,
+) -> anyhow::Error {
+    let (Some(applied), Some(previous)) = (applied, previous) else {
+        return cause;
+    };
 
-    if Path::new(LOG_PATH).exists() {
-        let file = fs::File::open(LOG_PATH).context("Failed to open log file")?;
-        let reader = BufReader::new(file);
-
-        for line in reader.lines().map_while(Result::ok) {
-            if let Ok(entry) = serde_json::from_str::<LogEntry>(&line) {
-                runs.push(ScheduledRunEntry {
-                    timestamp: entry.timestamp,
-                    mode: entry.mode,
-                    success: entry.success,
-                    status: derive_status(&entry.status, entry.success),
-                    packages_checked: entry.packages_checked,
-                    packages_upgraded: entry.packages_upgraded,
-                    error: entry.error,
-                    details: entry.details,
-                });
-            }
-        }
+    match previous.apply_schedule_to_systemd() {
+        Ok(()) => cause.context("Failed to save the schedule, so the timer was left unchanged"),
+        Err(undo) => cause.context(format!(
+            "Failed to save the schedule and could not put the timer back: it is now on '{}' \
+             while the saved configuration still says '{}' ({:#})",
+            applied, previous.schedule.schedule, undo
+        )),
     }
+}
+
+/// Entries oldest-first, skipping any line that does not parse. A single
+/// unreadable line must not hide the entries after it.
+fn parse_run_entries(content: &[u8]) -> Vec<ScheduledRunEntry> {
+    content
+        .split(|b| *b == b'\n')
+        .filter_map(|line| serde_json::from_slice::<LogEntry>(line).ok())
+        .map(|entry| ScheduledRunEntry {
+            timestamp: entry.timestamp,
+            mode: entry.mode,
+            success: entry.success,
+            status: derive_status(&entry.status, entry.success),
+            packages_checked: entry.packages_checked,
+            packages_upgraded: entry.packages_upgraded,
+            error: entry.error,
+            details: entry.details,
+            duration_secs: entry.duration_secs,
+            removed_stale_lock: entry.removed_stale_lock,
+        })
+        .collect()
+}
+
+pub fn get_scheduled_runs(offset: usize, limit: usize) -> Result<()> {
+    // A shared lock, not the writer's: this runs unprivileged whenever the
+    // session has not escalated, and taking the write lock would fail on the
+    // root-owned directory before the log itself was ever opened.
+    //
+    // Only a missing log means "no runs yet". Path::exists() cannot say that:
+    // it is equally false for a reader denied the directory.
+    let content = with_file_read_lock(Path::new(LOG_LOCK_PATH), || match fs::read(LOG_PATH) {
+        Ok(content) => Ok(Some(content)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).context("Failed to read run history"),
+    })?;
+
+    let mut runs = content
+        .as_deref()
+        .map(parse_run_entries)
+        .unwrap_or_default();
 
     runs.reverse();
     let total = runs.len();
@@ -271,14 +355,37 @@ pub fn record_interrupted() -> Result<()> {
         Some(format!("Run killed by systemd (result={result})")),
         Vec::new(),
     );
-    log_run(&entry)
+    log_run(&entry);
+    Ok(())
 }
 
 pub fn scheduled_run() -> Result<()> {
     let config = AppConfig::load()?;
 
+    let mut details = Vec::new();
+    let timestamp = get_timestamp();
+    let started = std::time::Instant::now();
+
+    // Reaching here at all means the timer fired, so config.json and the timer
+    // disagree. Recording the skip is the only way to tell that apart from a
+    // timer that never fired, which looks identical: no entry either way.
     if !config.schedule.enabled {
         eprintln!("Scheduled upgrades not enabled, exiting");
+        let entry = LogEntry::new(
+            timestamp,
+            config.schedule.mode,
+            "skipped",
+            0,
+            0,
+            None,
+            vec![
+                "Skipped: the timer fired while scheduled upgrades are disabled. The timer is \
+                 active but the saved configuration is not; setting the schedule again will put \
+                 them back in step."
+                    .to_string(),
+            ],
+        );
+        log_run(&entry.took(started));
         return Ok(());
     }
 
@@ -290,21 +397,19 @@ pub fn scheduled_run() -> Result<()> {
     let mode = config.schedule.mode;
     let max_packages = config.schedule.max_packages;
 
-    let mut details = Vec::new();
-    let timestamp = get_timestamp();
-
     eprintln!("[{}] Starting scheduled {} run", timestamp, mode);
 
     // A locked db is logged as a skipped run; the unit intentionally has no
     // ConditionPathExists so the skip is recorded rather than silent. A lock
     // with no holder process is reaped first, so a crashed pacman doesn't make
     // every future run skip.
-    match crate::handlers::lock::try_remove_stale_lock() {
+    let reaped_lock = match crate::handlers::lock::try_remove_stale_lock() {
         Ok(true) => {
             eprintln!("removed stale pacman database lock, continuing");
             details.push("Removed stale database lock (no holder process)".to_string());
+            true
         }
-        Ok(false) => {}
+        Ok(false) => false,
         Err(reason) => {
             eprintln!(
                 "pacman database is locked ({}), skipping scheduled run",
@@ -319,10 +424,10 @@ pub fn scheduled_run() -> Result<()> {
                 None,
                 vec![format!("Skipped: pacman database locked ({})", reason)],
             );
-            log_run(&entry)?;
+            log_run(&entry.took(started));
             return Ok(());
         }
-    }
+    };
 
     // Check for cancellation before starting
     if let CheckResult::Cancelled | CheckResult::TimedOut(_) = check_cancel(&_timeout_guard) {
@@ -335,7 +440,7 @@ pub fn scheduled_run() -> Result<()> {
             Some("Operation cancelled or timed out before starting".to_string()),
             details,
         );
-        log_run(&entry)?;
+        log_run(&entry.took(started).after_stale_lock(reaped_lock));
         anyhow::bail!("Operation cancelled or timed out");
     }
 
@@ -345,8 +450,8 @@ pub fn scheduled_run() -> Result<()> {
         handle.add_ignorepkg(pkg_name.as_str())?;
     }
 
-    setup_log_cb(&mut handle);
-    setup_dl_cb(&mut handle);
+    setup_log_cb(&mut handle, Verbosity::Journal);
+    setup_dl_cb(&mut handle, Verbosity::Journal);
 
     eprintln!("Syncing package databases...");
     if let Err(e) = handle.syncdbs_mut().update(false) {
@@ -359,7 +464,7 @@ pub fn scheduled_run() -> Result<()> {
             Some(format!("Failed to sync databases: {}", e)),
             details,
         );
-        log_run(&entry)?;
+        log_run(&entry.took(started).after_stale_lock(reaped_lock));
         return Err(e.into());
     }
 
@@ -374,37 +479,43 @@ pub fn scheduled_run() -> Result<()> {
             Some("Operation cancelled or timed out after database sync".to_string()),
             details,
         );
-        log_run(&entry)?;
+        log_run(&entry.took(started).after_stale_lock(reaped_lock));
         anyhow::bail!("Operation cancelled or timed out");
     }
 
     let updates = find_available_updates(&handle, &ignored_packages);
-    let packages_checked = updates.len();
+    // Ignored packages are still listed, so the UI can show them held back, but
+    // the handle carries them as IgnorePkg and the upgrade will not touch them.
+    // Counting them inflates the record and can trip the safety cap on work
+    // that was never going to happen.
+    let upgradable: Vec<_> = updates.iter().filter(|u| !u.ignored).collect();
+    let packages_checked = upgradable.len();
+    let held_back = updates.len() - packages_checked;
 
-    if updates.is_empty() {
-        eprintln!("No updates available");
-        let entry = LogEntry::new(
-            timestamp,
-            mode,
-            "ok",
-            0,
-            0,
-            None,
-            vec!["No updates available".to_string()],
-        );
-        log_run(&entry)?;
+    if upgradable.is_empty() {
+        eprintln!("No updates available ({held_back} held back)");
+        let detail = if held_back > 0 {
+            format!("No updates to apply ({held_back} held back by the ignore list)")
+        } else {
+            "No updates available".to_string()
+        };
+        let entry = LogEntry::new(timestamp, mode, "ok", 0, 0, None, vec![detail]);
+        log_run(&entry.took(started).after_stale_lock(reaped_lock));
         return Ok(());
     }
 
-    eprintln!("Found {} package(s) with updates", packages_checked);
-    for update in &updates {
+    eprintln!("Found {packages_checked} package(s) with updates ({held_back} held back)");
+    for update in &upgradable {
         details.push(format!("{} -> {}", update.name, update.new_version));
+    }
+    if held_back > 0 {
+        details.push(format!("{held_back} held back by the ignore list"));
     }
 
     if mode == ScheduleMode::Check {
         eprintln!("Check mode: logging updates without applying");
         let entry = LogEntry::new(timestamp, mode, "ok", packages_checked, 0, None, details);
-        log_run(&entry)?;
+        log_run(&entry.took(started).after_stale_lock(reaped_lock));
         return Ok(());
     }
 
@@ -425,7 +536,7 @@ pub fn scheduled_run() -> Result<()> {
                 packages_checked, max_packages
             )],
         );
-        log_run(&entry)?;
+        log_run(&entry.took(started).after_stale_lock(reaped_lock));
         return Ok(());
     }
 
@@ -446,7 +557,7 @@ pub fn scheduled_run() -> Result<()> {
                 Some(format!("{:#}", e)),
                 details,
             );
-            log_run(&entry)?;
+            log_run(&entry.took(started).after_stale_lock(reaped_lock));
             return Err(e);
         }
     };
@@ -465,12 +576,23 @@ pub fn scheduled_run() -> Result<()> {
             None => details,
         },
     );
-    log_run(&entry)?;
+    log_run(&entry.took(started).after_stale_lock(reaped_lock));
 
     if status == "failed" {
         anyhow::bail!(error.unwrap_or_else(|| "Scheduled upgrade failed".to_string()));
     }
     Ok(())
+}
+
+/// Whether an alpm error adds anything to a skip record. A refused question
+/// aborts the transaction with alpm's generic string, which appended after the
+/// reason reads like a second, separate failure. The conflict arm carries
+/// something real ("conflicting files"), so only the empty cases are dropped.
+fn carries_a_cause(error: &str) -> bool {
+    !matches!(
+        error.trim().to_ascii_lowercase().as_str(),
+        "" | "unexpected error"
+    )
 }
 
 /// Map a sysupgrade outcome onto run-record fields:
@@ -486,11 +608,14 @@ fn outcome_to_log_parts(
             None,
             Some("No packages to upgrade after preparation".to_string()),
         ),
+        // Skipped, not failed, even when it was a commit that returned the
+        // error: a refused question aborts before anything is applied, so the
+        // run is a safe no-op awaiting a human.
         SysupgradeOutcome::Intervention { reasons, error } => (
             "skipped",
             0,
             None,
-            Some(match error {
+            Some(match error.as_deref().filter(|e| carries_a_cause(e)) {
                 Some(e) => format!(
                     "Skipped: manual intervention required ({}); {}",
                     reasons.join(", "),
@@ -545,9 +670,199 @@ fn outcome_to_log_parts(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
-    use super::{SysupgradeOutcome, derive_status, is_kill_result, outcome_to_log_parts};
+    use super::{
+        MAX_LOG_ENTRIES, MAX_LOG_SIZE_BYTES, SysupgradeOutcome, derive_status, is_kill_result,
+        outcome_to_log_parts, parse_run_entries, rotate_if_needed_at, undo_apply,
+    };
     use crate::util::CheckResult;
+    use std::path::PathBuf;
+
+    #[test]
+    fn a_failure_before_the_apply_is_reported_as_itself() {
+        let err = undo_apply(None, None, anyhow::anyhow!("Failed to write config"));
+
+        assert_eq!(err.to_string(), "Failed to write config");
+    }
+
+    fn temp_log(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("cpac-sched-{}-{}.jsonl", tag, std::process::id()))
+    }
+
+    fn entry(ts: u32) -> String {
+        format!(
+            r#"{{"timestamp":"{ts}","mode":"check","success":true,"status":"ok","packages_checked":0,"packages_upgraded":0,"error":null,"details":[]}}"#
+        )
+    }
+
+    #[test]
+    fn rotation_keeps_lines_it_cannot_parse() {
+        let path = temp_log("odd");
+        let unknown = r#"{"timestamp":"1","mode":"check","success":true,"status":"ok","packages_checked":0,"packages_upgraded":0,"error":null,"details":[],"from_the_future":{"a":1}}"#;
+        let garbage = "{not json at all";
+
+        // Both odd lines must land in the newest half or the trim drops them
+        // before the assertions can see them.
+        let mut lines: Vec<String> = (0..MAX_LOG_ENTRIES as u32).map(entry).collect();
+        lines.push(unknown.to_string());
+        lines.push(garbage.to_string());
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+
+        rotate_if_needed_at(&path).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            after.contains("from_the_future"),
+            "an unknown field must survive rotation verbatim"
+        );
+        assert!(
+            after.contains(garbage),
+            "an unparseable line must survive rotation"
+        );
+        assert!(after.contains(&entry(MAX_LOG_ENTRIES as u32 - 1)));
+        assert!(
+            !after.contains(&entry(0)),
+            "rotation must still drop the oldest entries"
+        );
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rotation_trims_to_half_and_keeps_the_newest() {
+        let path = temp_log("trim");
+        let total = MAX_LOG_ENTRIES as u32 + 10;
+        let lines: Vec<String> = (0..total).map(entry).collect();
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+
+        rotate_if_needed_at(&path).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        let kept: Vec<&str> = after.lines().collect();
+        assert_eq!(kept.len(), MAX_LOG_ENTRIES / 2);
+        assert_eq!(kept[kept.len() - 1], entry(total - 1));
+        assert_eq!(kept[0], entry(total - (MAX_LOG_ENTRIES / 2) as u32));
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rotation_survives_a_non_utf8_line() {
+        let path = temp_log("binary");
+        let mut raw: Vec<u8> = Vec::new();
+        for line in (0..MAX_LOG_ENTRIES as u32).map(entry) {
+            raw.extend_from_slice(line.as_bytes());
+            raw.push(b'\n');
+        }
+        raw.extend_from_slice(&[0xff, 0xfe, b'\n']);
+        raw.extend_from_slice(entry(9999).as_bytes());
+        raw.push(b'\n');
+        std::fs::write(&path, &raw).unwrap();
+
+        rotate_if_needed_at(&path).unwrap();
+
+        let after = std::fs::read(&path).unwrap();
+        assert!(
+            after.windows(2).any(|w| w == [0xff, 0xfe]),
+            "invalid bytes must survive rotation"
+        );
+        assert!(
+            String::from_utf8_lossy(&after).contains(&entry(9999)),
+            "the entry after the invalid bytes must survive"
+        );
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn parse_run_entries_skips_bad_lines_without_truncating() {
+        let content = format!("{}\n{{bad\n\n{}\n", entry(1), entry(2));
+        let runs = parse_run_entries(content.as_bytes());
+
+        assert_eq!(runs.len(), 2, "a bad line must skip only itself");
+        assert_eq!(runs[0].timestamp, "1");
+        assert_eq!(runs[1].timestamp, "2");
+        assert_eq!(runs[0].status, "ok");
+    }
+
+    #[test]
+    fn parse_run_entries_handles_invalid_utf8() {
+        let mut content: Vec<u8> = Vec::new();
+        content.extend_from_slice(&[0xff, 0xfe, b'\n']);
+        content.extend_from_slice(entry(3).as_bytes());
+        content.push(b'\n');
+
+        let runs = parse_run_entries(&content);
+        assert_eq!(runs.len(), 1, "invalid bytes must not hide later entries");
+        assert_eq!(runs[0].timestamp, "3");
+    }
+
+    #[test]
+    fn rotation_shrinks_an_oversized_log_with_few_lines() {
+        let path = temp_log("fat");
+        // Ten fat entries: well past the byte budget, nowhere near the line cap.
+        let fat = format!(
+            r#"{{"timestamp":"1","mode":"check","success":true,"status":"ok","packages_checked":0,"packages_upgraded":0,"error":null,"details":["{}"]}}"#,
+            "x".repeat(150_000)
+        );
+        let before: Vec<String> = (0..10).map(|_| fat.clone()).collect();
+        std::fs::write(&path, before.join("\n") + "\n").unwrap();
+        let size_before = std::fs::metadata(&path).unwrap().len();
+        assert!(size_before > MAX_LOG_SIZE_BYTES);
+
+        rotate_if_needed_at(&path).unwrap();
+
+        let size_after = std::fs::metadata(&path).unwrap().len();
+        assert!(
+            size_after <= MAX_LOG_SIZE_BYTES,
+            "{size_before} -> {size_after} must fit the byte budget"
+        );
+        assert!(
+            std::fs::read_to_string(&path).unwrap().lines().count() >= 1,
+            "the newest entry must survive"
+        );
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rotation_keeps_the_newest_entry_even_when_it_alone_is_oversized() {
+        let path = temp_log("huge");
+        let huge = format!(
+            r#"{{"timestamp":"9","mode":"check","success":true,"status":"ok","packages_checked":0,"packages_upgraded":0,"error":null,"details":["{}"]}}"#,
+            "x".repeat((MAX_LOG_SIZE_BYTES as usize) * 2)
+        );
+        std::fs::write(&path, format!("{}\n{}\n", entry(1), huge)).unwrap();
+
+        rotate_if_needed_at(&path).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(after.contains(r#""timestamp":"9""#), "newest must survive");
+        assert!(!after.contains(&entry(1)), "the older entry must go first");
+
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rotation_leaves_a_small_log_untouched() {
+        let path = temp_log("small");
+        let before = (0..10).map(entry).collect::<Vec<_>>().join("\n") + "\n";
+        std::fs::write(&path, &before).unwrap();
+
+        rotate_if_needed_at(&path).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn rotation_is_a_noop_when_there_is_no_log() {
+        let path = temp_log("absent");
+        let _ = std::fs::remove_file(&path);
+        assert!(rotate_if_needed_at(&path).is_ok());
+        assert!(!path.exists());
+    }
 
     #[test]
     fn intervention_maps_to_skipped_at_every_stage() {
@@ -585,6 +900,18 @@ mod tests {
             detail.unwrap(),
             "Skipped: manual intervention required (conflicts detected, key imports required)"
         );
+
+        for empty in ["unexpected error", "Unexpected error", "  ", ""] {
+            let (_, _, _, detail) = outcome_to_log_parts(&SysupgradeOutcome::Intervention {
+                reasons: vec!["key imports required"],
+                error: Some(empty.to_string()),
+            });
+            assert_eq!(
+                detail.unwrap(),
+                "Skipped: manual intervention required (key imports required)",
+                "{empty:?} must not be appended"
+            );
+        }
     }
 
     #[test]
@@ -659,6 +986,14 @@ mod tests {
             "unit must set SendSIGKILL=no"
         );
 
+        // control-group would TERM mkinitcpio and dkms hooks directly, which
+        // know nothing of the backend's cooperative cancel.
+        assert_eq!(
+            last_value("KillMode="),
+            Some("mixed"),
+            "unit must TERM only the main process"
+        );
+
         // Kernel OOM is the one SIGKILL SendSIGKILL=no cannot forbid.
         assert_eq!(
             last_value("OOMScoreAdjust="),
@@ -669,6 +1004,12 @@ mod tests {
             last_value("OOMPolicy="),
             Some("continue"),
             "a child's OOM kill must not stop a commit in progress"
+        );
+
+        assert_eq!(
+            last_value("LogRateLimitIntervalSec="),
+            Some("0"),
+            "unit must exempt its own output from journald rate limiting"
         );
 
         let stop_timeout: u64 = last_value("TimeoutStopSec=")

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -445,6 +445,13 @@ pub struct ScheduledRunEntry {
     pub packages_upgraded: usize,
     pub error: Option<String>,
     pub details: Vec<String>,
+    /// Absent on records written before it existed, and on ExecStopPost
+    /// records, which never saw the run start.
+    pub duration_secs: Option<u64>,
+    /// This run found a pacman lock with no holder process and reaped it, which
+    /// means the run before it was killed mid-transaction. Says nothing about
+    /// this run, which is why it is not folded into `status`.
+    pub removed_stale_lock: bool,
 }
 
 #[derive(Serialize, Deserialize, TS)]

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -332,6 +332,25 @@ where
     f()
 }
 
+/// Shared lock for readers. Opens read-only and never creates anything, so an
+/// unprivileged reader can take it against a root-owned directory, which
+/// with_file_lock cannot. A lock file that is missing or unreadable falls
+/// through to an unlocked read: the readers here already tolerate a torn line,
+/// and refusing to read at all would be the worse failure.
+pub fn with_file_read_lock<F, R>(lock_path: &Path, body: F) -> Result<R>
+where
+    F: FnOnce() -> Result<R>,
+{
+    let guard = match std::fs::File::open(lock_path) {
+        Ok(file) => file.lock_shared().ok().map(|()| file),
+        Err(_) => None,
+    };
+
+    let result = body();
+    drop(guard);
+    result
+}
+
 /// Return a backup path of the form `{prefix}{unix_secs}` that does not yet
 /// exist, advancing the second counter on collision. Callers hold the relevant
 /// file lock, so the existence check is race-free against other backend
@@ -593,6 +612,18 @@ fn write_json_atomic_inner<T: Serialize>(path: &Path, state: &T, mode: Option<u3
 /// atomic rename, so a crash mid-restore can't leave a truncated target. Callers
 /// hold the relevant file lock.
 pub fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    write_bytes_atomic_inner(path, bytes, None)
+}
+
+/// Like [`write_bytes_atomic`], but chmods the temp file to `mode` before the
+/// rename so the target never appears with looser permissions, even briefly.
+pub fn write_bytes_atomic_with_mode(path: &Path, bytes: &[u8], mode: u32) -> Result<()> {
+    write_bytes_atomic_inner(path, bytes, Some(mode))
+}
+
+fn write_bytes_atomic_inner(path: &Path, bytes: &[u8], mode: Option<u32>) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let file_name = path
         .file_name()
@@ -609,6 +640,10 @@ pub fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
         tmp.write_all(bytes)
             .with_context(|| format!("Failed to write temp file {:?}", tmp_path))?;
         let _ = tmp.sync_all();
+        if let Some(m) = mode {
+            std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(m))
+                .with_context(|| format!("Failed to set permissions on {:?}", tmp_path))?;
+        }
         std::fs::rename(&tmp_path, path)
             .with_context(|| format!("Failed to rename {:?} to {:?}", tmp_path, path))?;
         Ok(())

--- a/backend/tests/contract_tests.rs
+++ b/backend/tests/contract_tests.rs
@@ -1374,6 +1374,8 @@ fn scheduled_run_entry_error_nullable() {
         packages_upgraded: 5,
         error: None,
         details: vec!["linux upgraded".into()],
+        duration_secs: Some(42),
+        removed_stale_lock: false,
     };
     let v = to_json(&entry);
 

--- a/src/bindings/index.ts
+++ b/src/bindings/index.ts
@@ -118,13 +118,28 @@ export type SaveMirrorlistResponse = { success: boolean, backup_path: string | n
 
 export type SaveReposResponse = { success: boolean, backup_path: string | null, message: string, };
 
-export type ScheduleConfig = { enabled: boolean, mode: string, schedule: string, max_packages: number, timer_active: boolean, timer_next_run: string | null, };
+export type ScheduleConfig = { enabled: boolean, mode: string, schedule: string, max_packages: number, timer_active: boolean, timer_next_run: string | null, 
+/**
+ * What the timer is actually set to, as systemd normalises it.
+ */
+timer_calendar: string | null, };
 
 export type ScheduleMode = "check" | "upgrade";
 
 export type ScheduleSetResponse = { success: boolean, message: string, };
 
-export type ScheduledRunEntry = { timestamp: string, mode: string, success: boolean, status: string, packages_checked: number, packages_upgraded: number, error: string | null, details: Array<string>, };
+export type ScheduledRunEntry = { timestamp: string, mode: string, success: boolean, status: string, packages_checked: number, packages_upgraded: number, error: string | null, details: Array<string>, 
+/**
+ * Absent on records written before it existed, and on ExecStopPost
+ * records, which never saw the run start.
+ */
+duration_secs: number | null, 
+/**
+ * This run found a pacman lock with no holder process and reaped it, which
+ * means the run before it was killed mid-transaction. Says nothing about
+ * this run, which is why it is not folded into `status`.
+ */
+removed_stale_lock: boolean, };
 
 export type ScheduledRunsResponse = { runs: Array<ScheduledRunEntry>, total: number, };
 

--- a/src/components/ScheduleModal.test.tsx
+++ b/src/components/ScheduleModal.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { ScheduleModal } from "./ScheduleModal";
+import * as api from "../api";
+
+vi.mock("../api", async () => {
+  const actual = await vi.importActual("../api");
+  return {
+    ...actual,
+    getScheduleConfig: vi.fn(),
+    setScheduleConfig: vi.fn(),
+    getScheduledRuns: vi.fn(),
+  };
+});
+
+const mockGetScheduleConfig = vi.mocked(api.getScheduleConfig);
+const mockGetScheduledRuns = vi.mocked(api.getScheduledRuns);
+
+const config: api.ScheduleConfig = {
+  enabled: true,
+  mode: "upgrade",
+  schedule: "daily",
+  max_packages: 1,
+  timer_active: true,
+  timer_next_run: null,
+  timer_calendar: null,
+};
+
+function run(overrides: Partial<api.ScheduledRunEntry>): api.ScheduledRunEntry {
+  return {
+    timestamp: "2026-08-21T10:35:21+0000",
+    mode: "upgrade",
+    success: true,
+    status: "ok",
+    packages_checked: 9,
+    packages_upgraded: 0,
+    error: null,
+    details: [],
+    duration_secs: null,
+    removed_stale_lock: false,
+    ...overrides,
+  };
+}
+
+async function renderWithRuns(runs: api.ScheduledRunEntry[]) {
+  mockGetScheduleConfig.mockResolvedValue(config);
+  mockGetScheduledRuns.mockResolvedValue({ runs, total: runs.length });
+  render(<ScheduleModal isOpen onClose={() => {}} />);
+  await waitFor(() => expect(mockGetScheduledRuns).toHaveBeenCalled());
+}
+
+describe("ScheduleModal run history", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => cleanup());
+
+  it("labels a skipped run as skipped, not success", async () => {
+    await renderWithRuns([
+      run({
+        status: "skipped",
+        success: true,
+        details: ["Skipped: 9 updates exceed safety limit of 1"],
+      }),
+    ]);
+
+    expect(await screen.findByText("Skipped")).toBeInTheDocument();
+    expect(screen.queryByText("Success")).not.toBeInTheDocument();
+  });
+
+  it("labels an ok run as success", async () => {
+    await renderWithRuns([run({ status: "ok", success: true, packages_upgraded: 9 })]);
+
+    expect(await screen.findByText("Success")).toBeInTheDocument();
+    expect(screen.queryByText("Skipped")).not.toBeInTheDocument();
+  });
+
+  it("labels a failed run as failed", async () => {
+    await renderWithRuns([
+      run({ status: "failed", success: false, error: "Failed to commit upgrade: disk full" }),
+    ]);
+
+    expect(await screen.findByText("Failed")).toBeInTheDocument();
+  });
+
+  // derive_status backfills status from success for pre-status records, but a
+  // record that reaches the UI without one must still not read as a success.
+  it("falls back to success only when status is absent", async () => {
+    await renderWithRuns([run({ status: "", success: false, error: "boom" })]);
+
+    expect(await screen.findByText("Failed")).toBeInTheDocument();
+  });
+
+  it("does not claim there are no runs when the history cannot be read", async () => {
+    mockGetScheduleConfig.mockResolvedValue(config);
+    mockGetScheduledRuns.mockRejectedValue(new Error("Permission denied"));
+    render(<ScheduleModal isOpen onClose={() => {}} />);
+
+    expect(await screen.findByText("Could not read the run history")).toBeInTheDocument();
+    expect(screen.queryByText("No scheduled runs yet")).not.toBeInTheDocument();
+  });
+
+  it("marks a run that had to clear a leftover lock", async () => {
+    await renderWithRuns([run({ status: "ok", removed_stale_lock: true })]);
+
+    expect(await screen.findByText("Recovered")).toBeInTheDocument();
+    expect(screen.getByText("Success")).toBeInTheDocument();
+  });
+
+  it("does not mark an ordinary run", async () => {
+    await renderWithRuns([run({ status: "ok", removed_stale_lock: false })]);
+
+    expect(await screen.findByText("Success")).toBeInTheDocument();
+    expect(screen.queryByText("Recovered")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are genuinely no runs", async () => {
+    await renderWithRuns([]);
+
+    expect(await screen.findByText("No scheduled runs yet")).toBeInTheDocument();
+    expect(screen.queryByText("Could not read the run history")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ScheduleModal.tsx
+++ b/src/components/ScheduleModal.tsx
@@ -32,6 +32,7 @@ import {
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
+  ExclamationTriangleIcon,
   OutlinedClockIcon,
   ClockIcon,
 } from "@patternfly/react-icons";
@@ -40,6 +41,7 @@ import {
   ScheduleConfig,
   ScheduleMode,
   ScheduledRunEntry,
+  ScheduledRunStatus,
   getScheduleConfig,
   setScheduleConfig,
   getScheduledRuns,
@@ -47,10 +49,71 @@ import {
 import { TimeAgo } from "./TimeAgo";
 import { sanitizeErrorMessage } from "../utils";
 
+/**
+ * A run's wall-clock time. `null` means the record predates the field, or the
+ * run was killed before it could be stamped.
+ */
+function formatDuration(secs: number | null): string {
+  if (secs === null) return "-";
+  if (secs < 60) return `${secs}s`;
+  const m = Math.floor(secs / 60);
+  if (m < 60) return `${m}m ${secs % 60}s`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
 interface ScheduleModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
+
+const RUN_STATUS = {
+  ok: { Icon: CheckCircleIcon, token: "success", label: "Success" },
+  skipped: { Icon: ExclamationTriangleIcon, token: "warning", label: "Skipped" },
+  failed: { Icon: ExclamationCircleIcon, token: "danger", label: "Failed" },
+} as const;
+
+/**
+ * Keyed off `status`, never `success`: LogEntry sets success = status !=
+ * "failed", so a skipped run is truthy and rendered as a green Success.
+ * `success` is only the fallback for records written before status existed.
+ */
+const RunStatus: React.FC<{ run: ScheduledRunEntry }> = ({ run }) => {
+  const status: ScheduledRunStatus =
+    run.status === "ok" || run.status === "skipped" || run.status === "failed"
+      ? run.status
+      : run.success
+        ? "ok"
+        : "failed";
+  const { Icon, token, label } = RUN_STATUS[status];
+
+  // A skip carries its reason in details, a failure in error.
+  const reason = run.error || run.details.join(", ");
+  const cell = (
+    <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsCenter" }}>
+      <FlexItem>
+        <Icon color={`var(--pf-t--global--icon--color--status--${token}--default)`} />
+      </FlexItem>
+      <FlexItem>{label}</FlexItem>
+    </Flex>
+  );
+  const statusCell = reason ? <Tooltip content={reason}>{cell}</Tooltip> : cell;
+
+  if (!run.removed_stale_lock) return statusCell;
+
+  // Kept out of the reason tooltip: two nested tooltips fight over the same hover.
+  return (
+    <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsCenter" }}>
+      <FlexItem>{statusCell}</FlexItem>
+      <FlexItem>
+        <Tooltip content="This run cleared a leftover pacman lock that no process was holding, so the run before it was killed part way through a transaction.">
+          <Label color="orange" isCompact>
+            Recovered
+          </Label>
+        </Tooltip>
+      </FlexItem>
+    </Flex>
+  );
+};
 
 const SCHEDULE_PRESETS = [
   { value: "hourly", label: "Hourly" },
@@ -83,6 +146,7 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
   const [maxPackages, setMaxPackages] = useState(0);
 
   const [runs, setRuns] = useState<ScheduledRunEntry[]>([]);
+  const [runsError, setRunsError] = useState<string | null>(null);
   const [historyExpanded, setHistoryExpanded] = useState(false);
 
   const loadConfig = useCallback(async () => {
@@ -116,8 +180,10 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
     try {
       const response = await getScheduledRuns({ limit: 10 });
       setRuns(response.runs);
-    } catch {
-      // Ignore errors loading run history
+      setRunsError(null);
+    } catch (ex) {
+      setRuns([]);
+      setRunsError(sanitizeErrorMessage(ex instanceof Error ? ex.message : String(ex)));
     }
   }, []);
 
@@ -308,6 +374,18 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
                     <DescriptionListDescription><TimeAgo timestamp={config.timer_next_run} /></DescriptionListDescription>
                   </DescriptionListGroup>
                 )}
+                {/* The schedule the timer is actually on, as systemd normalises
+                    it. Shown because a lost drop-in falls back to the unit's own
+                    OnCalendar, and the configured value above keeps claiming
+                    otherwise. */}
+                {config.timer_calendar && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Timer Calendar</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <code>{config.timer_calendar}</code>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
               </DescriptionList>
             )}
 
@@ -317,7 +395,16 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
               isExpanded={historyExpanded}
               className="pf-v6-u-mt-lg"
             >
-              {runs.length === 0 ? (
+              {runsError !== null ? (
+                <Alert
+                  variant="warning"
+                  isInline
+                  title="Could not read the run history"
+                  className="pf-v6-u-mt-sm"
+                >
+                  {runsError}
+                </Alert>
+              ) : runs.length === 0 ? (
                 <EmptyState headingLevel="h4" icon={ClockIcon} titleText="No scheduled runs yet">
                   <EmptyStateBody>
                     Scheduled upgrade history will appear here once the timer runs.
@@ -331,6 +418,7 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
                       <Th>Mode</Th>
                       <Th>Status</Th>
                       <Th>Packages</Th>
+                      <Th>Duration</Th>
                     </Tr>
                   </Thead>
                   <Tbody>
@@ -342,41 +430,13 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
                             {run.mode}
                           </Label>
                         </Td>
-                        <Td dataLabel="Status">
-                          {run.success ? (
-                            run.details.length > 0 ? (
-                              <Tooltip content={run.details.join(", ")}>
-                                <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsCenter" }}>
-                                  <FlexItem>
-                                    <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />
-                                  </FlexItem>
-                                  <FlexItem>Success</FlexItem>
-                                </Flex>
-                              </Tooltip>
-                            ) : (
-                              <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsCenter" }}>
-                                <FlexItem>
-                                  <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />
-                                </FlexItem>
-                                <FlexItem>Success</FlexItem>
-                              </Flex>
-                            )
-                          ) : (
-                            <Tooltip content={run.error || run.details.join(", ") || "Unknown error"}>
-                              <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsCenter" }}>
-                                <FlexItem>
-                                  <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
-                                </FlexItem>
-                                <FlexItem>Failed</FlexItem>
-                              </Flex>
-                            </Tooltip>
-                          )}
-                        </Td>
+                        <Td dataLabel="Status"><RunStatus run={run} /></Td>
                         <Td dataLabel="Packages">
                           {run.packages_upgraded > 0
                             ? `${(run.packages_upgraded).toLocaleString()} upgraded`
                             : `${(run.packages_checked).toLocaleString()} checked`}
                         </Td>
+                        <Td dataLabel="Duration">{formatDuration(run.duration_secs)}</Td>
                       </Tr>
                     ))}
                   </Tbody>

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -2387,6 +2387,8 @@ describe("UpdatesView", () => {
       packages_upgraded: 0,
       error,
       details,
+      duration_secs: null,
+      removed_stale_lock: false,
     });
 
     it("shows a danger alert when the last scheduled run failed", async () => {

--- a/systemd/cockpit-pacman-failure@.service
+++ b/systemd/cockpit-pacman-failure@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Report a failed cockpit-pacman scheduled run
+# Journal only: `journalctl -u cockpit-pacman-failure@*` shows a failure that
+# never got as far as writing a run record.
+#
+# Being a separate unit is the point: an OnFailure handler runs outside the
+# failing unit's cgroup, so unlike ExecStopPost it survives a cgroup-wide kill.
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'systemd-cat -t cockpit-pacman -p err echo "scheduled run failed: unit=%i result=$(systemctl show -p Result --value %i) status=$(systemctl show -p ExecMainStatus --value %i); see /var/log/cockpit-pacman/scheduled.jsonl and journalctl -u %i"'

--- a/systemd/cockpit-pacman-scheduled.service
+++ b/systemd/cockpit-pacman-scheduled.service
@@ -2,6 +2,7 @@
 Description=Cockpit Pacman Scheduled Upgrade
 After=network-online.target
 Wants=network-online.target
+OnFailure=cockpit-pacman-failure@%n.service
 
 [Service]
 Type=oneshot
@@ -17,10 +18,15 @@ IOSchedulingClass=idle
 TimeoutStartSec=10800
 TimeoutStopSec=900
 SendSIGKILL=no
+# TERM the main process only: mkinitcpio and dkms hooks know nothing of the
+# backend's cancel guard, and TERMing one mid-run leaves a half-built initramfs.
+KillMode=mixed
 # Kernel OOM SIGKILLs bypass SendSIGKILL=no: keep the unit a last-resort
 # victim (not exempt) and survive a child hook's OOM kill.
 OOMScoreAdjust=-500
 OOMPolicy=continue
+# A dropped line here is a lost diagnostic with nowhere else to appear.
+LogRateLimitIntervalSec=0
 
 # Security hardening
 ProtectKernelTunables=yes

--- a/test/fixtures/scheduled-runs.json
+++ b/test/fixtures/scheduled-runs.json
@@ -12,7 +12,8 @@
         "linux 6.6.9-1 -> 6.7.0.arch1-1",
         "glibc 2.38-1 -> 2.39-1",
         "openssl 3.1.4-1 -> 3.2.0-1"
-      ]
+      ],
+      "removed_stale_lock": false
     },
     {
       "timestamp": "2023-12-15T03:00:00+0000",
@@ -22,7 +23,8 @@
       "packages_checked": 0,
       "packages_upgraded": 0,
       "error": "Failed to sync package database: connection timeout",
-      "details": []
+      "details": [],
+      "removed_stale_lock": true
     }
   ],
   "total": 2


### PR DESCRIPTION
A record carried a timestamp and a success bool, so a skipped run read as a clean one, a killed predecessor left no trace and a manual intervention looked like an upgrade. Records now carry status, duration, held-back packages and lock cleanup, and the modal renders them.

The history itself reparsed every line on rotation, read without the lock and was root-only, so an unescalated session saw an empty table. It rotates by bytes and lines and takes a shared lock to read. Applying a schedule no longer leaves systemd and config.json disagreeing, and the unit stops TERMing pacman hooks.