### PR TITLE
fix: transparent upgrade outcomes and lossless pacman.conf round-trips

### DIFF
--- a/backend/src/alpm/sysupgrade.rs
+++ b/backend/src/alpm/sysupgrade.rs
@@ -50,11 +50,16 @@ pub enum SysupgradeOutcome {
     Upgraded {
         packages: usize,
     },
-    /// Cancel/timeout observed at a checkpoint, before any commit started.
+    /// Stopped with nothing applied: either at a checkpoint before the commit
+    /// started, or by a commit that reached the system with none of it.
     CancelledEarly(CheckResult),
-    /// Commit errored while a cancel/timeout was pending; the abort is the
-    /// cause, packages may be partially applied.
-    Interrupted(CheckResult),
+    /// A cancel landed part way: some packages are applied and some are not,
+    /// which is the only case that can leave the system inconsistent.
+    Interrupted,
+    /// A cancel was pending but everything landed: alpm refuses interrupts during post-transaction hooks.
+    CompletedDespiteCancel {
+        packages: usize,
+    },
     /// A recorded question kept alpm's refusal; the run needs a human.
     Intervention {
         reasons: Vec<&'static str>,
@@ -119,45 +124,114 @@ pub fn run_sysupgrade(
     if packages == 0 && tx.remove().is_empty() {
         return Ok(SysupgradeOutcome::NothingToDo);
     }
+    let targets: Vec<String> = tx.add().iter().map(|p| p.name().to_string()).collect();
 
     checkpoint!(timeout);
 
-    match tx.commit().err().map(|e| e.to_string()) {
-        None => Ok(SysupgradeOutcome::Upgraded { packages }),
-        Some(e) => Ok(classify_commit_error(
-            check_cancel(timeout),
-            flags.map(|f| f.reasons()).filter(|r| !r.is_empty()),
-            e,
-        )),
+    let commit_err = tx.commit().err().map(|e| e.to_string());
+    let check = check_cancel(timeout);
+    let intervention = flags.map(|f| f.reasons()).filter(|r| !r.is_empty());
+    drop(tx);
+
+    match commit_err {
+        None => Ok(classify_commit_ok(check, packages, || {
+            applied_state(handle, &targets)
+        })),
+        Some(e) => Ok(classify_commit_error(check, intervention, e)),
     }
 }
 
-/// Cancel/timeout outranks intervention outranks plain failure: a pending
-/// abort is what made commit fail (the error text carries no reliable
-/// keyword), and ImportKey fires inside trans_commit, so a refused key is
-/// only visible here.
+#[derive(Debug, PartialEq, Eq)]
+enum Applied {
+    All,
+    None,
+    Some,
+}
+
+fn applied_state(handle: &Alpm, targets: &[String]) -> Applied {
+    let local = handle.localdb();
+    // "Landed" is the same test find_available_updates makes: installed, and no
+    // syncdb offering anything newer.
+    let landed = targets
+        .iter()
+        .filter(|name| match local.pkg(name.as_str()) {
+            Ok(installed) => !handle.syncdbs().iter().any(|db| {
+                db.pkg(name.as_str())
+                    .map(|sync| sync.version() > installed.version())
+                    .unwrap_or(false)
+            }),
+            Err(_) => false,
+        })
+        .count();
+
+    applied_from_counts(landed, targets.len())
+}
+
+fn applied_from_counts(landed: usize, planned: usize) -> Applied {
+    match landed {
+        _ if planned == 0 => Applied::None,
+        n if n == planned => Applied::All,
+        0 => Applied::None,
+        _ => Applied::Some,
+    }
+}
+
+/// alpm returns Ok both from an interrupted commit and a completed one; the db settles which.
+fn classify_commit_ok(
+    check: CheckResult,
+    packages: usize,
+    applied: impl FnOnce() -> Applied,
+) -> SysupgradeOutcome {
+    match check {
+        CheckResult::Cancelled => match applied() {
+            Applied::All => SysupgradeOutcome::CompletedDespiteCancel { packages },
+            Applied::None => SysupgradeOutcome::CancelledEarly(CheckResult::Cancelled),
+            Applied::Some => SysupgradeOutcome::Interrupted,
+        },
+        CheckResult::Continue | CheckResult::TimedOut(_) => {
+            SysupgradeOutcome::Upgraded { packages }
+        }
+    }
+}
+
+/// Cancel outranks intervention outranks plain failure.
 fn classify_commit_error(
     check: CheckResult,
     intervention: Option<Vec<&'static str>>,
     error: String,
 ) -> SysupgradeOutcome {
     match check {
-        CheckResult::Continue => match intervention {
+        CheckResult::Cancelled => SysupgradeOutcome::Interrupted,
+        CheckResult::Continue | CheckResult::TimedOut(_) => match intervention {
             Some(reasons) => SysupgradeOutcome::Intervention {
                 reasons,
                 error: Some(error),
             },
             None => SysupgradeOutcome::CommitFailed(error),
         },
-        r => SysupgradeOutcome::Interrupted(r),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{InterventionFlags, SysupgradeOutcome, classify_commit_error};
+    use super::{
+        Applied, InterventionFlags, SysupgradeOutcome, applied_from_counts, classify_commit_error,
+        classify_commit_ok,
+    };
     use crate::util::CheckResult;
     use std::sync::atomic::Ordering;
+
+    #[test]
+    fn an_empty_plan_never_reads_as_fully_applied() {
+        assert_eq!(applied_from_counts(0, 0), Applied::None);
+    }
+
+    #[test]
+    fn a_partly_applied_plan_reads_as_some() {
+        assert_eq!(applied_from_counts(0, 3), Applied::None);
+        assert_eq!(applied_from_counts(2, 3), Applied::Some);
+        assert_eq!(applied_from_counts(3, 3), Applied::All);
+    }
 
     #[test]
     fn reasons_are_stable_and_ordered() {
@@ -178,16 +252,53 @@ mod tests {
     }
 
     #[test]
+    fn an_ok_commit_with_a_pending_cancel_is_classified_by_what_landed() {
+        assert_eq!(
+            classify_commit_ok(CheckResult::Cancelled, 10, || Applied::All),
+            SysupgradeOutcome::CompletedDespiteCancel { packages: 10 }
+        );
+        assert_eq!(
+            classify_commit_ok(CheckResult::Cancelled, 10, || Applied::None),
+            SysupgradeOutcome::CancelledEarly(CheckResult::Cancelled)
+        );
+        assert_eq!(
+            classify_commit_ok(CheckResult::Cancelled, 10, || Applied::Some),
+            SysupgradeOutcome::Interrupted
+        );
+    }
+
+    #[test]
+    fn an_ok_commit_without_a_cancel_is_an_upgrade() {
+        assert_eq!(
+            classify_commit_ok(CheckResult::Continue, 10, || panic!("must not re-check")),
+            SysupgradeOutcome::Upgraded { packages: 10 }
+        );
+        assert_eq!(
+            classify_commit_ok(CheckResult::TimedOut(1800), 10, || panic!(
+                "must not re-check"
+            )),
+            SysupgradeOutcome::Upgraded { packages: 10 }
+        );
+    }
+
+    #[test]
     fn commit_error_classification_precedence() {
         let reasons = || Some(vec!["key imports required"]);
 
         assert_eq!(
             classify_commit_error(CheckResult::Cancelled, reasons(), "err".into()),
-            SysupgradeOutcome::Interrupted(CheckResult::Cancelled)
+            SysupgradeOutcome::Interrupted
+        );
+        assert_eq!(
+            classify_commit_error(CheckResult::TimedOut(300), None, "err".into()),
+            SysupgradeOutcome::CommitFailed("err".into())
         );
         assert_eq!(
             classify_commit_error(CheckResult::TimedOut(300), reasons(), "err".into()),
-            SysupgradeOutcome::Interrupted(CheckResult::TimedOut(300))
+            SysupgradeOutcome::Intervention {
+                reasons: vec!["key imports required"],
+                error: Some("err".into())
+            }
         );
         assert_eq!(
             classify_commit_error(CheckResult::Continue, reasons(), "err".into()),

--- a/backend/src/handlers/mirrors.rs
+++ b/backend/src/handlers/mirrors.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant, UNIX_EPOCH};
@@ -10,8 +10,10 @@ use crate::models::{
     MirrorStatus, MirrorStatusResponse, MirrorTestResult, RefreshMirrorsResponse,
     RestoreMirrorBackupResponse, SaveMirrorlistResponse, StreamEvent,
 };
-use crate::util::{TimeoutGuard, emit_event, emit_json, is_cancelled, setup_signal_handler};
-use crate::validation::validate_mirror_url;
+use crate::util::{
+    EntryCounts, TimeoutGuard, emit_event, emit_json, is_cancelled, setup_signal_handler,
+};
+use crate::validation::{validate_directive_value, validate_mirror_url};
 
 const MIRRORLIST_PATH: &str = "/etc/pacman.d/mirrorlist";
 const LOCK_PATH: &str = "/etc/pacman.d/.mirrorlist.lock";
@@ -311,12 +313,23 @@ const BACKUP_PREFIX: &str = "/etc/pacman.d/mirrorlist.backup.";
 const BACKUP_META_PATH: &str = "/etc/pacman.d/.mirrorlist-backups.meta.json";
 
 pub fn save_mirrorlist(mirrors: &[MirrorEntry]) -> Result<()> {
+    if !mirrors.iter().any(|m| m.enabled) {
+        anyhow::bail!(
+            "Invalid mirror list: no enabled mirrors, which would leave pacman \
+             with nothing to sync from"
+        );
+    }
+
     for mirror in mirrors {
         validate_mirror_url(&mirror.url)?;
+        // A comment is written as `## {comment}`, so a newline in it ends the
+        // comment and whatever follows becomes a directive.
+        if let Some(comment) = mirror.comment.as_deref().filter(|c| !c.is_empty()) {
+            validate_directive_value(comment)?;
+        }
     }
 
     let path = Path::new(MIRRORLIST_PATH);
-    let parent = path.parent().unwrap_or(Path::new("/etc/pacman.d"));
 
     // Build content first
     let mut content = String::new();
@@ -339,31 +352,16 @@ pub fn save_mirrorlist(mirrors: &[MirrorEntry]) -> Result<()> {
     // Serialize the whole write/backup/rename/cleanup cycle against other
     // mirrorlist mutations (save, restore, delete) sharing this lock.
     let backup_path = crate::util::with_file_lock(Path::new(LOCK_PATH), || {
-        // Write to temp file first (atomic write pattern)
-        let temp_path = parent.join(format!(".mirrorlist.tmp.{}", std::process::id()));
-        {
-            let mut file = fs::File::create(&temp_path)?;
-            file.write_all(content.as_bytes())?;
-            file.sync_all()?;
-        }
-
-        // Create backup if original exists
         let backup_path = if path.exists() {
             let backup = crate::util::unique_backup_path(BACKUP_PREFIX);
-            if let Err(e) = fs::copy(path, &backup) {
-                let _ = fs::remove_file(&temp_path);
-                return Err(e.into());
-            }
+            fs::copy(path, &backup)?;
             Some(backup)
         } else {
             None
         };
 
-        // Atomic rename (on same filesystem)
-        if let Err(e) = fs::rename(&temp_path, path) {
-            let _ = fs::remove_file(&temp_path);
-            return Err(e.into());
-        }
+        // 0644 through the shared writer, not the caller's umask.
+        crate::util::write_bytes_atomic_with_mode(path, content.as_bytes(), 0o644)?;
 
         // Clean up old backups, keeping only the most recent MAX_BACKUPS
         cleanup_old_backups();
@@ -381,7 +379,7 @@ pub fn save_mirrorlist(mirrors: &[MirrorEntry]) -> Result<()> {
     emit_json(&response)
 }
 
-fn count_mirrors_in_file(path: &Path) -> Result<(usize, usize)> {
+fn count_mirrors_in_file(path: &Path) -> Result<EntryCounts> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut enabled = 0usize;
@@ -405,7 +403,18 @@ fn count_mirrors_in_file(path: &Path) -> Result<(usize, usize)> {
         }
     }
 
-    Ok((enabled, total))
+    Ok(EntryCounts { enabled, total })
+}
+
+fn ensure_mirrors_restorable(backup: &Path) -> Result<()> {
+    let enabled = count_mirrors_in_file(backup)?.enabled;
+    if enabled == 0 {
+        anyhow::bail!(
+            "Backup {} has no enabled Server entries, refusing to restore",
+            backup.display()
+        );
+    }
+    Ok(())
 }
 
 pub fn list_mirror_backups() -> Result<()> {
@@ -433,7 +442,7 @@ pub fn list_mirror_backups() -> Result<()> {
         let metadata = entry.metadata()?;
         let size = metadata.len();
 
-        let (enabled_count, total_count) = count_mirrors_in_file(&entry.path()).unwrap_or((0, 0));
+        let counts = count_mirrors_in_file(&entry.path()).unwrap_or_default();
 
         let date = chrono::DateTime::from_timestamp(timestamp, 0)
             .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
@@ -444,8 +453,8 @@ pub fn list_mirror_backups() -> Result<()> {
         backups.push(MirrorBackup {
             timestamp,
             date,
-            enabled_count,
-            total_count,
+            enabled_count: counts.enabled,
+            total_count: counts.total,
             size,
             source,
         });
@@ -466,14 +475,7 @@ pub fn restore_mirror_backup(timestamp: i64) -> Result<()> {
             anyhow::bail!("Backup not found: {}", backup_path);
         }
 
-        // Reject an empty or serverless backup before touching the live file.
-        let (_, total) = count_mirrors_in_file(backup)?;
-        if total == 0 {
-            anyhow::bail!(
-                "Backup {} has no Server entries, refusing to restore",
-                backup_path
-            );
-        }
+        ensure_mirrors_restorable(backup)?;
         let contents = fs::read(backup)?;
 
         let mirrorlist = Path::new(MIRRORLIST_PATH);
@@ -490,6 +492,7 @@ pub fn restore_mirror_backup(timestamp: i64) -> Result<()> {
         crate::util::write_bytes_atomic(mirrorlist, &contents)?;
 
         note_backup(&pre_restore_backup, BackupSource::Auto);
+        cleanup_old_backups();
 
         Ok(pre_restore_backup)
     })?;
@@ -526,7 +529,12 @@ pub fn delete_mirror_backup(timestamp: i64) -> Result<()> {
 }
 
 fn cleanup_old_backups() {
-    crate::util::prune_old_backups(Path::new(BACKUP_DIR), BACKUP_NAME_PREFIX, MAX_BACKUPS);
+    crate::util::prune_old_backups(
+        Path::new(BACKUP_DIR),
+        BACKUP_NAME_PREFIX,
+        MAX_BACKUPS,
+        Path::new(BACKUP_META_PATH),
+    );
 }
 
 fn note_backup(backup: &Option<String>, source: BackupSource) {
@@ -554,7 +562,27 @@ fn reconcile_backups() {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::parse_server_line;
+    use super::{ensure_mirrors_restorable, parse_server_line};
+
+    #[test]
+    fn a_backup_whose_servers_are_all_commented_is_refused() {
+        let path = std::env::temp_dir().join(format!("cpac-mirrors-{}", std::process::id()));
+        let commented = "## Arch Linux mirrorlist\n#Server = https://a.example/$repo/os/$arch\n#Server = https://b.example/$repo/os/$arch\n";
+
+        // Two Server entries are present, so a total-based guard would let this
+        // through and restore a mirrorlist pacman cannot sync from.
+        std::fs::write(&path, commented).unwrap();
+        assert!(ensure_mirrors_restorable(&path).is_err());
+
+        std::fs::write(
+            &path,
+            format!("Server = https://a.example/$repo/os/$arch\n{commented}"),
+        )
+        .unwrap();
+        assert!(ensure_mirrors_restorable(&path).is_ok());
+
+        std::fs::remove_file(&path).unwrap();
+    }
 
     #[test]
     fn well_formed_server_line_returns_trimmed_url() {

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -213,15 +213,12 @@ fn prepare_failure(err_msg: &str) -> anyhow::Error {
 
 fn commit_and_complete(
     tx: &mut TransactionGuard,
-    timeout: &TimeoutGuard,
     interrupt_msg: &str,
     success_msg: Option<String>,
 ) -> Result<()> {
     let _inhibitor = ShutdownInhibitor::take("Applying package changes");
     match tx.commit().err().map(|e| e.to_string()) {
-        Some(err_msg) => {
-            handle_commit_error(&err_msg, is_cancelled(), timeout, interrupt_msg).map(|_| ())
-        }
+        Some(err_msg) => handle_commit_error(&err_msg, is_cancelled(), interrupt_msg),
         None => {
             // Invariant: enqueue the success signal immediately after commit()
             // returns Ok, before anything else. emit_event hands it to the async
@@ -490,16 +487,21 @@ pub fn run_upgrade(ignore_pkgs: &[String], timeout_secs: Option<u64>) -> Result<
             });
             Ok(())
         }
-        SysupgradeOutcome::Interrupted(r @ CheckResult::TimedOut(_)) => {
-            emit_cancellation_complete(&r);
-            Ok(())
-        }
-        SysupgradeOutcome::Interrupted(_) => {
+        SysupgradeOutcome::Interrupted => {
             emit_event(&StreamEvent::Complete {
                 success: false,
                 message: Some(
                     "Operation interrupted - system may be in inconsistent state".to_string(),
                 ),
+            });
+            Ok(())
+        }
+        // Every package landed, and the view keys its "finished before the
+        // cancel took effect" notice off this success.
+        SysupgradeOutcome::CompletedDespiteCancel { .. } => {
+            emit_event(&StreamEvent::Complete {
+                success: true,
+                message: None,
             });
             Ok(())
         }
@@ -583,7 +585,6 @@ pub fn remove_orphans(timeout_secs: Option<u64>) -> Result<()> {
 
     commit_and_complete(
         &mut tx,
-        &timeout,
         "Operation interrupted",
         Some(format!("Removed {} orphan package(s)", orphan_names.len())),
     )
@@ -648,7 +649,6 @@ pub fn install_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
     commit_and_complete(
         &mut tx,
-        &timeout,
         "Operation interrupted - package may be in inconsistent state",
         Some(format!("Successfully installed {}", name)),
     )
@@ -697,7 +697,6 @@ pub fn remove_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
     commit_and_complete(
         &mut tx,
-        &timeout,
         "Operation interrupted - package may be in inconsistent state",
         Some(format!("Successfully removed {}", name)),
     )

--- a/backend/src/handlers/repos.rs
+++ b/backend/src/handlers/repos.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
 use serde::Serialize;
 use std::fs;
-use std::io::Write;
 use std::path::Path;
 use ts_rs::TS;
 
 use crate::models::{
     BackupSource, ListReposResponse, RepoDirectiveFull, RepoEntry, SaveReposResponse,
 };
-use crate::util::emit_json;
+use crate::util::{EntryCounts, emit_json};
 use crate::validation::{validate_directive_value, validate_repo_name};
 
 const PACMAN_CONF_PATH: &str = "/etc/pacman.conf";
@@ -19,7 +18,7 @@ const BACKUP_META_PATH: &str = "/etc/.pacman-conf-backups.meta.json";
 const LOCK_PATH: &str = "/etc/pacman.conf.lock";
 const MAX_BACKUPS: usize = 5;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DirectiveKind {
     Server,
     Include,
@@ -30,6 +29,9 @@ pub struct Directive {
     pub kind: DirectiveKind,
     pub value: String,
     pub enabled: bool,
+    /// Comments and lines this tool does not model that sat directly above,
+    /// kept with it because that is what they describe.
+    pub leading: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -38,10 +40,12 @@ pub struct RepoSection {
     pub enabled: bool,
     pub sig_level: Option<String>,
     pub directives: Vec<Directive>,
+    pub sig_leading: Vec<String>,
+    pub sig_after: usize,
     /// Lines pacman understands but this tool does not model (Usage,
-    /// CacheServer, in-section comments), kept verbatim so a round-trip does
-    /// not silently drop them.
-    pub passthrough: Vec<String>,
+    /// CacheServer, in-section comments) that followed the last directive,
+    /// kept verbatim so a round-trip does not silently drop them.
+    pub trailing: Vec<String>,
     pub trailing_blank_lines: usize,
 }
 
@@ -55,6 +59,9 @@ pub fn parse_conf(input: &str) -> PacmanConf {
     let mut preamble = String::new();
     let mut repos: Vec<RepoSection> = Vec::new();
     let mut in_repo = false;
+    // Lines seen since the last recognised directive. They describe whatever
+    // comes next, so they are held until that arrives.
+    let mut pending: Vec<String> = Vec::new();
 
     for line in input.lines() {
         let trimmed = line.trim();
@@ -62,6 +69,11 @@ pub fn parse_conf(input: &str) -> PacmanConf {
         let (is_commented_section, section_name) = parse_section_header(trimmed);
 
         if let Some(name) = section_name {
+            if let Some(previous) = repos.last_mut() {
+                previous.trailing = std::mem::take(&mut pending);
+            } else {
+                pending.clear();
+            }
             if name == "options" {
                 in_repo = false;
                 preamble.push_str(line);
@@ -74,7 +86,9 @@ pub fn parse_conf(input: &str) -> PacmanConf {
                 enabled: !is_commented_section,
                 sig_level: None,
                 directives: Vec::new(),
-                passthrough: Vec::new(),
+                sig_leading: Vec::new(),
+                sig_after: 0,
+                trailing: Vec::new(),
                 trailing_blank_lines: 0,
             });
             continue;
@@ -95,32 +109,70 @@ pub fn parse_conf(input: &str) -> PacmanConf {
             continue;
         }
 
-        let (commented, content) = if trimmed.starts_with('#') {
-            (true, trimmed.trim_start_matches('#').trim())
+        let hashes = trimmed.chars().take_while(|c| *c == '#').count();
+        let content = trimmed[hashes..].trim();
+        let commented = hashes > 0;
+
+        // Inside a disabled section the serializer's own hash says nothing about what the user wanted.
+        let ours = !repo.enabled && commented;
+        // One hash inside a disabled section is the serializer's; a second is
+        // the user's own switch for that mirror.
+        let directive_enabled = if repo.enabled {
+            hashes == 0
         } else {
-            (false, trimmed)
+            hashes <= 1
         };
 
         if let Some(val) = strip_key_value(content, "SigLevel") {
             repo.sig_level = Some(val.to_string());
+            repo.sig_leading = std::mem::take(&mut pending);
+            repo.sig_after = repo.directives.len();
         } else if let Some(val) = strip_key_value(content, "Server") {
             repo.directives.push(Directive {
                 kind: DirectiveKind::Server,
                 value: val.to_string(),
-                enabled: !commented,
+                enabled: directive_enabled,
+                leading: std::mem::take(&mut pending),
             });
         } else if let Some(val) = strip_key_value(content, "Include") {
             repo.directives.push(Directive {
                 kind: DirectiveKind::Include,
                 value: val.to_string(),
-                enabled: !commented,
+                enabled: directive_enabled,
+                leading: std::mem::take(&mut pending),
             });
+        } else if ours {
+            pending.push(uncomment_once(trimmed).to_string());
         } else {
-            repo.passthrough.push(trimmed.to_string());
+            pending.push(trimmed.to_string());
         }
     }
 
+    if let Some(repo) = repos.last_mut() {
+        repo.trailing = std::mem::take(&mut pending);
+    }
+
     PacmanConf { preamble, repos }
+}
+
+fn uncomment_once(trimmed: &str) -> &str {
+    let rest = &trimmed[1..];
+    if rest.starts_with('#') || reads_as_setting(rest.trim_start_matches('#').trim()) {
+        rest
+    } else {
+        trimmed
+    }
+}
+
+/// Tells a directive the serializer commented out from a comment the user typed.
+fn reads_as_setting(content: &str) -> bool {
+    content.split_once('=').is_some_and(|(key, _)| {
+        let key = key.trim();
+        !key.is_empty()
+            && key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    })
 }
 
 fn parse_section_header(trimmed: &str) -> (bool, Option<String>) {
@@ -158,37 +210,65 @@ pub fn serialize_conf(conf: &PacmanConf) -> String {
             output.push_str(&format!("#[{}]\n", repo.name));
         }
 
-        if let Some(ref sig) = repo.sig_level {
-            if repo.enabled {
-                output.push_str(&format!("SigLevel = {}\n", sig));
-            } else {
-                output.push_str(&format!("#SigLevel = {}\n", sig));
+        // A disabled section's header is commented, so any live line under it
+        // would bind to the section above; comment these too.
+        let emit_raw = |output: &mut String, raw: &str| {
+            if !repo.enabled {
+                output.push('#');
             }
+            output.push_str(raw);
+            output.push('\n');
+        };
+
+        let emit_sig = |output: &mut String| {
+            if let Some(ref sig) = repo.sig_level {
+                for raw in &repo.sig_leading {
+                    emit_raw(output, raw);
+                }
+                if repo.enabled {
+                    output.push_str(&format!("SigLevel = {}\n", sig));
+                } else {
+                    output.push_str(&format!("#SigLevel = {}\n", sig));
+                }
+            }
+        };
+
+        let mut sig_written = false;
+        if repo.sig_after == 0 {
+            emit_sig(&mut output);
+            sig_written = true;
         }
 
-        for directive in &repo.directives {
+        for (index, directive) in repo.directives.iter().enumerate() {
+            if !sig_written && index == repo.sig_after {
+                emit_sig(&mut output);
+                sig_written = true;
+            }
+
+            for raw in &directive.leading {
+                emit_raw(&mut output, raw);
+            }
+
             let key = match directive.kind {
                 DirectiveKind::Server => "Server",
                 DirectiveKind::Include => "Include",
             };
-            let line_enabled = repo.enabled && directive.enabled;
-            if line_enabled {
-                output.push_str(&format!("{} = {}\n", key, directive.value));
-            } else {
-                output.push_str(&format!("#{} = {}\n", key, directive.value));
+            // Two states, two hashes: disabling the section must not erase which mirrors were off.
+            if !repo.enabled {
+                output.push('#');
             }
+            if !directive.enabled {
+                output.push('#');
+            }
+            output.push_str(&format!("{} = {}\n", key, directive.value));
         }
 
-        for raw in &repo.passthrough {
-            // A disabled section's header is commented, so any live directive
-            // under it would bind to the wrong section; comment passthrough too.
-            if repo.enabled || raw.starts_with('#') {
-                output.push_str(raw);
-            } else {
-                output.push('#');
-                output.push_str(raw);
-            }
-            output.push('\n');
+        if !sig_written {
+            emit_sig(&mut output);
+        }
+
+        for raw in &repo.trailing {
+            emit_raw(&mut output, raw);
         }
 
         for _ in 0..repo.trailing_blank_lines {
@@ -235,9 +315,12 @@ fn entry_to_repo_section(entry: &RepoEntry) -> RepoSection {
                 },
                 value: d.value.clone(),
                 enabled: d.enabled,
+                leading: Vec::new(),
             })
             .collect(),
-        passthrough: Vec::new(),
+        sig_leading: Vec::new(),
+        sig_after: 0,
+        trailing: Vec::new(),
         trailing_blank_lines: 1,
     }
 }
@@ -256,7 +339,23 @@ pub fn list_repos() -> Result<()> {
     emit_json(&ListReposResponse { repos })
 }
 
+/// A section counts only when enabled with a live Server or Include.
+fn ensure_repos_usable(repos: &[RepoEntry]) -> Result<()> {
+    let usable = repos
+        .iter()
+        .any(|r| r.enabled && r.directives.iter().any(|d| d.enabled));
+    if !usable {
+        anyhow::bail!(
+            "Invalid repository list: no enabled repository has an enabled Server or Include, \
+             which would leave pacman with no package source"
+        );
+    }
+    Ok(())
+}
+
 pub fn save_repos(repos: &[RepoEntry]) -> Result<()> {
+    ensure_repos_usable(repos)?;
+
     for entry in repos {
         validate_repo_name(&entry.name)?;
         if let Some(ref sig) = entry.sig_level {
@@ -275,7 +374,6 @@ pub fn save_repos(repos: &[RepoEntry]) -> Result<()> {
     }
 
     let path = Path::new(PACMAN_CONF_PATH);
-    let parent = path.parent().unwrap_or(Path::new("/etc"));
 
     // Serialize the whole read/modify/backup/rename cycle so concurrent saves
     // can't lose each other's edits or clobber a backup.
@@ -283,45 +381,50 @@ pub fn save_repos(repos: &[RepoEntry]) -> Result<()> {
         let original = fs::read_to_string(path)?;
         let mut conf = parse_conf(&original);
 
-        // Passthrough isn't in RepoEntry, so recover it from the on-disk
-        // section by name before the rewrite drops it.
-        let mut preserved: std::collections::HashMap<String, Vec<String>> = conf
-            .repos
-            .drain(..)
-            .map(|r| (r.name, r.passthrough))
-            .collect();
+        // Matched by kind and value, not position, so toggling a mirror keeps its comment.
+        let mut preserved: std::collections::HashMap<String, RepoSection> =
+            conf.repos.drain(..).map(|r| (r.name.clone(), r)).collect();
 
         conf.repos = repos.iter().map(entry_to_repo_section).collect();
         for section in &mut conf.repos {
-            if let Some(p) = preserved.remove(&section.name) {
-                section.passthrough = p;
+            let Some(old) = preserved.remove(&section.name) else {
+                continue;
+            };
+            section.sig_leading = old.sig_leading;
+            section.sig_after = old.sig_after;
+            section.trailing = old.trailing;
+            section.trailing_blank_lines = old.trailing_blank_lines;
+
+            let mut by_value: std::collections::HashMap<(DirectiveKind, String), Vec<String>> = old
+                .directives
+                .into_iter()
+                .filter(|d| !d.leading.is_empty())
+                .map(|d| ((d.kind, d.value), d.leading))
+                .collect();
+            for directive in &mut section.directives {
+                if let Some(leading) = by_value.remove(&(directive.kind, directive.value.clone())) {
+                    directive.leading = leading;
+                }
+            }
+
+            // A deleted directive's comment lands at the section end instead of being dropped.
+            for (_, orphaned) in by_value {
+                section.trailing.extend(orphaned);
             }
         }
 
         let new_content = serialize_conf(&conf);
 
-        let temp_path = parent.join(format!(".pacman.conf.tmp.{}", std::process::id()));
-        {
-            let mut file = fs::File::create(&temp_path)?;
-            file.write_all(new_content.as_bytes())?;
-            file.sync_all()?;
-        }
-
         let backup_path = if path.exists() {
             let backup = crate::util::unique_backup_path(BACKUP_PREFIX);
-            if let Err(e) = fs::copy(path, &backup) {
-                let _ = fs::remove_file(&temp_path);
-                return Err(e.into());
-            }
+            fs::copy(path, &backup)?;
             Some(backup)
         } else {
             None
         };
 
-        if let Err(e) = fs::rename(&temp_path, path) {
-            let _ = fs::remove_file(&temp_path);
-            return Err(e.into());
-        }
+        // 0644 through the shared writer, not the caller's umask.
+        crate::util::write_bytes_atomic_with_mode(path, new_content.as_bytes(), 0o644)?;
 
         cleanup_old_backups();
         note_backup(&backup_path, BackupSource::Manual);
@@ -364,15 +467,26 @@ pub struct RestoreRepoBackupResponse {
     pub message: String,
 }
 
-fn count_repos_in_file(path: &Path) -> (usize, usize) {
-    let content = match fs::read_to_string(path) {
-        Ok(c) => c,
-        Err(_) => return (0, 0),
+fn count_repos_in_file(path: &Path) -> EntryCounts {
+    let Ok(content) = fs::read_to_string(path) else {
+        return EntryCounts::default();
     };
     let conf = parse_conf(&content);
-    let total = conf.repos.len();
-    let enabled = conf.repos.iter().filter(|r| r.enabled).count();
-    (total, enabled)
+    EntryCounts {
+        enabled: conf.repos.iter().filter(|r| r.enabled).count(),
+        total: conf.repos.len(),
+    }
+}
+
+fn ensure_repos_restorable(backup: &Path) -> Result<()> {
+    let enabled = count_repos_in_file(backup).enabled;
+    if enabled == 0 {
+        anyhow::bail!(
+            "Backup {} has no enabled repositories, refusing to restore",
+            backup.display()
+        );
+    }
+    Ok(())
 }
 
 pub fn list_repo_backups() -> Result<()> {
@@ -401,7 +515,7 @@ pub fn list_repo_backups() -> Result<()> {
             Err(_) => continue,
         };
         let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
-        let (repo_count, enabled_count) = count_repos_in_file(&entry.path());
+        let counts = count_repos_in_file(&entry.path());
         let date = chrono::DateTime::from_timestamp(timestamp, 0)
             .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
             .unwrap_or_else(|| "Unknown".to_string());
@@ -411,8 +525,8 @@ pub fn list_repo_backups() -> Result<()> {
         backups.push(RepoBackup {
             timestamp,
             date,
-            repo_count,
-            enabled_count,
+            repo_count: counts.total,
+            enabled_count: counts.enabled,
             size,
             source,
         });
@@ -431,14 +545,7 @@ pub fn restore_repo_backup(timestamp: i64) -> Result<()> {
             anyhow::bail!("Backup not found: {}", backup_path);
         }
 
-        // Reject an empty or repo-less backup before touching the live file.
-        let (total, _) = count_repos_in_file(backup);
-        if total == 0 {
-            anyhow::bail!(
-                "Backup {} has no repositories, refusing to restore",
-                backup_path
-            );
-        }
+        ensure_repos_restorable(backup)?;
         let contents = fs::read(backup)?;
 
         let conf = Path::new(PACMAN_CONF_PATH);
@@ -456,6 +563,7 @@ pub fn restore_repo_backup(timestamp: i64) -> Result<()> {
         crate::util::write_bytes_atomic(conf, &contents)?;
 
         note_backup(&pre_restore_backup, BackupSource::Auto);
+        cleanup_old_backups();
 
         Ok(pre_restore_backup)
     })?;
@@ -494,7 +602,12 @@ fn cleanup_old_backups() {
     let parent = Path::new(PACMAN_CONF_PATH)
         .parent()
         .unwrap_or(Path::new("/etc"));
-    crate::util::prune_old_backups(parent, BACKUP_NAME_PREFIX, MAX_BACKUPS);
+    crate::util::prune_old_backups(
+        parent,
+        BACKUP_NAME_PREFIX,
+        MAX_BACKUPS,
+        Path::new(BACKUP_META_PATH),
+    );
 }
 
 fn note_backup(backup: &Option<String>, source: BackupSource) {
@@ -517,4 +630,184 @@ fn reconcile_backups() {
         Path::new(BACKUP_DIR),
         BACKUP_NAME_PREFIX,
     );
+}
+
+#[cfg(test)]
+mod save_guard {
+    use super::ensure_repos_usable;
+    use crate::models::{RepoDirectiveFull, RepoEntry};
+
+    fn repo(name: &str, enabled: bool, directive_enabled: bool) -> RepoEntry {
+        RepoEntry {
+            name: name.to_string(),
+            enabled,
+            sig_level: None,
+            directives: vec![RepoDirectiveFull {
+                directive_type: "Include".to_string(),
+                value: "/etc/pacman.d/mirrorlist".to_string(),
+                enabled: directive_enabled,
+            }],
+        }
+    }
+
+    #[test]
+    fn a_list_with_one_usable_repo_is_accepted() {
+        assert!(
+            ensure_repos_usable(&[repo("core", true, true), repo("extra", false, true)]).is_ok()
+        );
+    }
+
+    #[test]
+    fn a_list_with_every_repo_disabled_is_refused() {
+        assert!(
+            ensure_repos_usable(&[repo("core", false, true), repo("extra", false, true)]).is_err()
+        );
+    }
+
+    /// An enabled section whose directives are all commented is just as dead:
+    /// pacman reports no servers configured for the repository.
+    #[test]
+    fn an_enabled_repo_with_no_live_directive_is_refused() {
+        assert!(ensure_repos_usable(&[repo("core", true, false)]).is_err());
+    }
+
+    #[test]
+    fn an_empty_list_is_refused() {
+        assert!(ensure_repos_usable(&[]).is_err());
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod round_trip {
+    use super::{parse_conf, serialize_conf};
+
+    const WITH_A_DISABLED_MIRROR: &str = "[options]\nHoldPkg = pacman\n\n[core]\n# the internal mirror is first on purpose\nServer = https://internal.example/core\n#Server = https://retired.example/core\nUsage = Sync Search\nInclude = /etc/pacman.d/mirrorlist\n";
+
+    fn toggled(conf: &str, name: &str, enabled: bool) -> String {
+        let mut parsed = parse_conf(conf);
+        for repo in &mut parsed.repos {
+            if repo.name == name {
+                repo.enabled = enabled;
+            }
+        }
+        serialize_conf(&parsed)
+    }
+
+    #[test]
+    fn a_comment_stays_with_the_line_it_documents() {
+        let conf = "[core]\n# the internal mirror is first on purpose\nServer = https://internal.example/core\nUsage = Sync Search\nInclude = /etc/pacman.d/mirrorlist\nSigLevel = Required\n";
+
+        let out = serialize_conf(&parse_conf(conf));
+
+        let comment = out
+            .find("# the internal mirror is first on purpose")
+            .expect("comment kept");
+        let server = out
+            .find("Server = https://internal.example/core")
+            .expect("server kept");
+        assert!(
+            comment < server,
+            "the comment must stay above its Server:\n{out}"
+        );
+
+        let usage = out.find("Usage = Sync Search").expect("usage kept");
+        let include = out
+            .find("Include = /etc/pacman.d/mirrorlist")
+            .expect("include kept");
+        assert!(
+            usage < include,
+            "Usage must stay above the Include it preceded:\n{out}"
+        );
+    }
+
+    /// SigLevel may sit anywhere in a section. pacman does not care, but moving
+    /// it is still an unasked-for edit to someone's file.
+    #[test]
+    fn a_section_round_trips_unchanged_when_nothing_is_edited() {
+        for conf in [
+            "[options]\nHoldPkg = pacman\n\n[core]\n# note\nServer = https://a.example/core\nUsage = Sync\nInclude = /etc/pacman.d/mirrorlist\n",
+            "[core]\n# note\nServer = https://a.example/core\nInclude = /etc/pacman.d/mirrorlist\nSigLevel = Required\n",
+            "[core]\nSigLevel = Required\nServer = https://a.example/core\n",
+            "[core]\nServer = https://a.example/core\nSigLevel = Required\nInclude = /etc/pacman.d/mirrorlist\n",
+        ] {
+            assert_eq!(
+                serialize_conf(&parse_conf(conf)),
+                conf,
+                "round trip changed:\n{conf}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_repo_still_has_its_sources_after_being_disabled_and_re_enabled() {
+        let off = toggled(WITH_A_DISABLED_MIRROR, "core", false);
+        assert!(off.contains("#[core]"), "section is disabled: {off}");
+
+        let on = toggled(&off, "core", true);
+        assert!(
+            on.contains("\nServer = https://internal.example/core\n"),
+            "{on}"
+        );
+        assert!(
+            on.contains("\nInclude = /etc/pacman.d/mirrorlist\n"),
+            "{on}"
+        );
+        assert!(on.contains("\nUsage = Sync Search\n"), "{on}");
+    }
+
+    #[test]
+    fn a_mirror_the_user_disabled_stays_disabled_across_the_cycle() {
+        let on = toggled(
+            &toggled(WITH_A_DISABLED_MIRROR, "core", false),
+            "core",
+            true,
+        );
+        assert!(
+            on.contains("#Server = https://retired.example/core"),
+            "{on}"
+        );
+    }
+
+    #[test]
+    fn prose_the_user_wrote_is_not_turned_into_a_directive() {
+        let on = toggled(
+            &toggled(WITH_A_DISABLED_MIRROR, "core", false),
+            "core",
+            true,
+        );
+        assert!(
+            on.contains("# the internal mirror is first on purpose"),
+            "{on}"
+        );
+        assert!(
+            !on.contains("\n the internal mirror"),
+            "comment lost its #: {on}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_repos_restorable;
+
+    #[test]
+    fn a_backup_whose_sections_are_all_commented_is_refused() {
+        let path = std::env::temp_dir().join(format!("cpac-repos-{}", std::process::id()));
+        let commented = "[options]\nHoldPkg = pacman glibc\n\n#[core]\n#Include = /etc/pacman.d/mirrorlist\n\n#[extra]\n#Include = /etc/pacman.d/mirrorlist\n";
+
+        // Both sections still parse as repos, so a total-based guard would let
+        // this through and restore a pacman.conf with no package source.
+        std::fs::write(&path, commented).unwrap();
+        assert!(ensure_repos_restorable(&path).is_err());
+
+        std::fs::write(
+            &path,
+            format!("{commented}\n[multilib]\nInclude = /etc/pacman.d/mirrorlist\n"),
+        )
+        .unwrap();
+        assert!(ensure_repos_restorable(&path).is_ok());
+
+        std::fs::remove_file(&path).unwrap();
+    }
 }

--- a/backend/src/handlers/scheduled.rs
+++ b/backend/src/handlers/scheduled.rs
@@ -630,23 +630,21 @@ fn outcome_to_log_parts(
         SysupgradeOutcome::CancelledEarly(_) => (
             "failed",
             0,
-            Some("Operation cancelled or timed out before commit".to_string()),
+            Some("Operation cancelled or timed out with nothing applied".to_string()),
             None,
         ),
-        SysupgradeOutcome::Interrupted(CheckResult::TimedOut(secs)) => (
-            "failed",
-            0,
-            Some(format!(
-                "Upgrade timed out after {} seconds during commit",
-                secs
-            )),
-            None,
-        ),
-        SysupgradeOutcome::Interrupted(_) => (
+        SysupgradeOutcome::Interrupted => (
             "failed",
             0,
             Some("Upgrade interrupted during commit".to_string()),
             None,
+        ),
+        // The packages are on the system, so this is not a failed run.
+        SysupgradeOutcome::CompletedDespiteCancel { packages } => (
+            "ok",
+            *packages,
+            None,
+            Some("Upgrade finished before the cancel could take effect".to_string()),
         ),
         SysupgradeOutcome::SyncFailed(e) => (
             "failed",
@@ -921,8 +919,8 @@ mod tests {
             SysupgradeOutcome::PrepareFailed("e".into()),
             SysupgradeOutcome::CommitFailed("e".into()),
             SysupgradeOutcome::CancelledEarly(CheckResult::Cancelled),
-            SysupgradeOutcome::Interrupted(CheckResult::Cancelled),
-            SysupgradeOutcome::Interrupted(CheckResult::TimedOut(1800)),
+            SysupgradeOutcome::CancelledEarly(CheckResult::TimedOut(1800)),
+            SysupgradeOutcome::Interrupted,
         ];
         for outcome in cases {
             let (status, upgraded, error, _) = outcome_to_log_parts(&outcome);

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -780,43 +780,21 @@ fn test_config_preserves_unknown_fields_on_rewrite() {
 
 #[test]
 fn test_handle_commit_error_cancelled() {
-    use crate::util::{TimeoutGuard, handle_commit_error};
-
-    let timeout = TimeoutGuard::new(300);
+    use crate::util::handle_commit_error;
 
     // The cancel flag, not the error text, drives the interrupted outcome.
-    let result = handle_commit_error("transaction aborted", true, &timeout, "Operation cancelled");
+    let result = handle_commit_error("transaction aborted", true, "Operation cancelled");
     assert!(result.is_ok());
-    assert!(!result.unwrap());
-}
-
-#[test]
-fn test_handle_commit_error_timed_out() {
-    use crate::util::{TimeoutGuard, handle_commit_error};
-
-    // A zero-second guard is already timed out; an uncancelled commit failure
-    // is then reported as a timeout, not a generic error.
-    let timeout = TimeoutGuard::new(0);
-    let result = handle_commit_error(
-        "transaction aborted",
-        false,
-        &timeout,
-        "Operation cancelled",
-    );
-    assert!(result.is_ok());
-    assert!(!result.unwrap());
 }
 
 #[test]
 fn test_handle_commit_error_keywords_are_not_interrupts() {
-    use crate::util::{TimeoutGuard, handle_commit_error};
-
-    let timeout = TimeoutGuard::new(300);
+    use crate::util::handle_commit_error;
 
     // A real failure whose text mentions "signal"/"timeout" must not be masked
     // as a user interrupt: without the flag set, it is an error.
     for msg in ["download timeout on mirror", "scriptlet killed by signal 9"] {
-        let result = handle_commit_error(msg, false, &timeout, "Operation interrupted");
+        let result = handle_commit_error(msg, false, "Operation interrupted");
         assert!(
             result.is_err(),
             "{msg:?} should be a failure, not an interrupt"
@@ -826,16 +804,9 @@ fn test_handle_commit_error_keywords_are_not_interrupts() {
 
 #[test]
 fn test_handle_commit_error_actual_failure() {
-    use crate::util::{TimeoutGuard, handle_commit_error};
+    use crate::util::handle_commit_error;
 
-    let timeout = TimeoutGuard::new(300);
-
-    let result = handle_commit_error(
-        "conflicting files exist",
-        false,
-        &timeout,
-        "Operation failed",
-    );
+    let result = handle_commit_error("conflicting files exist", false, "Operation failed");
     assert!(result.is_err());
     assert!(
         result

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -5,10 +5,10 @@ use crate::models::{
 };
 use crate::util::parse_package_filename;
 use crate::validation::{
-    validate_archive_filename, validate_depth, validate_direction, validate_json_payload_size,
-    validate_keep_versions, validate_max_packages, validate_mirror_timeout, validate_mirror_url,
-    validate_package_name, validate_pagination, validate_schedule, validate_search_query,
-    validate_version,
+    validate_archive_filename, validate_depth, validate_direction, validate_directive_value,
+    validate_json_payload_size, validate_keep_versions, validate_max_packages,
+    validate_mirror_timeout, validate_mirror_url, validate_package_name, validate_pagination,
+    validate_schedule, validate_search_query, validate_version,
 };
 
 #[test]
@@ -232,6 +232,17 @@ fn test_validate_keep_versions_invalid() {
     assert!(validate_keep_versions(101).is_err());
     assert!(validate_keep_versions(1000).is_err());
     assert!(validate_keep_versions(u32::MAX).is_err());
+}
+
+// A newline in a mirror comment would end it and leave a directive pacman obeys.
+#[test]
+fn test_validate_directive_value_rejects_line_breaks() {
+    assert!(validate_directive_value("Germany, Hetzner").is_ok());
+    assert!(validate_directive_value("tabs\tare fine").is_ok());
+    assert!(
+        validate_directive_value("harmless\nServer = https://evil.example/$repo/os/$arch").is_err()
+    );
+    assert!(validate_directive_value("carriage\rreturn").is_err());
 }
 
 #[test]

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -893,30 +893,18 @@ pub(crate) fn parse_package_filename(filename: &str) -> Option<(String, String, 
     }
 }
 
-/// Classify a failed commit: Ok(false) on cancel/timeout, Err on a real
-/// failure. `cancelled` decides it, not the error text, since the abort
-/// carries no reliable keyword and sniffing would mask real failures.
+/// Ok when a cancel caused the failure, Err otherwise; only the cancel flag decides.
 pub fn handle_commit_error(
     err_msg: &str,
     cancelled: bool,
-    timeout: &TimeoutGuard,
     interrupted_message: &str,
-) -> Result<bool> {
+) -> Result<()> {
     if cancelled {
         emit_event(&StreamEvent::Complete {
             success: false,
             message: Some(interrupted_message.to_string()),
         });
-        return Ok(false);
-    } else if timeout.is_timed_out() {
-        emit_event(&StreamEvent::Complete {
-            success: false,
-            message: Some(format!(
-                "Operation timed out after {} seconds",
-                timeout.timeout_secs()
-            )),
-        });
-        return Ok(false);
+        return Ok(());
     }
 
     emit_event(&StreamEvent::Complete {

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -288,6 +288,13 @@ pub fn emit_json<T: Serialize>(response: &T) -> Result<()> {
     Ok(())
 }
 
+/// Commented entries still count toward `total`; only `enabled` says the file can serve.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EntryCounts {
+    pub enabled: usize,
+    pub total: usize,
+}
+
 /// Path of a state or cache file under ~/.config/cockpit-pacman.
 /// `file` must be a bare file name; path components are rejected.
 pub fn config_path(file: &str) -> Result<std::path::PathBuf> {
@@ -375,12 +382,21 @@ pub fn unique_backup_path(prefix: &str) -> String {
 /// the `keep` entries with the highest timestamps survive. Ranking is by the
 /// timestamp embedded in the filename, never the file's mtime, so a restored or
 /// copied backup (which gets a fresh mtime) is not mistaken for the newest.
-pub fn backups_to_prune(mut entries: Vec<(PathBuf, i64)>, keep: usize) -> Vec<PathBuf> {
+pub fn backups_to_prune(
+    mut entries: Vec<(PathBuf, i64, BackupSource)>,
+    keep: usize,
+) -> Vec<PathBuf> {
     if entries.len() <= keep {
         return Vec::new();
     }
-    entries.sort_by_key(|(_, ts)| std::cmp::Reverse(*ts));
-    entries.into_iter().skip(keep).map(|(p, _)| p).collect()
+    // Manual outranks automatic at any age.
+    entries.sort_by_key(|(_, ts, source)| {
+        (
+            !matches!(source, BackupSource::Manual),
+            std::cmp::Reverse(*ts),
+        )
+    });
+    entries.into_iter().skip(keep).map(|(p, _, _)| p).collect()
 }
 
 /// Remove all but the `keep` most recent backups in `parent` whose name starts
@@ -388,7 +404,7 @@ pub fn backups_to_prune(mut entries: Vec<(PathBuf, i64)>, keep: usize) -> Vec<Pa
 /// whose suffix is not an integer are ignored (matching the listing logic), so
 /// they neither count toward `keep` nor get deleted. Best-effort: scan and
 /// remove failures are logged, not propagated, so cleanup never fails a save.
-pub fn prune_old_backups(parent: &Path, name_prefix: &str, keep: usize) {
+pub fn prune_old_backups(parent: &Path, name_prefix: &str, keep: usize, manifest: &Path) {
     let read_dir = match std::fs::read_dir(parent) {
         Ok(rd) => rd,
         Err(e) => {
@@ -400,11 +416,19 @@ pub fn prune_old_backups(parent: &Path, name_prefix: &str, keep: usize) {
         }
     };
 
-    let entries: Vec<(PathBuf, i64)> = read_dir
+    // Unlisted backups default to Manual, as the listing renders them, so one
+    // predating the manifest is protected rather than silently evictable.
+    let provenance = read_backup_provenance(manifest);
+    let entries: Vec<(PathBuf, i64, BackupSource)> = read_dir
         .filter_map(|entry| entry.ok())
         .filter_map(|entry| {
             let name = entry.file_name().into_string().ok()?;
-            Some((entry.path(), backup_timestamp(&name, name_prefix)?))
+            let ts = backup_timestamp(&name, name_prefix)?;
+            Some((
+                entry.path(),
+                ts,
+                provenance.get(&ts).copied().unwrap_or_default(),
+            ))
         })
         .collect();
 
@@ -442,6 +466,14 @@ fn existing_backup_timestamps(parent: &Path, name_prefix: &str) -> std::collecti
 /// missing or corrupt manifest yields an empty map; callers default unlisted
 /// backups to Manual so backups predating the manifest still render.
 pub fn read_backup_provenance(manifest: &Path) -> std::collections::BTreeMap<i64, BackupSource> {
+    read_provenance_raw(manifest)
+        .into_iter()
+        .filter_map(|(ts, value)| serde_json::from_value(value).ok().map(|src| (ts, src)))
+        .collect()
+}
+
+/// Values stay uninterpreted, so an unknown source round-trips instead of being dropped.
+fn read_provenance_raw(manifest: &Path) -> std::collections::BTreeMap<i64, serde_json::Value> {
     std::fs::read_to_string(manifest)
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
@@ -460,10 +492,13 @@ pub fn record_backup_provenance(
     source: BackupSource,
 ) {
     let live = existing_backup_timestamps(backup_dir, name_prefix);
-    let mut map = read_backup_provenance(manifest);
-    map.insert(timestamp, source);
+    let mut map = read_provenance_raw(manifest);
+    map.insert(
+        timestamp,
+        serde_json::to_value(source).unwrap_or(serde_json::Value::Null),
+    );
     map.retain(|ts, _| *ts == timestamp || live.contains(ts));
-    if let Err(e) = write_json_atomic_with_mode(manifest, &map, 0o600) {
+    if let Err(e) = write_json_atomic_with_mode(manifest, &map, 0o644) {
         eprintln!(
             "Warning: failed to write backup provenance {:?}: {}",
             manifest, e
@@ -475,7 +510,7 @@ pub fn record_backup_provenance(
 /// backup is deleted so the manifest doesn't retain a stale source. Best-effort.
 pub fn reconcile_backup_provenance(manifest: &Path, backup_dir: &Path, name_prefix: &str) {
     let live = existing_backup_timestamps(backup_dir, name_prefix);
-    let mut map = read_backup_provenance(manifest);
+    let mut map = read_provenance_raw(manifest);
     let before = map.len();
     map.retain(|ts, _| live.contains(ts));
     if map.len() != before {
@@ -1117,6 +1152,42 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unwrap_used)]
+    fn an_unknown_provenance_value_survives_a_write() {
+        let dir = std::env::temp_dir().join(format!("cpac-prov-unknown-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let prefix = "cfg.backup.";
+        let manifest = dir.join(".meta.json");
+        for ts in [100i64, 200, 300] {
+            std::fs::write(dir.join(format!("{prefix}{ts}")), b"x").unwrap();
+        }
+        std::fs::write(
+            &manifest,
+            br#"{"100":"manual","200":"scheduled","300":"auto"}"#,
+        )
+        .unwrap();
+
+        let map = read_backup_provenance(&manifest);
+        assert_eq!(map.get(&100), Some(&BackupSource::Manual));
+        assert_eq!(map.get(&300), Some(&BackupSource::Auto));
+        assert_eq!(map.get(&200), None, "an unreadable value is not guessed at");
+
+        record_backup_provenance(&manifest, &dir, prefix, 400, BackupSource::Auto);
+
+        let written = std::fs::read_to_string(&manifest).unwrap();
+        assert!(
+            written.contains("scheduled"),
+            "a value this build cannot read must not be dropped by writing: {written}"
+        );
+        assert_eq!(
+            read_backup_provenance(&manifest).get(&400),
+            Some(&BackupSource::Auto)
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
     fn classify_returns_none_for_unclassifiable_error() {
         assert_eq!(classify_message("something entirely unexpected"), None);
         assert_eq!(classify_error(&anyhow::anyhow!("weird failure")), None);
@@ -1264,10 +1335,15 @@ mod tests {
         std::fs::remove_file(&path).unwrap();
     }
 
-    fn entry(ts: i64) -> (PathBuf, i64) {
+    fn entry(ts: i64) -> (PathBuf, i64, BackupSource) {
+        sourced(ts, BackupSource::Auto)
+    }
+
+    fn sourced(ts: i64, source: BackupSource) -> (PathBuf, i64, BackupSource) {
         (
             PathBuf::from(format!("/etc/pacman.d/mirrorlist.backup.{ts}")),
             ts,
+            source,
         )
     }
 
@@ -1286,6 +1362,24 @@ mod tests {
         ];
         let pruned = backups_to_prune(entries, 5);
         assert_eq!(pruned, vec![entry(2).0, entry(1).0]);
+    }
+
+    #[test]
+    fn backups_to_prune_evicts_automatic_before_manual() {
+        let entries = vec![
+            sourced(1, BackupSource::Manual),
+            sourced(5, BackupSource::Auto),
+            sourced(6, BackupSource::Auto),
+            sourced(7, BackupSource::Auto),
+        ];
+
+        let pruned = backups_to_prune(entries, 3);
+
+        assert_eq!(
+            pruned,
+            vec![sourced(5, BackupSource::Auto).0],
+            "the oldest automatic goes, not the older manual"
+        );
     }
 
     #[test]

--- a/backend/tests/repos_tests.rs
+++ b/backend/tests/repos_tests.rs
@@ -89,6 +89,7 @@ fn adding_server_directive_appends_in_correct_section() {
         kind: DirectiveKind::Server,
         value: "https://mirror.rackspace.com/archlinux/$repo/os/$arch".to_string(),
         enabled: true,
+        leading: Vec::new(),
     };
     parsed.repos[0].directives.push(new_directive);
     let output = serialize_conf(&parsed);
@@ -145,7 +146,9 @@ CacheServer = https://cache.example.com/$repo
 fn unknown_directives_and_comments_round_trip_verbatim() {
     let parsed: PacmanConf = parse_conf(FIXTURE_EXTRAS);
     assert_eq!(
-        parsed.repos[0].passthrough,
+        // They follow the last directive, so they belong to the section's tail
+        // rather than to any one line.
+        parsed.repos[0].trailing,
         vec![
             "Usage = Sync Search".to_string(),
             "CacheServer = https://cache.example.com/$repo".to_string(),
@@ -162,6 +165,34 @@ fn disabling_section_comments_passthrough_directives() {
     let output = serialize_conf(&parsed);
     assert!(output.contains("#Usage = Sync Search"));
     assert!(output.contains("#CacheServer = https://cache.example.com/$repo"));
-    assert!(output.contains("# keep this note"));
-    assert!(!output.contains("## keep this note"));
+    assert!(output.contains("## keep this note"));
+}
+
+#[test]
+fn a_disable_and_enable_cycle_restores_the_section_verbatim() {
+    let mut parsed: PacmanConf = parse_conf(FIXTURE_EXTRAS);
+    parsed.repos[0].enabled = false;
+    let disabled = serialize_conf(&parsed);
+
+    let mut reparsed: PacmanConf = parse_conf(&disabled);
+    reparsed.repos[0].enabled = true;
+    assert_eq!(serialize_conf(&reparsed), FIXTURE_EXTRAS);
+}
+
+#[test]
+fn a_directive_the_user_commented_out_stays_commented_after_a_cycle() {
+    let conf = "[core]\nServer = https://mirror.example.com/$repo\n#CacheServer = https://cache.example.com/$repo\n";
+
+    let mut parsed: PacmanConf = parse_conf(conf);
+    parsed.repos[0].enabled = false;
+    let disabled = serialize_conf(&parsed);
+
+    let mut reparsed: PacmanConf = parse_conf(&disabled);
+    reparsed.repos[0].enabled = true;
+    let output = serialize_conf(&reparsed);
+
+    assert!(
+        output.contains("#CacheServer = https://cache.example.com/$repo"),
+        "a CacheServer the user had switched off must not come back live: {output}"
+    );
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ export default [
         MutationObserver: "readonly",
         ResizeObserver: "readonly",
         MouseEvent: "readonly",
+        Event: "readonly",
         HTMLDivElement: "readonly",
         HTMLElement: "readonly",
         HTMLInputElement: "readonly",

--- a/src/components/MirrorsView.test.tsx
+++ b/src/components/MirrorsView.test.tsx
@@ -347,6 +347,44 @@ describe("MirrorsView", () => {
     });
   });
 
+  it("distinguishes a backup you took from one taken for you", async () => {
+    mockListMirrorBackups.mockResolvedValue({
+      backups: [
+        {
+          timestamp: 1704067200,
+          date: "2024-01-01 00:00:00 UTC",
+          enabled_count: 3,
+          total_count: 10,
+          size: 2048,
+          source: "manual",
+        },
+        {
+          timestamp: 1704063600,
+          date: "2023-12-31 23:00:00 UTC",
+          enabled_count: 2,
+          total_count: 9,
+          size: 1024,
+          source: "auto",
+        },
+      ],
+    });
+
+    render(<MirrorsView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/mirror1\.example\.com/)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Backup history"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Manual")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Automatic")).toBeInTheDocument();
+  });
+
   it("shows empty state when no backups exist", async () => {
     mockListMirrorBackups.mockResolvedValue({ backups: [] });
 

--- a/src/components/MirrorsView.tsx
+++ b/src/components/MirrorsView.tsx
@@ -982,6 +982,7 @@ export const MirrorsView: React.FC = () => {
                   </Th>
                   <Th>Date</Th>
                   <Th>Mirrors</Th>
+                  <Th>Origin</Th>
                   <Th>Size</Th>
                   <Th width={10}>Actions</Th>
                 </Tr>
@@ -1004,6 +1005,19 @@ export const MirrorsView: React.FC = () => {
                     </Td>
                     <Td dataLabel="Mirrors">
                       {backup.enabled_count} enabled / {backup.total_count} total
+                    </Td>
+                    <Td dataLabel="Origin">
+                      <Tooltip
+                        content={
+                          backup.source === "manual"
+                            ? "Taken when you saved. Kept ahead of automatic ones when old backups are pruned."
+                            : "Taken automatically before a restore. Pruned first."
+                        }
+                      >
+                        <Label isCompact color={backup.source === "manual" ? "blue" : "grey"}>
+                          {backup.source === "manual" ? "Manual" : "Automatic"}
+                        </Label>
+                      </Tooltip>
                     </Td>
                     <Td dataLabel="Size">{formatSize(backup.size)}</Td>
                     <Td dataLabel="Actions">

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -534,6 +534,38 @@ describe("UpdatesView", () => {
   });
 
   describe("Upgrade Progress", () => {
+    it("warns before leaving while an upgrade is applying", async () => {
+      let upgradeCallbacks: Parameters<typeof api.runUpgrade>[0] | undefined;
+      mockRunUpgrade.mockImplementation((callbacks) => {
+        upgradeCallbacks = callbacks;
+        return { cancel: vi.fn(), forceStop: vi.fn() };
+      });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText(/1 of 1 update/)).toBeInTheDocument();
+      });
+
+      expect(window.dispatchEvent(new Event("beforeunload", { cancelable: true }))).toBe(true);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Apply 1 Update/i }));
+      });
+      await waitFor(() => {
+        expect(screen.getByText("Applying Updates")).toBeInTheDocument();
+      });
+
+      // dispatchEvent returns false once a listener has cancelled it, which is
+      // what makes the browser prompt.
+      expect(window.dispatchEvent(new Event("beforeunload", { cancelable: true }))).toBe(false);
+
+      await act(async () => {
+        upgradeCallbacks?.onComplete();
+      });
+
+      expect(window.dispatchEvent(new Event("beforeunload", { cancelable: true }))).toBe(true);
+    });
+
     it("shows progress during download phase", async () => {
       mockRunUpgrade.mockImplementation((callbacks) => {
         setTimeout(() => {
@@ -726,14 +758,54 @@ describe("UpdatesView", () => {
       });
 
       await act(async () => {
+        upgradeCallbacks?.onError("BACKEND_TERMINAL_DETAIL", "internal_error");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/BACKEND_TERMINAL_DETAIL/)).toBeInTheDocument();
+      });
+      expect(mockCheckUpdates.mock.calls.length).toBeGreaterThan(checksBeforeCancel);
+      expect(screen.queryByText(/Failed to/)).not.toBeInTheDocument();
+    });
+
+    it("does not claim a package count after a cancel", async () => {
+      let upgradeCallbacks: api.UpgradeCallbacks | undefined;
+      mockRunUpgrade.mockImplementation((callbacks) => {
+        upgradeCallbacks = callbacks;
+        return { cancel: vi.fn(), forceStop: vi.fn() };
+      });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText(/1 of 1 update/)).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Apply 1 Update/i }));
+      });
+      await waitFor(() => {
+        expect(screen.getByText("Applying Updates")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        upgradeCallbacks?.onEvent?.({
+          type: "progress", operation: "upgrade", package: "linux",
+          percent: 100, current: 1, total: 1,
+        });
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Cancel Anyway/i }));
+      });
+      await act(async () => {
         upgradeCallbacks?.onError("Operation interrupted", "internal_error");
       });
 
       await waitFor(() => {
-        expect(screen.getByText("Upgrade stopped at a safe point")).toBeInTheDocument();
+        expect(screen.getByText(/Upgrade cancelled/)).toBeInTheDocument();
       });
-      expect(mockCheckUpdates.mock.calls.length).toBeGreaterThan(checksBeforeCancel);
-      expect(screen.queryByText(/Failed to/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/were updated before stopping/)).not.toBeInTheDocument();
     });
 
     it("shows the finished outcome when the upgrade completes despite the cancel", async () => {

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -350,6 +350,14 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [lockRetryExhausted, setLockRetryExhausted] = useState(false);
   const [errorEpoch, setErrorEpoch] = useState(0);
 
+  // alpm acts on a cancel only between packages; leaving mid-transaction half-applies the upgrade.
+  useEffect(() => {
+    if (state !== "applying") return;
+    const warn = (event: Event) => event.preventDefault();
+    window.addEventListener("beforeunload", warn);
+    return () => window.removeEventListener("beforeunload", warn);
+  }, [state]);
+
   // Consecutive errors can commit in one render batch without ever showing
   // the intermediate state, so the epoch forces LockErrorBody to remount
   // (and re-check the lock) for each new error.
@@ -384,7 +392,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [isCancelling, setIsCancelling] = useState(false);
   // Ref mirror for the upgrade callbacks, which close over stale state.
   const isCancellingRef = useRef(false);
-  const [cancelOutcome, setCancelOutcome] = useState<"stopped" | "finished" | null>(null);
+  const [cancelOutcome, setCancelOutcome] = useState<{ kind: "stopped" | "finished"; detail?: string } | null>(null);
   const setCancelling = (value: boolean) => {
     isCancellingRef.current = value;
     setIsCancelling(value);
@@ -939,7 +947,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         autoResumedRef.current = false;
         if (isCancellingRef.current) {
           setCancelling(false);
-          setCancelOutcome("finished");
+          setCancelOutcome({ kind: "finished" });
         }
         setState("success");
         setUpdates([]);
@@ -964,10 +972,8 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       onError: (err, code) => {
         cancelRef.current = null;
         if (isCancellingRef.current) {
-          // The abort we requested: show stopped and refetch (partial upgrade).
           setCancelling(false);
-          setCancelOutcome("stopped");
-          setLog("");
+          setCancelOutcome({ kind: "stopped", detail: err });
           loadUpdates();
           loadRebootStatus();
           loadPacnewStatus();
@@ -1145,17 +1151,18 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
 
   const cancelAlert = cancelOutcome ? (
     <Alert
-      variant={cancelOutcome === "stopped" ? "info" : "success"}
-      title={cancelOutcome === "stopped"
-        ? "Upgrade stopped at a safe point"
+      variant={cancelOutcome.kind === "stopped" ? "warning" : "success"}
+      title={cancelOutcome.kind === "stopped"
+        ? "Upgrade cancelled"
         : "Upgrade finished before the cancel took effect"}
       className="pf-v6-u-mb-md"
       actionClose={<AlertActionCloseButton onClose={() => setCancelOutcome(null)} />}
     >
-      {cancelOutcome === "stopped" && (
-        upgradeProgress.current > 0
-          ? `${upgradeProgress.current} of ${upgradeProgress.total} packages were updated before stopping; the rest remain pending.`
-          : "No packages were installed."
+      {cancelOutcome.kind === "stopped" && (
+        <>
+          {cancelOutcome.detail}
+          {" The update list has been rechecked; what it shows now is what is still pending."}
+        </>
       )}
     </Alert>
   ) : null;


### PR DESCRIPTION
alpm returns Ok from a commit it interrupted having applied nothing, so a cancelled upgrade showed "System Updated" over an untouched system. The backend now asks the db what actually happened, and the view relays that.

The pacman.conf serializer also rewrote files into a different shape than the admin wrote them: reordered sections, drifted comments, and a commented-out directive could come back live after disabling and re-enabling a repo. The disabled-section encoding is reversible now, so the cycle round-trips byte-identical. A save that leaves pacman with no enabled repository or mirror is refused, and restores prune old backups with manual ones kept first.
