### PR TITLE
fix: cancel safety, honest lock scans, and least-privilege reads

### DIFF
--- a/backend/src/alpm/callbacks.rs
+++ b/backend/src/alpm/callbacks.rs
@@ -1,14 +1,21 @@
 use alpm::{Alpm, AnyDownloadEvent, DownloadEvent, LogLevel};
 
 use crate::models::StreamEvent;
-use crate::util::{emit_event, is_cancelled};
+use crate::util::{emit_event, may_interrupt_transaction};
 
 use super::log_level_to_string;
 
 /// Re-arm from every callback: alpm only latches the interrupt in
 /// STATE_COMMITTING, so a request during downloads has to be retried.
+///
+/// A cancel that came from the control channel going away is deliberately not
+/// re-armed. Cockpit's logout button and a websocket restart both close the
+/// channel without sending a cancel, and interrupting here stops libalpm
+/// between packages: the transaction ends part-applied, with the
+/// post-transaction hooks unrun. Nobody is waiting on the result either way, so
+/// finishing is the safer of the two.
 pub fn interrupt_if_cancelled() {
-    if is_cancelled() {
+    if may_interrupt_transaction() {
         super::try_interrupt();
     }
 }

--- a/backend/src/alpm/callbacks.rs
+++ b/backend/src/alpm/callbacks.rs
@@ -1,49 +1,33 @@
 use alpm::{Alpm, AnyDownloadEvent, DownloadEvent, LogLevel};
+use std::collections::HashMap;
 
 use crate::models::StreamEvent;
 use crate::util::{emit_event, may_interrupt_transaction};
 
 use super::log_level_to_string;
 
-/// Re-arm from every callback: alpm only latches the interrupt in
-/// STATE_COMMITTING, so a request during downloads has to be retried.
-///
-/// A cancel that came from the control channel going away is deliberately not
-/// re-armed. Cockpit's logout button and a websocket restart both close the
-/// channel without sending a cancel, and interrupting here stops libalpm
-/// between packages: the transaction ends part-applied, with the
-/// post-transaction hooks unrun. Nobody is waiting on the result either way, so
-/// finishing is the safer of the two.
 pub fn interrupt_if_cancelled() {
     if may_interrupt_transaction() {
         super::try_interrupt();
     }
 }
 
-/// A scheduled run has no client reading stdout, so events go to the journal,
-/// where alpm's per-chunk tracing would blow past journald's rate limit and
-/// drop the run's own diagnostics.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Verbosity {
     Streaming,
     Journal,
 }
 
-impl Verbosity {
-    fn wants_level(self, level: LogLevel) -> bool {
-        match self {
-            Verbosity::Streaming => true,
-            Verbosity::Journal => !matches!(log_level_to_string(level), "debug" | "function"),
-        }
-    }
+fn worth_emitting(level: LogLevel) -> bool {
+    !matches!(log_level_to_string(level), "debug" | "function")
 }
 
-pub fn setup_log_cb(handle: &mut Alpm, verbosity: Verbosity) {
+pub fn setup_log_cb(handle: &mut Alpm) {
     handle.set_log_cb((), move |level: LogLevel, msg: &str, _: &mut ()| {
         // The re-arm has to happen for every callback, including the ones whose
         // message is dropped: it is the only cancel path during downloads.
         interrupt_if_cancelled();
-        if !verbosity.wants_level(level) {
+        if !worth_emitting(level) {
             return;
         }
         emit_event(&StreamEvent::Log {
@@ -53,7 +37,13 @@ pub fn setup_log_cb(handle: &mut Alpm, verbosity: Verbosity) {
     });
 }
 
+fn percent_of(downloaded: i64, total: i64) -> Option<u8> {
+    (total > 0).then(|| ((downloaded.max(0) as f64 / total as f64) * 100.0).round() as u8)
+}
+
 pub fn setup_dl_cb(handle: &mut Alpm, verbosity: Verbosity) {
+    let mut last_percent: HashMap<String, u8> = HashMap::new();
+
     handle.set_dl_cb(
         (),
         move |filename: &str, event: AnyDownloadEvent, _: &mut ()| {
@@ -64,10 +54,21 @@ pub fn setup_dl_cb(handle: &mut Alpm, verbosity: Verbosity) {
                 DownloadEvent::Retry(_) => ("retry", None, None),
                 DownloadEvent::Completed(c) => ("completed", None, Some(c.total)),
             };
-            // Progress is per chunk; init, retry and completed are one line per file.
-            if verbosity == Verbosity::Journal && event_str == "progress" {
-                return;
+
+            if event_str == "progress" {
+                if verbosity == Verbosity::Journal {
+                    return;
+                }
+                if let Some(pct) = downloaded.zip(total).and_then(|(d, t)| percent_of(d, t)) {
+                    if last_percent.get(filename) == Some(&pct) {
+                        return;
+                    }
+                    last_percent.insert(filename.to_string(), pct);
+                }
+            } else if event_str == "completed" {
+                last_percent.remove(filename);
             }
+
             emit_event(&StreamEvent::Download {
                 filename: filename.to_string(),
                 event: event_str.to_string(),
@@ -76,4 +77,40 @@ pub fn setup_dl_cb(handle: &mut Alpm, verbosity: Verbosity) {
             });
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LogLevel, percent_of, worth_emitting};
+
+    #[test]
+    fn an_error_or_a_warning_is_never_withheld() {
+        assert!(worth_emitting(LogLevel::ERROR));
+        assert!(worth_emitting(LogLevel::WARNING));
+    }
+
+    #[test]
+    fn alpm_tracing_is_withheld() {
+        assert!(!worth_emitting(LogLevel::DEBUG));
+        assert!(!worth_emitting(LogLevel::FUNCTION));
+    }
+
+    #[test]
+    fn percent_spans_zero_to_a_hundred() {
+        assert_eq!(percent_of(0, 200), Some(0));
+        assert_eq!(percent_of(199, 200), Some(100));
+        assert_eq!(percent_of(200, 200), Some(100));
+    }
+
+    #[test]
+    fn chunks_within_one_percent_share_a_value() {
+        assert_eq!(percent_of(1000, 100_000), percent_of(1004, 100_000));
+        assert_ne!(percent_of(1000, 100_000), percent_of(1600, 100_000));
+    }
+
+    #[test]
+    fn an_unknown_total_has_no_percent() {
+        assert_eq!(percent_of(50, 0), None);
+        assert_eq!(percent_of(50, -1), None);
+    }
 }

--- a/backend/src/alpm/sysupgrade.rs
+++ b/backend/src/alpm/sysupgrade.rs
@@ -50,13 +50,8 @@ pub enum SysupgradeOutcome {
     Upgraded {
         packages: usize,
     },
-    /// Stopped with nothing applied: either at a checkpoint before the commit
-    /// started, or by a commit that reached the system with none of it.
     CancelledEarly(CheckResult),
-    /// A cancel landed part way: some packages are applied and some are not,
-    /// which is the only case that can leave the system inconsistent.
     Interrupted,
-    /// A cancel was pending but everything landed: alpm refuses interrupts during post-transaction hooks.
     CompletedDespiteCancel {
         packages: usize,
     },
@@ -150,8 +145,6 @@ enum Applied {
 
 fn applied_state(handle: &Alpm, targets: &[String]) -> Applied {
     let local = handle.localdb();
-    // "Landed" is the same test find_available_updates makes: installed, and no
-    // syncdb offering anything newer.
     let landed = targets
         .iter()
         .filter(|name| match local.pkg(name.as_str()) {
@@ -169,9 +162,8 @@ fn applied_state(handle: &Alpm, targets: &[String]) -> Applied {
 
 fn applied_from_counts(landed: usize, planned: usize) -> Applied {
     match landed {
-        _ if planned == 0 => Applied::None,
-        n if n == planned => Applied::All,
         0 => Applied::None,
+        n if n == planned => Applied::All,
         _ => Applied::Some,
     }
 }
@@ -194,7 +186,6 @@ fn classify_commit_ok(
     }
 }
 
-/// Cancel outranks intervention outranks plain failure.
 fn classify_commit_error(
     check: CheckResult,
     intervention: Option<Vec<&'static str>>,

--- a/backend/src/handlers/lock.rs
+++ b/backend/src/handlers/lock.rs
@@ -16,6 +16,7 @@ pub struct LockStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub blocking_process: Option<String>,
+    pub holder_unknown: bool,
 }
 
 #[derive(Serialize, TS)]
@@ -36,34 +37,71 @@ fn db_path() -> PathBuf {
     )
 }
 
-// alpm holds an open fd to db.lck while locked, so the owner is whichever
-// process has that exact file open; matching anything under the db dir would
-// misreport read-only queries (and our own backend) as the holder. `lock` must
-// be canonical since /proc fd links resolve fully.
-fn find_lock_holder(lock: &Path) -> Option<String> {
-    for entry in fs::read_dir("/proc").ok()?.flatten() {
-        let pid = entry.file_name().to_str()?.to_string();
+enum Holder {
+    Process(String),
+    None,
+    Unknown,
+}
+
+fn scan_error_hides_a_holder(e: &std::io::Error) -> bool {
+    e.kind() != std::io::ErrorKind::NotFound
+}
+
+fn find_lock_holder(lock: &Path) -> Holder {
+    let Ok(meta) = fs::metadata(lock) else {
+        return Holder::Unknown;
+    };
+    let target = (meta.dev(), meta.ino());
+
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return Holder::Unknown;
+    };
+
+    let mut hidden_from_us = false;
+    for entry in entries {
+        let Ok(entry) = entry else {
+            hidden_from_us = true;
+            continue;
+        };
+        let name = entry.file_name();
+        let Some(pid) = name.to_str() else {
+            hidden_from_us = true;
+            continue;
+        };
         if !pid.chars().all(|c| c.is_ascii_digit()) {
             continue;
         }
-        let fd_dir = entry.path().join("fd");
-        let fds = match fs::read_dir(&fd_dir) {
+        let fds = match fs::read_dir(entry.path().join("fd")) {
             Ok(fds) => fds,
-            Err(_) => continue,
+            Err(e) => {
+                hidden_from_us |= scan_error_hides_a_holder(&e);
+                continue;
+            }
         };
-        for fd in fds.flatten() {
-            if let Ok(target) = fs::read_link(fd.path())
-                && target == lock
-            {
-                let comm = fs::read_to_string(entry.path().join("comm"))
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string();
-                return Some(format!("{} (pid {})", comm, pid));
+        for fd in fds {
+            let Ok(fd) = fd else {
+                hidden_from_us = true;
+                continue;
+            };
+            match fs::metadata(fd.path()) {
+                Ok(m) if (m.dev(), m.ino()) == target => {
+                    let comm = fs::read_to_string(entry.path().join("comm"))
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
+                    return Holder::Process(format!("{} (pid {})", comm, pid));
+                }
+                Ok(_) => {}
+                Err(e) => hidden_from_us |= scan_error_hides_a_holder(&e),
             }
         }
     }
-    None
+
+    if hidden_from_us {
+        Holder::Unknown
+    } else {
+        Holder::None
+    }
 }
 
 /// Identify a specific file instance: (dev, ino, ctime_secs, ctime_nsec). ctime
@@ -85,24 +123,30 @@ pub fn check_lock() -> Result<()> {
     } else {
         None
     };
-    let blocking = canonical.as_deref().and_then(find_lock_holder);
-    let stale = canonical.is_some() && blocking.is_none();
+
+    let (blocking, holder_unknown) = match canonical.as_deref().map(find_lock_holder) {
+        Some(Holder::Process(name)) => (Some(name), false),
+        Some(Holder::None) => (None, false),
+        Some(Holder::Unknown) => (None, true),
+        None => (None, locked),
+    };
 
     emit_json(&LockStatus {
         locked,
-        stale,
+        stale: canonical.is_some() && blocking.is_none() && !holder_unknown,
         lock_path: lock.to_string_lossy().to_string(),
         blocking_process: blocking,
+        holder_unknown,
     })
 }
 
 /// Remove db.lck only if no process holds it open. Ok(true) if removed,
 /// Ok(false) if no lock existed, Err with the refusal reason otherwise.
 pub(crate) fn try_remove_stale_lock() -> Result<bool, String> {
-    try_remove_stale_lock_at(&db_path().join("db.lck"))
+    remove_if_holderless(&db_path().join("db.lck"), find_lock_holder)
 }
 
-fn try_remove_stale_lock_at(lock: &Path) -> Result<bool, String> {
+fn remove_if_holderless(lock: &Path, scan: impl Fn(&Path) -> Holder) -> Result<bool, String> {
     if !lock.exists() {
         return Ok(false);
     }
@@ -115,8 +159,14 @@ fn try_remove_stale_lock_at(lock: &Path) -> Result<bool, String> {
 
     let before = lock_identity(&canonical).ok_or("Could not stat lock file")?;
 
-    if let Some(proc) = find_lock_holder(&canonical) {
-        return Err(format!("Database in use by {}", proc));
+    match scan(&canonical) {
+        Holder::Process(proc) => return Err(format!("Database in use by {}", proc)),
+        Holder::Unknown => {
+            return Err(
+                "Could not determine whether the database is in use; not removing".to_string(),
+            );
+        }
+        Holder::None => {}
     }
 
     // db.lck is an O_EXCL presence lock: it can't be acquired while it exists, so
@@ -136,12 +186,38 @@ fn try_remove_stale_lock_at(lock: &Path) -> Result<bool, String> {
     Ok(true)
 }
 
+/// Write one line to the journal without going through stderr. This handler
+/// runs under cockpit.spawn, which collects stderr to build error messages
+/// rather than journalling it, so on success stderr reaches nobody.
+fn journal_note(message: &str) {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let Ok(mut child) = Command::new("systemd-cat")
+        .args(["-t", "cockpit-pacman", "-p", "warning"])
+        .stdin(Stdio::piped())
+        .spawn()
+    else {
+        return;
+    };
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = writeln!(stdin, "{}", message);
+    }
+    let _ = child.wait();
+}
+
 pub fn remove_stale_lock() -> Result<()> {
     let result = match try_remove_stale_lock() {
-        Ok(true) => LockRemoveResult {
-            removed: true,
-            error: None,
-        },
+        Ok(true) => {
+            journal_note(
+                "cleared stale pacman database lock: a package transaction was interrupted \
+                 before it could finish",
+            );
+            LockRemoveResult {
+                removed: true,
+                error: None,
+            }
+        }
         Ok(false) => LockRemoveResult {
             removed: false,
             error: Some("No lock file exists".to_string()),
@@ -157,23 +233,81 @@ pub fn remove_stale_lock() -> Result<()> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use super::{find_lock_holder, lock_identity, try_remove_stale_lock_at};
+    use super::{
+        Holder, find_lock_holder, lock_identity, remove_if_holderless, scan_error_hides_a_holder,
+    };
     use std::fs::File;
+
+    #[test]
+    fn only_a_vanished_process_proves_it_is_not_the_holder() {
+        use std::io::{Error, ErrorKind};
+
+        assert!(!scan_error_hides_a_holder(&Error::from(
+            ErrorKind::NotFound
+        )));
+
+        for kind in [
+            ErrorKind::PermissionDenied,
+            ErrorKind::OutOfMemory,
+            ErrorKind::Other,
+        ] {
+            assert!(
+                scan_error_hides_a_holder(&Error::from(kind)),
+                "{kind:?} leaves the scan unable to tell"
+            );
+        }
+    }
 
     #[test]
     fn try_remove_reaps_only_a_holderless_lock() {
         let path = std::env::temp_dir().join(format!("db-lck-reap-{}", std::process::id()));
 
-        assert_eq!(try_remove_stale_lock_at(&path), Ok(false));
+        assert_eq!(remove_if_holderless(&path, find_lock_holder), Ok(false));
 
         let file = File::create(&path).unwrap();
-        let err = try_remove_stale_lock_at(&path).unwrap_err();
+        let err = remove_if_holderless(&path, find_lock_holder).unwrap_err();
         assert!(err.contains(&format!("(pid {})", std::process::id())));
         assert!(path.exists(), "a held lock must not be removed");
 
         drop(file);
-        assert_eq!(try_remove_stale_lock_at(&path), Ok(true));
+        assert_eq!(remove_if_holderless(&path, |_| Holder::None), Ok(true));
         assert!(!path.exists(), "a holderless lock must be removed");
+    }
+
+    #[test]
+    fn finds_a_holder_that_opened_the_lock_by_another_path() {
+        let path = std::env::temp_dir().join(format!("db-lck-alias-{}", std::process::id()));
+        let alias = std::env::temp_dir().join(format!("db-lck-alias-{}-2", std::process::id()));
+        File::create(&path).unwrap();
+        std::fs::hard_link(&path, &alias).unwrap();
+
+        let held = File::open(&alias).unwrap();
+        let found = find_lock_holder(&path.canonicalize().unwrap());
+
+        drop(held);
+        std::fs::remove_file(&alias).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        match found {
+            Holder::Process(name) => {
+                assert!(name.contains(&format!("(pid {})", std::process::id())))
+            }
+            _ => panic!("a holder that opened the same file by another path must still be found"),
+        }
+    }
+
+    #[test]
+    fn a_scan_that_saw_nothing_is_not_a_holderless_lock() {
+        let path = std::env::temp_dir().join(format!("db-lck-blind-{}", std::process::id()));
+        File::create(&path).unwrap();
+
+        let err = remove_if_holderless(&path, |_| Holder::Unknown).unwrap_err();
+
+        assert!(err.contains("Could not determine"));
+        assert!(
+            path.exists(),
+            "a lock that could not be checked must survive"
+        );
+        std::fs::remove_file(&path).unwrap();
     }
 
     #[test]
@@ -212,16 +346,15 @@ mod tests {
         let file = File::create(&path).unwrap();
         let canonical = path.canonicalize().unwrap();
 
-        let holder = find_lock_holder(&canonical);
-        assert!(holder.is_some());
-        assert!(
-            holder
-                .unwrap()
-                .contains(&format!("(pid {})", std::process::id()))
-        );
+        match find_lock_holder(&canonical) {
+            Holder::Process(name) => {
+                assert!(name.contains(&format!("(pid {})", std::process::id())))
+            }
+            _ => panic!("the scan must name the process holding the file open"),
+        }
 
         drop(file);
-        assert!(find_lock_holder(&canonical).is_none());
+        assert!(!matches!(find_lock_holder(&canonical), Holder::Process(_)));
         std::fs::remove_file(&path).unwrap();
     }
 }

--- a/backend/src/handlers/lock.rs
+++ b/backend/src/handlers/lock.rs
@@ -186,30 +186,10 @@ fn remove_if_holderless(lock: &Path, scan: impl Fn(&Path) -> Holder) -> Result<b
     Ok(true)
 }
 
-/// Write one line to the journal without going through stderr. This handler
-/// runs under cockpit.spawn, which collects stderr to build error messages
-/// rather than journalling it, so on success stderr reaches nobody.
-fn journal_note(message: &str) {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-
-    let Ok(mut child) = Command::new("systemd-cat")
-        .args(["-t", "cockpit-pacman", "-p", "warning"])
-        .stdin(Stdio::piped())
-        .spawn()
-    else {
-        return;
-    };
-    if let Some(stdin) = child.stdin.as_mut() {
-        let _ = writeln!(stdin, "{}", message);
-    }
-    let _ = child.wait();
-}
-
 pub fn remove_stale_lock() -> Result<()> {
     let result = match try_remove_stale_lock() {
         Ok(true) => {
-            journal_note(
+            crate::util::journal_note(
                 "cleared stale pacman database lock: a package transaction was interrupted \
                  before it could finish",
             );

--- a/backend/src/handlers/mirrors.rs
+++ b/backend/src/handlers/mirrors.rs
@@ -322,8 +322,6 @@ pub fn save_mirrorlist(mirrors: &[MirrorEntry]) -> Result<()> {
 
     for mirror in mirrors {
         validate_mirror_url(&mirror.url)?;
-        // A comment is written as `## {comment}`, so a newline in it ends the
-        // comment and whatever follows becomes a directive.
         if let Some(comment) = mirror.comment.as_deref().filter(|c| !c.is_empty()) {
             validate_directive_value(comment)?;
         }
@@ -360,7 +358,6 @@ pub fn save_mirrorlist(mirrors: &[MirrorEntry]) -> Result<()> {
             None
         };
 
-        // 0644 through the shared writer, not the caller's umask.
         crate::util::write_bytes_atomic_with_mode(path, content.as_bytes(), 0o644)?;
 
         // Clean up old backups, keeping only the most recent MAX_BACKUPS
@@ -569,8 +566,6 @@ mod tests {
         let path = std::env::temp_dir().join(format!("cpac-mirrors-{}", std::process::id()));
         let commented = "## Arch Linux mirrorlist\n#Server = https://a.example/$repo/os/$arch\n#Server = https://b.example/$repo/os/$arch\n";
 
-        // Two Server entries are present, so a total-based guard would let this
-        // through and restore a mirrorlist pacman cannot sync from.
         std::fs::write(&path, commented).unwrap();
         assert!(ensure_mirrors_restorable(&path).is_err());
 

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::alpm::{
     SysupgradeOutcome, TransactionGuard, Verbosity, get_handle, interrupt_if_cancelled,
-    progress_to_string, run_sysupgrade, setup_dl_cb, setup_log_cb, try_interrupt,
+    progress_to_string, run_sysupgrade, setup_dl_cb, setup_log_cb,
 };
 use crate::check_cancel_early;
 use crate::db::invalidate_repo_map_cache;
@@ -63,8 +63,8 @@ fn setup_progress_cb(handle: &mut Alpm) {
          howmany: usize,
          current: usize,
          _: &mut ()| {
+            interrupt_if_cancelled();
             if is_cancelled() {
-                try_interrupt();
                 return;
             }
             emit_event(&StreamEvent::Progress {
@@ -458,6 +458,17 @@ pub fn run_upgrade(ignore_pkgs: &[String], timeout_secs: Option<u64>) -> Result<
     setup_event_cb(&mut handle, EventScope::Upgrade);
     setup_question_cb(&mut handle, true);
 
+    if let Err(e) = handle.syncdbs_mut().update(false) {
+        emit_event(&StreamEvent::Complete {
+            success: false,
+            message: Some(format!("Failed to refresh package databases: {}", e)),
+        });
+        return Err(e.into());
+    }
+    invalidate_repo_map_cache();
+
+    check_cancel_early!(&timeout);
+
     let _inhibitor = ShutdownInhibitor::take("Applying package changes");
 
     match run_sysupgrade(&mut handle, &timeout, None)? {
@@ -522,6 +533,7 @@ pub fn run_upgrade(ignore_pkgs: &[String], timeout_secs: Option<u64>) -> Result<
 
 pub fn remove_orphans(timeout_secs: Option<u64>) -> Result<()> {
     setup_signal_handler();
+    spawn_cancel_listener();
     let timeout = TimeoutGuard::new(timeout_secs.unwrap_or(DEFAULT_MUTATION_TIMEOUT_SECS));
 
     let mut handle = get_handle()?;
@@ -590,6 +602,7 @@ pub fn remove_orphans(timeout_secs: Option<u64>) -> Result<()> {
 
 pub fn install_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
     setup_signal_handler();
+    spawn_cancel_listener();
     let timeout = TimeoutGuard::new(timeout_secs.unwrap_or(DEFAULT_MUTATION_TIMEOUT_SECS));
 
     let mut handle = get_handle()?;
@@ -654,6 +667,7 @@ pub fn install_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
 pub fn remove_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
     setup_signal_handler();
+    spawn_cancel_listener();
     let timeout = TimeoutGuard::new(timeout_secs.unwrap_or(DEFAULT_MUTATION_TIMEOUT_SECS));
 
     let mut handle = get_handle()?;

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -55,25 +55,40 @@ impl EventScope {
 }
 
 fn setup_progress_cb(handle: &mut Alpm) {
+    let mut last: Option<(&'static str, String, i32, usize, usize)> = None;
+
     handle.set_progress_cb(
         (),
-        |progress: Progress,
-         pkgname: &str,
-         percent: i32,
-         howmany: usize,
-         current: usize,
-         _: &mut ()| {
+        move |progress: Progress,
+              pkgname: &str,
+              percent: i32,
+              howmany: usize,
+              current: usize,
+              _: &mut ()| {
             interrupt_if_cancelled();
             if is_cancelled() {
                 return;
             }
+
+            let operation = progress_to_string(progress);
+            if last.as_ref().is_some_and(|(op, pkg, pct, cur, total)| {
+                *op == operation
+                    && pkg == pkgname
+                    && *pct == percent
+                    && *cur == current
+                    && *total == howmany
+            }) {
+                return;
+            }
+
             emit_event(&StreamEvent::Progress {
-                operation: progress_to_string(progress).to_string(),
+                operation: operation.to_string(),
                 package: pkgname.to_string(),
                 percent,
                 current,
                 total: howmany,
             });
+            last = Some((operation, pkgname.to_string(), percent, current, howmany));
         },
     );
 }
@@ -403,7 +418,7 @@ pub fn sync_database(force: bool, timeout_secs: Option<u64>) -> Result<()> {
     check_cancel_early!(&timeout);
 
     let mut handle = get_handle()?;
-    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_log_cb(&mut handle);
     setup_dl_cb(&mut handle, Verbosity::Streaming);
 
     match handle.syncdbs_mut().update(force) {
@@ -452,7 +467,7 @@ pub fn run_upgrade(ignore_pkgs: &[String], timeout_secs: Option<u64>) -> Result<
         })?;
     }
 
-    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_log_cb(&mut handle);
     setup_dl_cb(&mut handle, Verbosity::Streaming);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Upgrade);
@@ -560,7 +575,7 @@ pub fn remove_orphans(timeout_secs: Option<u64>) -> Result<()> {
         return Ok(());
     }
 
-    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_log_cb(&mut handle);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Remove);
 
@@ -607,7 +622,7 @@ pub fn install_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
     let mut handle = get_handle()?;
 
-    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_log_cb(&mut handle);
     setup_dl_cb(&mut handle, Verbosity::Streaming);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Install);
@@ -672,7 +687,7 @@ pub fn remove_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
 
     let mut handle = get_handle()?;
 
-    setup_log_cb(&mut handle, Verbosity::Streaming);
+    setup_log_cb(&mut handle);
     setup_progress_cb(&mut handle);
     setup_event_cb(&mut handle, EventScope::Remove);
 

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -496,8 +496,6 @@ pub fn run_upgrade(ignore_pkgs: &[String], timeout_secs: Option<u64>) -> Result<
             });
             Ok(())
         }
-        // Every package landed, and the view keys its "finished before the
-        // cancel took effect" notice off this success.
         SysupgradeOutcome::CompletedDespiteCancel { .. } => {
             emit_event(&StreamEvent::Complete {
                 success: true,

--- a/backend/src/handlers/repos.rs
+++ b/backend/src/handlers/repos.rs
@@ -29,8 +29,6 @@ pub struct Directive {
     pub kind: DirectiveKind,
     pub value: String,
     pub enabled: bool,
-    /// Comments and lines this tool does not model that sat directly above,
-    /// kept with it because that is what they describe.
     pub leading: Vec<String>,
 }
 
@@ -59,8 +57,6 @@ pub fn parse_conf(input: &str) -> PacmanConf {
     let mut preamble = String::new();
     let mut repos: Vec<RepoSection> = Vec::new();
     let mut in_repo = false;
-    // Lines seen since the last recognised directive. They describe whatever
-    // comes next, so they are held until that arrives.
     let mut pending: Vec<String> = Vec::new();
 
     for line in input.lines() {
@@ -113,7 +109,6 @@ pub fn parse_conf(input: &str) -> PacmanConf {
         let content = trimmed[hashes..].trim();
         let commented = hashes > 0;
 
-        // Inside a disabled section the serializer's own hash says nothing about what the user wanted.
         let ours = !repo.enabled && commented;
         // One hash inside a disabled section is the serializer's; a second is
         // the user's own switch for that mirror.
@@ -164,7 +159,6 @@ fn uncomment_once(trimmed: &str) -> &str {
     }
 }
 
-/// Tells a directive the serializer commented out from a comment the user typed.
 fn reads_as_setting(content: &str) -> bool {
     content.split_once('=').is_some_and(|(key, _)| {
         let key = key.trim();
@@ -210,8 +204,6 @@ pub fn serialize_conf(conf: &PacmanConf) -> String {
             output.push_str(&format!("#[{}]\n", repo.name));
         }
 
-        // A disabled section's header is commented, so any live line under it
-        // would bind to the section above; comment these too.
         let emit_raw = |output: &mut String, raw: &str| {
             if !repo.enabled {
                 output.push('#');
@@ -253,7 +245,6 @@ pub fn serialize_conf(conf: &PacmanConf) -> String {
                 DirectiveKind::Server => "Server",
                 DirectiveKind::Include => "Include",
             };
-            // Two states, two hashes: disabling the section must not erase which mirrors were off.
             if !repo.enabled {
                 output.push('#');
             }
@@ -339,7 +330,6 @@ pub fn list_repos() -> Result<()> {
     emit_json(&ListReposResponse { repos })
 }
 
-/// A section counts only when enabled with a live Server or Include.
 fn ensure_repos_usable(repos: &[RepoEntry]) -> Result<()> {
     let usable = repos
         .iter()
@@ -381,7 +371,6 @@ pub fn save_repos(repos: &[RepoEntry]) -> Result<()> {
         let original = fs::read_to_string(path)?;
         let mut conf = parse_conf(&original);
 
-        // Matched by kind and value, not position, so toggling a mirror keeps its comment.
         let mut preserved: std::collections::HashMap<String, RepoSection> =
             conf.repos.drain(..).map(|r| (r.name.clone(), r)).collect();
 
@@ -407,7 +396,6 @@ pub fn save_repos(repos: &[RepoEntry]) -> Result<()> {
                 }
             }
 
-            // A deleted directive's comment lands at the section end instead of being dropped.
             for (_, orphaned) in by_value {
                 section.trailing.extend(orphaned);
             }
@@ -423,7 +411,6 @@ pub fn save_repos(repos: &[RepoEntry]) -> Result<()> {
             None
         };
 
-        // 0644 through the shared writer, not the caller's umask.
         crate::util::write_bytes_atomic_with_mode(path, new_content.as_bytes(), 0o644)?;
 
         cleanup_old_backups();
@@ -664,8 +651,6 @@ mod save_guard {
         );
     }
 
-    /// An enabled section whose directives are all commented is just as dead:
-    /// pacman reports no servers configured for the repository.
     #[test]
     fn an_enabled_repo_with_no_live_directive_is_refused() {
         assert!(ensure_repos_usable(&[repo("core", true, false)]).is_err());
@@ -721,8 +706,6 @@ mod round_trip {
         );
     }
 
-    /// SigLevel may sit anywhere in a section. pacman does not care, but moving
-    /// it is still an unasked-for edit to someone's file.
     #[test]
     fn a_section_round_trips_unchanged_when_nothing_is_edited() {
         for conf in [
@@ -796,8 +779,6 @@ mod tests {
         let path = std::env::temp_dir().join(format!("cpac-repos-{}", std::process::id()));
         let commented = "[options]\nHoldPkg = pacman glibc\n\n#[core]\n#Include = /etc/pacman.d/mirrorlist\n\n#[extra]\n#Include = /etc/pacman.d/mirrorlist\n";
 
-        // Both sections still parse as repos, so a total-based guard would let
-        // this through and restore a pacman.conf with no package source.
         std::fs::write(&path, commented).unwrap();
         assert!(ensure_repos_restorable(&path).is_err());
 

--- a/backend/src/handlers/scheduled.rs
+++ b/backend/src/handlers/scheduled.rs
@@ -639,7 +639,6 @@ fn outcome_to_log_parts(
             Some("Upgrade interrupted during commit".to_string()),
             None,
         ),
-        // The packages are on the system, so this is not a failed run.
         SysupgradeOutcome::CompletedDespiteCancel { packages } => (
             "ok",
             *packages,

--- a/backend/src/handlers/scheduled.rs
+++ b/backend/src/handlers/scheduled.rs
@@ -450,7 +450,7 @@ pub fn scheduled_run() -> Result<()> {
         handle.add_ignorepkg(pkg_name.as_str())?;
     }
 
-    setup_log_cb(&mut handle, Verbosity::Journal);
+    setup_log_cb(&mut handle);
     setup_dl_cb(&mut handle, Verbosity::Journal);
 
     eprintln!("Syncing package databases...");

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -234,7 +234,6 @@ fn test_validate_keep_versions_invalid() {
     assert!(validate_keep_versions(u32::MAX).is_err());
 }
 
-// A newline in a mirror comment would end it and leave a directive pacman obeys.
 #[test]
 fn test_validate_directive_value_rejects_line_breaks() {
     assert!(validate_directive_value("Germany, Hetzner").is_ok());

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -288,7 +288,6 @@ pub fn emit_json<T: Serialize>(response: &T) -> Result<()> {
     Ok(())
 }
 
-/// Commented entries still count toward `total`; only `enabled` says the file can serve.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct EntryCounts {
     pub enabled: usize,
@@ -389,7 +388,6 @@ pub fn backups_to_prune(
     if entries.len() <= keep {
         return Vec::new();
     }
-    // Manual outranks automatic at any age.
     entries.sort_by_key(|(_, ts, source)| {
         (
             !matches!(source, BackupSource::Manual),
@@ -416,8 +414,6 @@ pub fn prune_old_backups(parent: &Path, name_prefix: &str, keep: usize, manifest
         }
     };
 
-    // Unlisted backups default to Manual, as the listing renders them, so one
-    // predating the manifest is protected rather than silently evictable.
     let provenance = read_backup_provenance(manifest);
     let entries: Vec<(PathBuf, i64, BackupSource)> = read_dir
         .filter_map(|entry| entry.ok())
@@ -472,7 +468,6 @@ pub fn read_backup_provenance(manifest: &Path) -> std::collections::BTreeMap<i64
         .collect()
 }
 
-/// Values stay uninterpreted, so an unknown source round-trips instead of being dropped.
 fn read_provenance_raw(manifest: &Path) -> std::collections::BTreeMap<i64, serde_json::Value> {
     std::fs::read_to_string(manifest)
         .ok()
@@ -928,7 +923,6 @@ pub(crate) fn parse_package_filename(filename: &str) -> Option<(String, String, 
     }
 }
 
-/// Ok when a cancel caused the failure, Err otherwise; only the cancel flag decides.
 pub fn handle_commit_error(
     err_msg: &str,
     cancelled: bool,

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -36,13 +36,30 @@ pub fn detected_ip_family() -> IpFamily {
 }
 
 static CANCELLED: AtomicBool = AtomicBool::new(false);
+static CHANNEL_LOST: AtomicBool = AtomicBool::new(false);
 
 pub fn is_cancelled() -> bool {
     CANCELLED.load(AtomicOrdering::SeqCst)
 }
 
+pub fn channel_lost() -> bool {
+    CHANNEL_LOST.load(AtomicOrdering::SeqCst)
+}
+
+pub fn may_interrupt_transaction() -> bool {
+    is_cancelled() && !channel_lost()
+}
+
+fn note_channel_lost() {
+    if !is_cancelled() {
+        CHANNEL_LOST.store(true, AtomicOrdering::SeqCst);
+    }
+    request_cancel();
+}
+
 pub fn reset_cancelled() {
     CANCELLED.store(false, AtomicOrdering::SeqCst);
+    CHANNEL_LOST.store(false, AtomicOrdering::SeqCst);
 }
 
 /// Only sets the flag; the alpm callbacks re-issue the interrupt on the commit
@@ -51,8 +68,6 @@ pub fn request_cancel() {
     CANCELLED.store(true, AtomicOrdering::SeqCst);
 }
 
-/// Watch stdin for a "cancel" line; EOF or read error also cancels (the
-/// channel is gone). Runs until process exit.
 pub fn spawn_cancel_listener() {
     // Off fd 0 so a libalpm scriptlet inheriting stdin can't steal the cancel
     // line; scriptlets get /dev/null, we keep a private close-on-exec dup.
@@ -79,7 +94,12 @@ pub fn spawn_cancel_listener() {
             line.clear();
             match reader.read_line(&mut line) {
                 Ok(0) | Err(_) => {
-                    request_cancel();
+                    note_channel_lost();
+                    journal_note(
+                        "control channel closed with no cancel request; \
+                         work not yet applied will stop, an upgrade already \
+                         applying will run to completion",
+                    );
                     return;
                 }
                 Ok(_) => {
@@ -90,6 +110,23 @@ pub fn spawn_cancel_listener() {
             }
         }
     });
+}
+
+pub fn journal_note(message: &str) {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let Ok(mut child) = Command::new("systemd-cat")
+        .args(["-t", "cockpit-pacman", "-p", "warning"])
+        .stdin(Stdio::piped())
+        .spawn()
+    else {
+        return;
+    };
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = writeln!(stdin, "{}", message);
+    }
+    let _ = child.wait();
 }
 
 pub const DEFAULT_MUTATION_TIMEOUT_SECS: u64 = 300;
@@ -509,7 +546,7 @@ pub fn reconcile_backup_provenance(manifest: &Path, backup_dir: &Path, name_pref
     let before = map.len();
     map.retain(|ts, _| live.contains(ts));
     if map.len() != before {
-        let _ = write_json_atomic_with_mode(manifest, &map, 0o600);
+        let _ = write_json_atomic_with_mode(manifest, &map, 0o644);
     }
 }
 
@@ -1191,6 +1228,14 @@ mod tests {
     }
 
     #[test]
+    fn a_failed_database_refresh_reads_as_a_network_error() {
+        assert_eq!(
+            classify_message("Failed to refresh package databases: failed to retrieve some files"),
+            Some("network_error")
+        );
+    }
+
+    #[test]
     fn every_classified_code_is_in_the_shared_vocabulary() {
         // classify_* return bare literals; this pins them to ERROR_CODES so the
         // backend can't emit a code the frontend doesn't know.
@@ -1225,6 +1270,48 @@ mod tests {
         super::reset_cancelled();
         super::request_cancel();
         assert!(super::is_cancelled());
+        super::reset_cancelled();
+    }
+
+    #[test]
+    fn a_user_cancel_may_interrupt_a_running_transaction() {
+        super::reset_cancelled();
+        super::request_cancel();
+        assert!(super::may_interrupt_transaction());
+        super::reset_cancelled();
+    }
+
+    #[test]
+    fn a_lost_channel_may_not_interrupt_a_running_transaction() {
+        super::reset_cancelled();
+        super::CHANNEL_LOST.store(true, super::AtomicOrdering::SeqCst);
+        super::request_cancel();
+
+        assert!(super::is_cancelled(), "still cancels work not yet applied");
+        assert!(!super::may_interrupt_transaction());
+
+        super::reset_cancelled();
+        assert!(!super::channel_lost(), "reset clears the reason too");
+    }
+
+    #[test]
+    fn a_channel_lost_after_a_user_cancel_still_may_interrupt() {
+        super::reset_cancelled();
+        super::request_cancel();
+        super::note_channel_lost();
+
+        assert!(super::may_interrupt_transaction());
+        assert!(!super::channel_lost());
+        super::reset_cancelled();
+    }
+
+    #[test]
+    fn a_channel_lost_on_its_own_may_not_interrupt() {
+        super::reset_cancelled();
+        super::note_channel_lost();
+
+        assert!(super::is_cancelled());
+        assert!(!super::may_interrupt_transaction());
         super::reset_cancelled();
     }
 

--- a/backend/tests/repos_tests.rs
+++ b/backend/tests/repos_tests.rs
@@ -146,8 +146,6 @@ CacheServer = https://cache.example.com/$repo
 fn unknown_directives_and_comments_round_trip_verbatim() {
     let parsed: PacmanConf = parse_conf(FIXTURE_EXTRAS);
     assert_eq!(
-        // They follow the last directive, so they belong to the section's tail
-        // rather than to any one line.
         parsed.repos[0].trailing,
         vec![
             "Usage = Sync Search".to_string(),

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -27,7 +27,7 @@ setup("authenticate with cockpit", async ({ page }) => {
   await page.fill("#login-password-input", password);
   await page.click("#login-button");
 
-  await expect(page.locator("#host-toggle")).toBeVisible({ timeout: 30000 });
+  await expect(page.locator("#nav-system")).toBeVisible({ timeout: 30000 });
 
   await page.context().storageState({ path: authFile });
 });

--- a/e2e/cache.spec.ts
+++ b/e2e/cache.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "./fixtures";
+
+const SIZE = /^\d+(\.\d+)? (B|KiB|MiB|GiB)$/;
+const CACHE_ROWS = 'table[aria-label="Cached packages"] > tbody > tr';
+
+test.describe("Cache Tab", () => {
+  test.beforeEach(async ({ pacman }) => {
+    await pacman.navigateToPlugin();
+    await pacman.switchTab("Cache");
+    await pacman.waitForLoading();
+  });
+
+  test("lists the packages held in the cache", async ({ pacman }) => {
+    const sizes = pacman.panel.locator(`${CACHE_ROWS} td[data-label="Size"]`);
+    await expect(sizes.first()).toBeVisible({ timeout: 30000 });
+
+    expect(await sizes.count()).toBeGreaterThan(0);
+    await expect(sizes.filter({ hasNotText: SIZE })).toHaveCount(0);
+    await expect(sizes.filter({ hasText: /^0 B$/ })).toHaveCount(0);
+  });
+
+  test("shows the versions each cached package has", async ({ pacman }) => {
+    const versions = pacman.panel.locator(`${CACHE_ROWS} td[data-label="Version"]`);
+    await expect(versions.first()).toBeVisible({ timeout: 30000 });
+
+    await expect(versions.first()).toContainText(/\d[\w.+]*-\d+/);
+  });
+
+  test("filters the cache by package name", async ({ pacman }) => {
+    const packages = pacman.panel.locator(`${CACHE_ROWS} td[data-label="Package"]`);
+    await expect(packages.first()).toBeVisible({ timeout: 30000 });
+    const name = (await packages.first().innerText()).trim();
+
+    await pacman.panel.locator('input[aria-label="Filter cached packages"]').fill(name);
+    await pacman.page.waitForTimeout(300);
+
+    expect(await packages.count()).toBeGreaterThan(0);
+    await expect(packages.filter({ hasNotText: name })).toHaveCount(0);
+  });
+
+  test("arms the clean button from the selection", async ({ pacman }) => {
+    const clean = pacman.panel.getByRole("button", { name: /^Clean/ });
+    const selectAll = pacman.panel.locator('input[aria-label="Select all packages"]');
+
+    await expect(clean).toBeEnabled({ timeout: 30000 });
+    await expect(clean).toContainText("Clean Cache");
+
+    await selectAll.uncheck();
+    await expect(clean).toBeDisabled();
+
+    await pacman.panel.locator(CACHE_ROWS).first().locator('input[type="checkbox"]').check();
+    await expect(clean).toContainText("Clean 1 package");
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,36 +1,89 @@
-import { test as base, expect, Page } from "@playwright/test";
+import { test as base, expect, FrameLocator, Locator, Page } from "@playwright/test";
 
-const PLUGIN_PATH = "/cockpit/@localhost/pacman/";
+const SHELL_PATH = "/pacman";
+const PLUGIN_FRAME = 'iframe[name*="pacman"], iframe[src*="pacman"]';
+
+async function ensureLoggedIn(page: Page) {
+  const username = process.env.COCKPIT_USER;
+  const password = process.env.COCKPIT_PASSWORD;
+  if (!username || !password) {
+    throw new Error("COCKPIT_USER and COCKPIT_PASSWORD environment variables are required");
+  }
+
+  await page.goto("/");
+  if (await page.locator("#login-user-input").isVisible().catch(() => false)) {
+    await page.fill("#login-user-input", username);
+    await page.fill("#login-password-input", password);
+    await page.click("#login-button");
+  }
+  await page.waitForSelector("#nav-system", { timeout: 30000 });
+
+  await escalate(page, password);
+}
+
+async function escalate(page: Page, password: string) {
+  const indicator = page.locator("#super-user-indicator");
+  await indicator.waitFor({ timeout: 30000 });
+  if ((await indicator.innerText()).includes("Administrative")) {
+    return;
+  }
+
+  await indicator.click();
+  const dialog = page.locator('[role="dialog"]');
+  const prompt = dialog.locator('input[type="password"]');
+  if (await prompt.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await prompt.fill(password);
+    await dialog.locator('button:has-text("Authenticate")').click();
+  }
+  await expect(indicator).toContainText("Administrative", { timeout: 15000 });
+
+  const close = dialog.locator('button:has-text("Close")');
+  if (await close.isVisible().catch(() => false)) {
+    await close.click();
+  }
+}
 
 export interface PackmanPage {
   page: Page;
+  frame: FrameLocator;
+  panel: Locator;
   navigateToPlugin: () => Promise<void>;
   switchTab: (tabName: string) => Promise<void>;
+  selectFilter: (label: string) => Promise<void>;
   waitForLoading: () => Promise<void>;
 }
 
 export const test = base.extend<{ pacman: PackmanPage }>({
   pacman: async ({ page }, use) => {
+    const frame = page.frameLocator(PLUGIN_FRAME);
+
+    const panel = frame.locator('[role="tabpanel"]:visible').first();
+
     const pacman: PackmanPage = {
       page,
+      frame,
+      panel,
 
       async navigateToPlugin() {
-        await page.goto(PLUGIN_PATH);
-        await page.waitForLoadState("networkidle");
-        await page.waitForSelector('[role="tablist"]', { timeout: 30000 });
+        await ensureLoggedIn(page);
+        await page.goto(SHELL_PATH);
+        await frame.locator('[role="tablist"]').first().waitFor({ timeout: 60000 });
       },
 
       async switchTab(tabName: string) {
-        const tabButton = page.locator(`button[role="tab"]:has-text("${tabName}")`);
-        await tabButton.click();
+        await frame.locator(`button[role="tab"]:has-text("${tabName}")`).click();
+        await page.waitForTimeout(500);
+      },
+
+      async selectFilter(label: string) {
+        await panel.locator(`.pf-v6-c-toggle-group__button:has-text("${label}")`).click();
         await page.waitForTimeout(500);
       },
 
       async waitForLoading() {
-        const spinner = page.locator(".pf-v6-c-spinner");
-        if (await spinner.isVisible()) {
-          await spinner.waitFor({ state: "hidden", timeout: 30000 });
-        }
+        const spinner = panel.locator(".pf-v6-c-spinner").first();
+        await spinner.waitFor({ state: "visible", timeout: 2000 }).catch(() => {});
+        await spinner.waitFor({ state: "hidden", timeout: 30000 });
       },
     };
 

--- a/e2e/graph.spec.ts
+++ b/e2e/graph.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type PackmanPage } from "./fixtures";
+
+const NODES = "svg g.nodes > g";
+
+async function graphFor(pacman: PackmanPage, name: string) {
+  const search = pacman.panel.getByPlaceholder("Search packages...");
+  await search.fill(name);
+  await search.press("Enter");
+  await pacman.waitForLoading();
+  await expect(pacman.panel.locator(NODES).first()).toBeAttached({ timeout: 30000 });
+}
+
+async function nodeNames(pacman: PackmanPage): Promise<string[]> {
+  const names = await pacman.panel.locator(`${NODES} text`).allTextContents();
+  return names.map((n) => n.trim()).sort();
+}
+
+test.describe("Dependency Graph", () => {
+  test.beforeEach(async ({ pacman }) => {
+    await pacman.navigateToPlugin();
+    await pacman.switchTab("Installed Packages");
+    await pacman.waitForLoading();
+    await pacman.selectFilter("Graph");
+  });
+
+  test("draws what a package depends on", async ({ pacman }) => {
+    await graphFor(pacman, "bash");
+
+    const names = await nodeNames(pacman);
+    expect(names).toContain("bash");
+    expect(names.length).toBeGreaterThan(1);
+  });
+
+  test("counts the nodes and edges it drew", async ({ pacman }) => {
+    await graphFor(pacman, "bash");
+
+    const drawn = await pacman.panel.locator(NODES).count();
+    await expect(pacman.panel.getByText(`${drawn} nodes`)).toBeVisible();
+
+    const label = await pacman.panel.getByText(/^\d+ edges$/).innerText();
+    expect(Number(label.split(" ")[0])).toBeGreaterThanOrEqual(drawn - 1);
+  });
+
+  test("reverses to what depends on a package", async ({ pacman }) => {
+    await graphFor(pacman, "bash");
+    const forward = await nodeNames(pacman);
+
+    await pacman.panel.locator('.pf-v6-c-toggle-group__button:has-text("Reverse")').click();
+    await pacman.waitForLoading();
+    await expect(pacman.panel.locator(NODES).first()).toBeAttached({ timeout: 30000 });
+
+    const reverse = await nodeNames(pacman);
+    expect(reverse).toContain("bash");
+    expect(reverse).not.toEqual(forward);
+  });
+
+  test("says so when the package does not exist", async ({ pacman }) => {
+    const search = pacman.panel.getByPlaceholder("Search packages...");
+    await search.fill("no-such-package-anywhere");
+    await search.press("Enter");
+    await pacman.waitForLoading();
+
+    await expect(pacman.panel.getByText("Package not found")).toBeVisible({ timeout: 30000 });
+    await expect(pacman.panel.locator(NODES)).toHaveCount(0);
+  });
+});

--- a/e2e/history.spec.ts
+++ b/e2e/history.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, type PackmanPage } from "./fixtures";
+
+const ACTIONS = /^(upgraded|downgraded|installed|removed|reinstalled)$/;
+
+async function showFlatEntries(pacman: PackmanPage) {
+  await pacman.panel.locator('.pf-v6-c-toggle-group__button:has-text("Flat")').click();
+  await pacman.waitForLoading();
+}
+
+test.describe("History Tab", () => {
+  test.beforeEach(async ({ pacman }) => {
+    await pacman.navigateToPlugin();
+    await pacman.switchTab("History");
+    await pacman.waitForLoading();
+  });
+
+  test("groups the log into transactions", async ({ pacman }) => {
+    const groups = pacman.panel.locator(".pf-v6-c-accordion__toggle");
+    await expect(groups.first()).toBeVisible({ timeout: 30000 });
+
+    await groups.first().click();
+    const packages = pacman.panel.locator('td[data-label="Package"]');
+    await expect(packages.first()).toBeVisible();
+    await expect(packages.first()).not.toBeEmpty();
+  });
+
+  test("names the action pacman recorded for each entry", async ({ pacman }) => {
+    await showFlatEntries(pacman);
+
+    const actions = pacman.panel.locator('td[data-label="Action"]');
+    await expect(actions.first()).toBeVisible({ timeout: 30000 });
+    await expect(actions.filter({ hasNotText: ACTIONS })).toHaveCount(0);
+  });
+
+  test("keeps only the action the filter selects", async ({ pacman }) => {
+    await showFlatEntries(pacman);
+    await pacman.panel.getByRole("button", { name: "All actions" }).click();
+    await pacman.frame.getByRole("option", { name: "Installed", exact: true }).click();
+    await pacman.waitForLoading();
+
+    const actions = pacman.panel.locator('td[data-label="Action"]');
+    await expect(actions.first()).toBeVisible({ timeout: 30000 });
+    expect(await actions.count()).toBeGreaterThan(0);
+    await expect(actions.filter({ hasNotText: /^installed$/ })).toHaveCount(0);
+  });
+
+  test("filters by package name", async ({ pacman }) => {
+    await showFlatEntries(pacman);
+    await pacman.panel.locator('input[aria-label="Filter history by package name"]').fill("pacman");
+    await pacman.waitForLoading();
+
+    const packages = pacman.panel.locator('td[data-label="Package"]');
+    await expect(packages.first()).toBeVisible({ timeout: 30000 });
+    await expect(packages.filter({ hasNotText: /pacman/ })).toHaveCount(0);
+  });
+
+  test("pages through the log", async ({ pacman }) => {
+    await showFlatEntries(pacman);
+    const packages = pacman.panel.locator('td[data-label="Package"]');
+    await expect(packages.first()).toBeVisible({ timeout: 30000 });
+    const firstOnPageOne = await packages.first().innerText();
+
+    await pacman.panel.getByRole("button", { name: "Go to next page" }).first().click();
+    await pacman.waitForLoading();
+    await expect(packages.first()).not.toHaveText(firstOnPageOne);
+  });
+});

--- a/e2e/installed.spec.ts
+++ b/e2e/installed.spec.ts
@@ -9,10 +9,10 @@ test.describe("Installed Packages Tab", () => {
   test("displays installed packages list", async ({ pacman }) => {
     await pacman.waitForLoading();
 
-    const table = pacman.page.locator("table");
+    const table = pacman.panel.locator("table").first();
     await expect(table).toBeVisible();
 
-    const rows = pacman.page.locator("table tbody tr");
+    const rows = pacman.panel.locator("table tbody tr");
     const count = await rows.count();
     expect(count).toBeGreaterThan(0);
   });
@@ -20,62 +20,62 @@ test.describe("Installed Packages Tab", () => {
   test("shows package count in pagination", async ({ pacman }) => {
     await pacman.waitForLoading();
 
-    const pagination = pacman.page.locator('[class*="pagination"]');
+    const pagination = pacman.panel.locator('[class*="pagination"]').first();
     await expect(pagination).toBeVisible();
   });
 
-  test("can search for packages", async ({ pacman }) => {
+  test("narrows the list when searching", async ({ pacman }) => {
     await pacman.waitForLoading();
 
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+    const rows = pacman.panel.locator("table tbody tr");
+    const before = await rows.count();
+    expect(before).toBeGreaterThan(0);
+
+    const searchInput = pacman.panel
+      .locator('input[type="search"], input[placeholder*="Search"]')
+      .first();
     await expect(searchInput).toBeVisible();
-
     await searchInput.fill("linux");
-    await pacman.page.waitForTimeout(500);
-
     await pacman.waitForLoading();
 
-    const table = pacman.page.locator("table");
-    await expect(table).toBeVisible();
+    await expect(rows.first()).toBeVisible();
+    await expect.poll(() => rows.count()).toBeLessThan(before);
+    expect(await rows.count()).toBeGreaterThan(0);
   });
 
-  test("can filter by install reason", async ({ pacman }) => {
+  test("shows only explicit packages under the Explicit filter", async ({ pacman }) => {
+    await pacman.waitForLoading();
+    await pacman.selectFilter("Explicit");
     await pacman.waitForLoading();
 
-    const filterDropdown = pacman.page.locator('[class*="select"], [class*="dropdown"]').first();
-    if (await filterDropdown.isVisible()) {
-      await filterDropdown.click();
+    const reasons = pacman.panel.locator('td[data-label="Reason"]');
+    await expect(reasons.first()).toBeVisible();
 
-      const explicitOption = pacman.page.locator('button:has-text("Explicit"), [role="option"]:has-text("Explicit")');
-      if (await explicitOption.isVisible()) {
-        await explicitOption.click();
-        await pacman.waitForLoading();
-      }
+    const count = await reasons.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(reasons.nth(i)).toHaveText("explicit");
     }
   });
 
   test("can click on package to view details", async ({ pacman }) => {
     await pacman.waitForLoading();
 
-    const firstRow = pacman.page.locator("table tbody tr").first();
+    const firstRow = pacman.panel.locator("table tbody tr").first();
     await firstRow.click();
 
-    const modal = pacman.page.locator('[class*="modal"], [role="dialog"]');
+    const modal = pacman.frame.locator('[class*="modal"], [role="dialog"]').first();
     await expect(modal).toBeVisible({ timeout: 10000 });
   });
 
-  test("can change page size", async ({ pacman }) => {
+  test("renders one page rather than every installed package", async ({ pacman }) => {
     await pacman.waitForLoading();
 
-    const perPageDropdown = pacman.page.locator('[class*="per-page"], [class*="options-menu"]');
-    if (await perPageDropdown.isVisible()) {
-      await perPageDropdown.click();
+    const rows = pacman.panel.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible();
+    const shown = await rows.count();
 
-      const option100 = pacman.page.locator('[role="option"]:has-text("100")');
-      if (await option100.isVisible()) {
-        await option100.click();
-        await pacman.waitForLoading();
-      }
-    }
+    expect(shown).toBeGreaterThan(0);
+    expect(shown).toBeLessThanOrEqual(100);
   });
 });

--- a/e2e/keyring.spec.ts
+++ b/e2e/keyring.spec.ts
@@ -4,61 +4,33 @@ test.describe("Keyring Tab", () => {
   test.beforeEach(async ({ pacman }) => {
     await pacman.navigateToPlugin();
     await pacman.switchTab("Keyring");
+    await pacman.waitForLoading();
   });
 
-  test("displays keyring status", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const tableOrEmptyState = pacman.page.locator('table, [class*="empty-state"]');
-    await expect(tableOrEmptyState).toBeVisible({ timeout: 30000 });
+  test("lists the keys pacman trusts", async ({ pacman }) => {
+    const rows = pacman.panel.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 30000 });
+    expect(await rows.count()).toBeGreaterThan(0);
   });
 
-  test("shows key list when initialized", async ({ pacman }) => {
-    await pacman.waitForLoading();
+  test("shows a fingerprint for each key", async ({ pacman }) => {
+    const fingerprints = pacman.panel.locator('td[data-label="Fingerprint"]');
+    await expect(fingerprints.first()).toBeVisible({ timeout: 30000 });
 
-    const table = pacman.page.locator("table");
-    const emptyState = pacman.page.locator('[class*="empty-state"]');
-
-    const hasTable = await table.isVisible().catch(() => false);
-    const hasEmptyState = await emptyState.isVisible().catch(() => false);
-
-    expect(hasTable || hasEmptyState).toBe(true);
+    await expect(fingerprints.first()).toHaveText(/^[0-9A-Fa-f]{40}$/);
   });
 
-  test("displays key fingerprints", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const table = pacman.page.locator("table");
-    if (await table.isVisible()) {
-      const fingerprintCell = pacman.page.locator("td").first();
-      await expect(fingerprintCell).toBeVisible();
-    }
+  test("offers to refresh the keys", async ({ pacman }) => {
+    await expect(
+      pacman.panel.getByRole("button", { name: /^Refresh$/i })
+    ).toBeVisible({ timeout: 30000 });
   });
 
-  test("shows refresh keyring button", async ({ pacman }) => {
-    await pacman.waitForLoading();
+  test("paginates a keyring larger than one page", async ({ pacman }) => {
+    const rows = pacman.panel.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 30000 });
 
-    const refreshButton = pacman.page.locator('button:has-text("Refresh")');
-    const initButton = pacman.page.locator('button:has-text("Initialize")');
-
-    const hasRefresh = await refreshButton.isVisible().catch(() => false);
-    const hasInit = await initButton.isVisible().catch(() => false);
-
-    expect(hasRefresh || hasInit).toBe(true);
-  });
-
-  test("has pagination when many keys", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const table = pacman.page.locator("table");
-    if (await table.isVisible()) {
-      const rows = pacman.page.locator("table tbody tr");
-      const count = await rows.count();
-
-      if (count > 10) {
-        const pagination = pacman.page.locator('[class*="pagination"]');
-        await expect(pagination).toBeVisible();
-      }
-    }
+    await expect(pacman.panel.locator('[class*="pagination"]').first()).toBeVisible();
+    expect(await rows.count()).toBeLessThanOrEqual(100);
   });
 });

--- a/e2e/mirrors.spec.ts
+++ b/e2e/mirrors.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Mirrors Tab", () => {
+  test.beforeEach(async ({ pacman }) => {
+    await pacman.navigateToPlugin();
+    await pacman.switchTab("Mirrors");
+    await pacman.panel.locator('table[aria-label="Mirror list"]').waitFor({ timeout: 60000 });
+  });
+
+  test("lists the mirrors the mirrorlist defines", async ({ pacman }) => {
+    const urls = pacman.panel.locator('td[data-label="URL"]');
+    await expect(urls.first()).toBeVisible({ timeout: 30000 });
+
+    const count = await urls.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(urls.nth(i)).toContainText(/https?:\/\/\S+/);
+    }
+  });
+
+  test("marks which mirrors pacman will use", async ({ pacman }) => {
+    const switches = pacman.panel.locator('input[type="checkbox"][aria-label^="Enable mirror"]');
+    await expect(switches.first()).toBeAttached({ timeout: 30000 });
+
+    const enabled = pacman.panel.locator(
+      'tr:has(input[type="checkbox"][aria-label^="Enable mirror"]:checked)'
+    );
+    expect(await enabled.count()).toBeGreaterThan(0);
+  });
+
+  test("filters the list by URL", async ({ pacman }) => {
+    const urls = pacman.panel.locator('td[data-label="URL"]');
+    await expect(urls.first()).toBeVisible({ timeout: 30000 });
+
+    const host = (await urls.first().innerText()).match(/https?:\/\/([^/\s]+)/)?.[1];
+    expect(host).toBeTruthy();
+
+    await pacman.panel.locator('input[aria-label="Search mirrors"]').fill(host!);
+    await pacman.page.waitForTimeout(300);
+
+    const remaining = await urls.count();
+    expect(remaining).toBeGreaterThan(0);
+    for (let i = 0; i < remaining; i++) {
+      await expect(urls.nth(i)).toContainText(host!);
+    }
+  });
+
+  test("does not offer to write a mirrorlist nothing has changed", async ({ pacman }) => {
+    await expect(pacman.panel.getByRole("button", { name: "Save Changes" })).toBeDisabled({
+      timeout: 30000,
+    });
+  });
+});

--- a/e2e/orphans.spec.ts
+++ b/e2e/orphans.spec.ts
@@ -3,70 +3,44 @@ import { test, expect } from "./fixtures";
 test.describe("Orphans Tab", () => {
   test.beforeEach(async ({ pacman }) => {
     await pacman.navigateToPlugin();
-    await pacman.switchTab("Orphans");
+    await pacman.switchTab("Installed Packages");
+    await pacman.selectFilter("Orphans");
+    await pacman.waitForLoading();
   });
 
-  test("displays orphans view", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const tableOrEmptyState = pacman.page.locator('table, [class*="empty-state"]');
-    await expect(tableOrEmptyState).toBeVisible({ timeout: 30000 });
+  test("lists the orphaned packages", async ({ pacman }) => {
+    const rows = pacman.panel.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 30000 });
+    expect(await rows.count()).toBeGreaterThan(0);
   });
 
-  test("shows orphan count or empty state", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const table = pacman.page.locator("table");
-    const emptyState = pacman.page.locator('[class*="empty-state"], text="No orphan"');
-
-    const hasTable = await table.isVisible().catch(() => false);
-    const hasEmptyState = await emptyState.isVisible().catch(() => false);
-
-    expect(hasTable || hasEmptyState).toBe(true);
+  test("names and versions every orphan", async ({ pacman }) => {
+    await expect(pacman.panel.locator('td[data-label="Package"]').first()).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(pacman.panel.locator('td[data-label="Version"]').first()).not.toBeEmpty();
   });
 
-  test("displays total size of orphans", async ({ pacman }) => {
-    await pacman.waitForLoading();
+  test("reports how much space removing them frees", async ({ pacman }) => {
+    const spaceToFree = pacman.panel.locator("text=Space to Free");
+    await expect(spaceToFree).toBeVisible({ timeout: 30000 });
 
-    const table = pacman.page.locator("table");
-    if (await table.isVisible()) {
-      const sizeText = pacman.page.locator('text=/\\d+(\\.\\d+)?\\s*(B|KiB|MiB|GiB)/');
-      await expect(sizeText.first()).toBeVisible();
-    }
+    await expect(
+      pacman.panel.locator("text=/\\d+(\\.\\d+)?\\s*(B|KiB|MiB|GiB)/").first()
+    ).toBeVisible();
   });
 
-  test("shows remove button when orphans exist", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const table = pacman.page.locator("table");
-    if (await table.isVisible()) {
-      const removeButton = pacman.page.locator('button:has-text("Remove"), button:has-text("Clean")');
-      await expect(removeButton).toBeVisible();
-    }
+  test("offers to remove them", async ({ pacman }) => {
+    await expect(
+      pacman.panel.getByRole("button", { name: /Remove All Orphans/i })
+    ).toBeVisible({ timeout: 30000 });
   });
 
-  test("lists orphan package details", async ({ pacman }) => {
-    await pacman.waitForLoading();
+  test("opens details for an orphan", async ({ pacman }) => {
+    await pacman.panel.locator("table tbody tr").first().click();
 
-    const table = pacman.page.locator("table");
-    if (await table.isVisible()) {
-      const nameHeader = pacman.page.locator('th:has-text("Name")');
-      const versionHeader = pacman.page.locator('th:has-text("Version")');
-
-      await expect(nameHeader).toBeVisible();
-      await expect(versionHeader).toBeVisible();
-    }
-  });
-
-  test("can click on orphan to view details", async ({ pacman }) => {
-    await pacman.waitForLoading();
-
-    const firstRow = pacman.page.locator("table tbody tr").first();
-    if (await firstRow.isVisible()) {
-      await firstRow.click();
-
-      const modal = pacman.page.locator('[class*="modal"], [role="dialog"]');
-      await expect(modal).toBeVisible({ timeout: 10000 });
-    }
+    await expect(
+      pacman.frame.locator('[class*="modal"], [role="dialog"]').first()
+    ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/repositories.spec.ts
+++ b/e2e/repositories.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "./fixtures";
+
+const REPO_ROWS = 'table[aria-label="Repository list"] > tbody > tr';
+
+test.describe("Repositories Tab", () => {
+  test.beforeEach(async ({ pacman }) => {
+    await pacman.navigateToPlugin();
+    await pacman.switchTab("Repositories");
+    await pacman.waitForLoading();
+  });
+
+  test("lists the repositories pacman.conf defines", async ({ pacman }) => {
+    const names = pacman.panel.locator(`${REPO_ROWS} td[data-label="Repository"]`);
+    await expect(names.first()).toBeVisible({ timeout: 30000 });
+
+    await expect(names.filter({ hasText: "[core]" })).toHaveCount(1);
+  });
+
+  test("counts the servers each repository has", async ({ pacman }) => {
+    const core = pacman.panel.locator(REPO_ROWS, { hasText: "[core]" }).first();
+    await expect(core).toBeVisible({ timeout: 30000 });
+
+    await expect(core.locator('td[data-label="Servers"]')).toHaveText(/^[1-9]\d*$/);
+  });
+
+  test("expands a repository to the directives behind it", async ({ pacman }) => {
+    const core = pacman.panel.locator(REPO_ROWS, { hasText: "[core]" }).first();
+    await expect(core).toBeVisible({ timeout: 30000 });
+    await core.getByRole("button", { name: "Expand core" }).click();
+
+    const directives = pacman.panel.locator('table[aria-label="Directives for core"] tbody tr');
+    const values = directives.locator('td[data-label="Value"]');
+    await expect(values.first()).toBeVisible();
+
+    const existing = await values.count() - 1;
+    expect(existing).toBeGreaterThan(0);
+    for (let i = 0; i < existing; i++) {
+      await expect(values.nth(i)).toHaveText(/^(https?:\/\/|\/)\S+/);
+    }
+  });
+
+  test("does not offer to write a pacman.conf nothing has changed", async ({ pacman }) => {
+    const save = pacman.panel.getByRole("button", { name: "Save Changes" });
+    await expect(save).toBeDisabled({ timeout: 30000 });
+
+    const core = pacman.panel.locator(REPO_ROWS, { hasText: "[core]" }).first();
+    await core.locator('label:has(input[aria-label="Enable repository core"])').click();
+    await expect(save).toBeEnabled();
+  });
+});

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -7,80 +7,91 @@ test.describe("Search Packages Tab", () => {
   });
 
   test("displays search input", async ({ pacman }) => {
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+    const searchInput = pacman.panel.locator('input[type="search"], input[placeholder*="Search"]').first();
     await expect(searchInput).toBeVisible();
   });
 
   test("shows empty state before search", async ({ pacman }) => {
-    const emptyState = pacman.page.locator('[class*="empty-state"], text="Enter a search"');
-    const isEmptyStateVisible = await emptyState.isVisible().catch(() => false);
-    expect(isEmptyStateVisible).toBe(true);
+    const emptyState = pacman.panel.locator('[class*="empty-state"]').first();
+    await expect(emptyState).toBeVisible({ timeout: 30000 });
   });
 
   test("can search for packages", async ({ pacman }) => {
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+    const searchInput = pacman.panel.locator('input[type="search"], input[placeholder*="Search"]').first();
     await searchInput.fill("vim");
 
     await pacman.page.waitForTimeout(500);
     await pacman.waitForLoading();
 
-    const results = pacman.page.locator("table tbody tr");
+    const results = pacman.panel.locator("table tbody tr");
     const count = await results.count();
     expect(count).toBeGreaterThan(0);
   });
 
   test("shows repository column in results", async ({ pacman }) => {
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+    const searchInput = pacman.panel.locator('input[type="search"], input[placeholder*="Search"]').first();
     await searchInput.fill("python");
 
     await pacman.page.waitForTimeout(500);
     await pacman.waitForLoading();
 
-    const repoHeader = pacman.page.locator('th:has-text("Repository")');
+    const repoHeader = pacman.panel.locator('th:has-text("Repository")');
     await expect(repoHeader).toBeVisible();
   });
 
-  test("indicates installed packages in results", async ({ pacman }) => {
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+  test("marks each result installed or not installed", async ({ pacman }) => {
+    const searchInput = pacman.panel
+      .locator('input[type="search"], input[placeholder*="Search"]')
+      .first();
     await searchInput.fill("bash");
-
-    await pacman.page.waitForTimeout(500);
     await pacman.waitForLoading();
 
-    const table = pacman.page.locator("table");
-    await expect(table).toBeVisible();
+    const statuses = pacman.panel.locator('td[data-label="Status"]');
+    await expect(statuses.first()).toBeVisible();
+
+    const count = await statuses.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(statuses.nth(i)).toHaveText(/Installed|Not installed/);
+    }
+    await expect(pacman.panel.locator('td[data-label="Status"]', { hasText: /^Installed/ }).first())
+      .toBeVisible();
   });
 
-  test("can filter by installation status", async ({ pacman }) => {
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+  test("drops uninstalled results under the Installed filter", async ({ pacman }) => {
+    const searchInput = pacman.panel
+      .locator('input[type="search"], input[placeholder*="Search"]')
+      .first();
     await searchInput.fill("git");
-
-    await pacman.page.waitForTimeout(500);
     await pacman.waitForLoading();
 
-    const filterDropdown = pacman.page.locator('[class*="select"]').first();
-    if (await filterDropdown.isVisible()) {
-      await filterDropdown.click();
+    await pacman.panel
+      .locator('.pf-v6-c-toggle-group__button:has-text("Installed")')
+      .first()
+      .click();
+    await pacman.waitForLoading();
 
-      const installedOption = pacman.page.locator('[role="option"]:has-text("Installed")');
-      if (await installedOption.isVisible()) {
-        await installedOption.click();
-        await pacman.waitForLoading();
-      }
+    const statuses = pacman.panel.locator('td[data-label="Status"]');
+    await expect(statuses.first()).toBeVisible();
+
+    const count = await statuses.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(statuses.nth(i)).toHaveText(/^Installed/);
     }
   });
 
   test("can click on result to view details", async ({ pacman }) => {
-    const searchInput = pacman.page.locator('input[type="search"], input[placeholder*="Search"]');
+    const searchInput = pacman.panel.locator('input[type="search"], input[placeholder*="Search"]').first();
     await searchInput.fill("pacman");
 
     await pacman.page.waitForTimeout(500);
     await pacman.waitForLoading();
 
-    const firstRow = pacman.page.locator("table tbody tr").first();
+    const firstRow = pacman.panel.locator("table tbody tr").first();
     await firstRow.click();
 
-    const modal = pacman.page.locator('[class*="modal"], [role="dialog"]');
+    const modal = pacman.frame.locator('[class*="modal"], [role="dialog"]').first();
     await expect(modal).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/signoffs.spec.ts
+++ b/e2e/signoffs.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "./fixtures";
+
+const SIGNOFFS_TAB = 'button[role="tab"]:has-text("Signoffs")';
+
+test.describe("Signoffs Tab", () => {
+  test.beforeEach(async ({ pacman }) => {
+    await pacman.navigateToPlugin();
+  });
+
+  test("hides signoffs from a session with no archweb credentials", async ({ pacman }) => {
+    const tab = pacman.frame.locator(SIGNOFFS_TAB);
+    test.skip(await tab.count() > 0, "this session has archweb credentials");
+
+    await expect(pacman.frame.getByRole("button", { name: /signoff/i })).toHaveCount(0);
+  });
+
+  test("lists the packages awaiting signoff", async ({ pacman }) => {
+    const tab = pacman.frame.locator(SIGNOFFS_TAB);
+    test.skip(await tab.count() === 0, "no archweb credentials in the session keyring");
+
+    await tab.click();
+    await pacman.waitForLoading();
+
+    const rows = pacman.panel.locator('table[aria-label="Signoff packages"] > tbody > tr');
+    test.skip(await rows.count() === 0, "nothing is awaiting signoff right now");
+
+    const counts = pacman.panel.locator('td[data-label="Signoffs"]');
+    await expect(counts.filter({ hasNotText: /^\d+ \/ \d+$/ })).toHaveCount(0);
+
+    const statuses = pacman.panel.locator('td[data-label="Status"]');
+    await expect(statuses.filter({ hasNotText: /^(Pending|Approved|Known Bad)$/ })).toHaveCount(0);
+  });
+});

--- a/e2e/unescalated.spec.ts
+++ b/e2e/unescalated.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, type Page } from "@playwright/test";
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const PLUGIN_FRAME = 'iframe[name*="pacman"], iframe[src*="pacman"]';
+
+async function openPluginUnescalated(page: Page) {
+  const username = process.env.COCKPIT_USER;
+  const password = process.env.COCKPIT_PASSWORD;
+  if (!username || !password) {
+    throw new Error("COCKPIT_USER and COCKPIT_PASSWORD are required");
+  }
+
+  await page.goto("/");
+  await page.fill("#login-user-input", username);
+  await page.fill("#login-password-input", password);
+  await page.click("#login-button");
+  await page.waitForSelector("#nav-system", { timeout: 30000 });
+
+  await page.goto("/pacman");
+  const frame = page.frameLocator(PLUGIN_FRAME);
+  await frame.locator('[role="tablist"]').first().waitFor({ timeout: 60000 });
+  return frame;
+}
+
+test.describe("unescalated session", () => {
+  test("reads every view that does not need root", async ({ page }) => {
+    const frame = await openPluginUnescalated(page);
+
+    const panel = frame.locator('[role="tabpanel"]:visible').first();
+
+    for (const tab of ["Installed Packages", "History", "Cache", "Mirrors", "Repositories"]) {
+      await frame.locator(`button[role="tab"]:has-text("${tab}")`).click();
+      await page.waitForTimeout(800);
+      await expect(panel).not.toContainText("Not permitted", { timeout: 15000 });
+    }
+  });
+
+  test("does not offer to initialize a keyring it cannot read", async ({ page }) => {
+    const frame = await openPluginUnescalated(page);
+    await frame.locator('button[role="tab"]:has-text("Keyring")').click();
+
+    await expect(frame.getByText(/could not be determined/i)).toBeVisible({ timeout: 15000 });
+    await expect(frame.getByRole("button", { name: /Initialize Keyring/i })).toHaveCount(0);
+  });
+});

--- a/e2e/updates.spec.ts
+++ b/e2e/updates.spec.ts
@@ -6,42 +6,30 @@ test.describe("Updates Tab", () => {
   });
 
   test("displays updates tab by default", async ({ pacman }) => {
-    const updatesTab = pacman.page.locator('button[role="tab"]:has-text("Updates")');
+    const updatesTab = pacman.frame.locator('button[role="tab"]:has-text("Updates")');
     await expect(updatesTab).toHaveAttribute("aria-selected", "true");
   });
 
-  test("shows check for updates button", async ({ pacman }) => {
+  test("resolves to either a pending list or the up-to-date state", async ({ pacman }) => {
     await pacman.waitForLoading();
-    const checkButton = pacman.page.locator('button:has-text("Check for Updates")');
-    await expect(checkButton).toBeVisible();
+
+    const updateTable = pacman.panel.locator("table").first();
+    const upToDate = pacman.panel.locator('text="System is up to date"');
+
+    await expect(updateTable.or(upToDate).first()).toBeVisible({ timeout: 60000 });
   });
 
-  test("can check for updates", async ({ pacman }) => {
+  test("does not surface a permission error", async ({ pacman }) => {
     await pacman.waitForLoading();
-    const checkButton = pacman.page.locator('button:has-text("Check for Updates")');
-    await checkButton.click();
 
-    const spinner = pacman.page.locator(".pf-v6-c-spinner");
-    await expect(spinner).toBeVisible();
-
-    await spinner.waitFor({ state: "hidden", timeout: 60000 });
-
-    const content = pacman.page.locator('[class*="updates"]');
-    await expect(content).toBeVisible();
+    await expect(pacman.panel.locator('text="Not permitted to perform this action."'))
+      .toHaveCount(0);
   });
 
-  test("displays update count or no updates message", async ({ pacman }) => {
-    await pacman.waitForLoading();
-    const checkButton = pacman.page.locator('button:has-text("Check for Updates")');
-    await checkButton.click();
+  test("shows the system overview counters", async ({ pacman }) => {
     await pacman.waitForLoading();
 
-    const noUpdates = pacman.page.locator('text="System is up to date"');
-    const updateList = pacman.page.locator("table");
-
-    const hasNoUpdates = await noUpdates.isVisible().catch(() => false);
-    const hasUpdateList = await updateList.isVisible().catch(() => false);
-
-    expect(hasNoUpdates || hasUpdateList).toBe(true);
+    const overview = pacman.panel.locator('text="System Overview"');
+    await expect(overview).toBeVisible({ timeout: 30000 });
   });
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,31 @@ export default [
     },
   },
   {
+    files: ["e2e/**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
+      "no-unused-vars": "off",
+    },
+  },
+  {
     ignores: ["dist/", "node_modules/", "*.config.js", "src/bindings/", "backend/"],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/d3-selection": "^3.0.11",
         "@types/d3-transition": "^3.0.9",
         "@types/d3-zoom": "^3.0.8",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.59.2",
@@ -1473,9 +1474,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1493,9 +1491,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1513,9 +1508,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1533,9 +1525,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1553,9 +1542,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1573,9 +1559,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1857,6 +1840,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -4930,9 +4923,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4954,9 +4944,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4978,9 +4965,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5002,9 +4986,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6508,6 +6489,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "esbuild src/index.tsx --bundle --outfile=dist/index.js --minify --sourcemap --target=es2020 --loader:.tsx=tsx --loader:.ts=ts --loader:.woff2=dataurl --loader:.woff=dataurl --loader:.ttf=dataurl --loader:.svg=dataurl --loader:.eot=dataurl",
     "watch": "esbuild src/index.tsx --bundle --outfile=dist/index.js --sourcemap --target=es2020 --loader:.tsx=tsx --loader:.ts=ts --loader:.woff2=dataurl --loader:.woff=dataurl --loader:.ttf=dataurl --loader:.svg=dataurl --loader:.eot=dataurl --watch",
-    "typecheck": "tsc --noEmit",
-    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json",
+    "lint": "eslint src/ e2e/",
     "lint:fix": "eslint src/ --fix",
     "test": "LC_ALL=C.UTF-8 vitest run",
     "test:watch": "vitest",
@@ -37,6 +37,7 @@
     "@types/d3-selection": "^3.0.11",
     "@types/d3-transition": "^3.0.9",
     "@types/d3-zoom": "^3.0.8",
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.59.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     },
     {
       name: "chromium",
+      testIgnore: /shots\.spec\.ts/,
       use: {
         ...devices["Desktop Chrome"],
         storageState: ".auth/session.json",

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -8,6 +8,7 @@ import {
   createMockSpawnPromise,
   createMockStreamingProcess,
 } from "./test/mocks";
+import { STREAM_FIRST_OUTPUT_TIMEOUT_MS } from "./constants";
 import {
   formatSize,
   listInstalled,
@@ -77,7 +78,7 @@ describe("listInstalled", () => {
         "",
         "",
       ],
-      { superuser: "try", err: "message" }
+      { err: "message" }
     );
     expect(result.packages).toHaveLength(2);
     expect(result.total).toBe(2);
@@ -110,7 +111,7 @@ describe("listInstalled", () => {
         "name",
         "desc",
       ],
-      { superuser: "try", err: "message" }
+      { err: "message" }
     );
   });
 
@@ -199,7 +200,7 @@ describe("checkUpdates", () => {
         "/usr/libexec/cockpit-pacman/cockpit-pacman-backend",
         "check-updates",
       ],
-      { superuser: "try", err: "message" }
+      { err: "message" }
     );
     expect(result.updates).toHaveLength(1);
     expect(result.updates[0].name).toBe("linux");
@@ -224,7 +225,7 @@ describe("getPackageInfo", () => {
         "local-package-info",
         "linux",
       ],
-      { superuser: "try", err: "message" }
+      { err: "message" }
     );
     expect(result.name).toBe("linux");
     expect(result.licenses).toContain("GPL-2.0-only");
@@ -254,7 +255,7 @@ describe("searchPackages", () => {
         "",
         "",
       ],
-      { superuser: "try", err: "message" }
+      { err: "message" }
     );
     expect(result.results).toHaveLength(2);
     expect(result.total).toBe(2);
@@ -287,6 +288,49 @@ describe("runUpgrade", () => {
     expect(callbacks.onError).not.toHaveBeenCalled();
   });
 
+  it("fails a stream that never produces any output", () => {
+    vi.useFakeTimers();
+    try {
+      const mockProc = createMockStreamingProcess();
+      const close = vi.fn();
+      mockProc.close = close;
+      mockSpawn.mockReturnValue(mockProc);
+
+      const callbacks = { onComplete: vi.fn(), onError: vi.fn() };
+      runUpgrade(callbacks);
+
+      vi.advanceTimersByTime(STREAM_FIRST_OUTPUT_TIMEOUT_MS + 1);
+
+      expect(callbacks.onError).toHaveBeenCalledTimes(1);
+      expect(callbacks.onError.mock.calls[0][1]).toBe("timeout");
+      expect(close).toHaveBeenCalled();
+      expect(callbacks.onComplete).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not time out once the stream has produced output", () => {
+    vi.useFakeTimers();
+    try {
+      const mockProc = createMockStreamingProcess();
+      mockSpawn.mockReturnValue(mockProc);
+
+      const callbacks = { onComplete: vi.fn(), onError: vi.fn(), onData: vi.fn() };
+      runUpgrade(callbacks);
+
+      mockProc._emit(JSON.stringify({ type: "log", level: "info", message: "working" }) + "\n");
+      vi.advanceTimersByTime(STREAM_FIRST_OUTPUT_TIMEOUT_MS * 10);
+
+      expect(callbacks.onError).not.toHaveBeenCalled();
+
+      mockProc._emit(JSON.stringify({ type: "complete", success: true }) + "\n");
+      expect(callbacks.onComplete).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("calls onError when receiving failed complete event", () => {
     const mockProc = createMockStreamingProcess();
     mockSpawn.mockReturnValue(mockProc);
@@ -305,7 +349,7 @@ describe("runUpgrade", () => {
     };
     mockProc._emit(JSON.stringify(completeEvent) + "\n");
 
-    expect(callbacks.onError).toHaveBeenCalledWith("Package conflict", "internal_error");
+    expect(callbacks.onError).toHaveBeenCalledWith("Package conflict", "internal_error", undefined);
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });
 
@@ -326,8 +370,34 @@ describe("runUpgrade", () => {
       JSON.stringify({ code: "network_error", message: "failed retrieving file" }) + "\n"
     );
 
-    expect(callbacks.onError).toHaveBeenCalledWith("failed retrieving file", "network_error");
+    expect(callbacks.onError).toHaveBeenCalledWith("failed retrieving file", "network_error", undefined);
     expect(callbacks.onComplete).not.toHaveBeenCalled();
+  });
+
+  it("carries the envelope's details through to onError", () => {
+    const mockProc = createMockStreamingProcess();
+    mockSpawn.mockReturnValue(mockProc);
+
+    const callbacks = {
+      onComplete: vi.fn(),
+      onError: vi.fn(),
+    };
+
+    runUpgrade(callbacks);
+
+    mockProc._emit(
+      JSON.stringify({
+        code: "network_error",
+        message: "failed to refresh package databases",
+        details: "failed to refresh package databases: could not resolve host mirror.example",
+      }) + "\n"
+    );
+
+    expect(callbacks.onError).toHaveBeenCalledWith(
+      "failed to refresh package databases",
+      "network_error",
+      "failed to refresh package databases: could not resolve host mirror.example"
+    );
   });
 
   it("surfaces a streaming envelope with an unrecognized code instead of dropping it", () => {
@@ -343,7 +413,7 @@ describe("runUpgrade", () => {
 
     mockProc._emit(JSON.stringify({ code: "some_future_code", message: "unexpected" }) + "\n");
 
-    expect(callbacks.onError).toHaveBeenCalledWith("unexpected", "internal_error");
+    expect(callbacks.onError).toHaveBeenCalledWith("unexpected", "internal_error", undefined);
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });
 
@@ -468,7 +538,7 @@ describe("runUpgrade", () => {
 
     mockProc._fail({ message: "Permission denied" });
 
-    expect(callbacks.onError).toHaveBeenCalledWith("Permission denied", "permission_denied");
+    expect(callbacks.onError).toHaveBeenCalledWith("Permission denied", "permission_denied", undefined);
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });
 
@@ -572,7 +642,8 @@ describe("runUpgrade", () => {
 
     expect(callbacks.onError).toHaveBeenCalledWith(
       "Backend process ended without sending completion status",
-      "internal_error"
+      "internal_error",
+      undefined
     );
     expect(callbacks.onComplete).not.toHaveBeenCalled();
   });
@@ -604,18 +675,20 @@ describe("syncDatabase", () => {
     vi.clearAllMocks();
   });
 
-  it("spawns sync-database command with force flag", () => {
-    const mockProc = createMockStreamingProcess();
-    mockSpawn.mockReturnValue(mockProc);
+  it("only forces a re-download when asked to", () => {
+    const callbacks = { onComplete: vi.fn(), onError: vi.fn() };
 
-    const callbacks = {
-      onComplete: vi.fn(),
-      onError: vi.fn(),
-    };
-
+    mockSpawn.mockReturnValue(createMockStreamingProcess());
     syncDatabase(callbacks);
-
     expect(mockSpawn).toHaveBeenCalledWith(
+      expect.arrayContaining(["sync-database", "false"]),
+      expect.any(Object)
+    );
+
+    mockSpawn.mockReturnValue(createMockStreamingProcess());
+    syncDatabase(callbacks, true);
+
+    expect(mockSpawn).toHaveBeenLastCalledWith(
       expect.arrayContaining(["sync-database", "true"]),
       expect.any(Object)
     );

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { BACKEND_TIMEOUT_MS } from "./constants";
+import { BACKEND_TIMEOUT_MS, STREAM_FIRST_OUTPUT_TIMEOUT_MS } from "./constants";
 import { isDbLockError, sanitizeSearchInput } from "./utils";
 
 // Wire types are generated from the Rust serde structs via ts-rs (see
@@ -6,55 +6,33 @@ import { isDbLockError, sanitizeSearchInput } from "./utils";
 // consumers keep importing them from "../api".
 import type {
   CacheInfo,
-  CachePackage,
-  CachedVersion,
-  ConflictInfo,
-  DependencyEdge,
-  DependencyNode,
   DependencyTreeResponse,
   DismissalState,
   DowngradeResponse,
   GroupedLogResponse,
   IgnoreOperationResponse,
   IgnoredPackagesResponse,
-  KeyringKey,
   KeyringStatusResponse,
   ListReposResponse,
   LockRemoveResult,
   LockStatus,
-  LogEntry,
-  LogGroup,
   LogResponse,
-  MirrorBackup,
   MirrorBackupListResponse,
   MirrorEntry,
   MirrorListResponse,
-  MirrorStatus,
   MirrorStatusResponse,
   MirrorTestResult,
-  NewsItem,
   NewsReadState,
   NewsResponse,
-  OrphanPackage,
   OrphanResponse,
-  Package,
   PackageDetails,
   PackageListResponse,
-  PackageSecurityAdvisory,
-  PacnewFile,
   PacnewStatus,
-  PreflightKeyInfo,
   PreflightResponse,
-  PreflightWarning,
-  ProviderChoice,
   RebootStatus,
   RefreshMirrorsResponse,
-  ReplacementInfo,
-  RepoBackup,
   RepoBackupListResponse,
-  RepoDirectiveFull,
   RepoEntry,
-  RestartBlocked,
   RestoreMirrorBackupResponse,
   RestoreRepoBackupResponse,
   SaveMirrorlistResponse,
@@ -62,110 +40,18 @@ import type {
   ScheduleConfig,
   ScheduleMode,
   ScheduleSetResponse,
-  ScheduledRunEntry,
   ScheduledRunsResponse,
   SearchResponse,
-  SearchResult,
-  SecurityInfoAdvisory,
-  SecurityInfoGroup,
-  SecurityInfoIssue,
   SecurityInfoResponse,
   SecurityResponse,
-  ServiceRestart,
   ServicesStatus,
-  Signoff,
   SignoffActionResponse,
-  SignoffGroupWithLocal,
   SignoffListResponse,
   StreamEvent,
   SyncPackageDetails,
-  UpdateInfo,
-  UpdateStats,
   UpdatesResponse,
-  VersionMatch,
-  WarningSeverity,
 } from "./bindings";
-export type {
-  CacheInfo,
-  CachePackage,
-  CachedVersion,
-  ConflictInfo,
-  DependencyEdge,
-  DependencyNode,
-  DependencyTreeResponse,
-  DismissalState,
-  DowngradeResponse,
-  GroupedLogResponse,
-  IgnoreOperationResponse,
-  IgnoredPackagesResponse,
-  KeyringKey,
-  KeyringStatusResponse,
-  ListReposResponse,
-  LockRemoveResult,
-  LockStatus,
-  LogEntry,
-  LogGroup,
-  LogResponse,
-  MirrorBackup,
-  MirrorBackupListResponse,
-  MirrorEntry,
-  MirrorListResponse,
-  MirrorStatus,
-  MirrorStatusResponse,
-  MirrorTestResult,
-  NewsItem,
-  NewsReadState,
-  NewsResponse,
-  OrphanPackage,
-  OrphanResponse,
-  Package,
-  PackageDetails,
-  PackageListResponse,
-  PackageSecurityAdvisory,
-  PacnewFile,
-  PacnewStatus,
-  PreflightKeyInfo,
-  PreflightResponse,
-  PreflightWarning,
-  ProviderChoice,
-  RebootStatus,
-  RefreshMirrorsResponse,
-  ReplacementInfo,
-  RepoBackup,
-  RepoBackupListResponse,
-  RepoDirectiveFull,
-  RepoEntry,
-  RestartBlocked,
-  RestoreMirrorBackupResponse,
-  RestoreRepoBackupResponse,
-  SaveMirrorlistResponse,
-  SaveReposResponse,
-  ScheduleConfig,
-  ScheduleMode,
-  ScheduleSetResponse,
-  ScheduledRunEntry,
-  ScheduledRunsResponse,
-  SearchResponse,
-  SearchResult,
-  SecurityInfoAdvisory,
-  SecurityInfoGroup,
-  SecurityInfoIssue,
-  SecurityInfoResponse,
-  SecurityResponse,
-  ServiceRestart,
-  ServicesStatus,
-  Signoff,
-  SignoffActionResponse,
-  SignoffGroupWithLocal,
-  SignoffListResponse,
-  StreamEvent,
-  SyncPackageDetails,
-  UpdateInfo,
-  UpdateStats,
-  UpdatesResponse,
-  VersionMatch,
-  WarningSeverity,
-};
+export type * from "./bindings";
 
 const BACKEND_PATH = "/usr/libexec/cockpit-pacman/cockpit-pacman-backend";
 
@@ -389,11 +275,11 @@ export async function listInstalled(
     repo,
     sortBy,
     sortDir,
-  ]);
+  ], { superuser: "none" });
 }
 
 export async function checkUpdates(): Promise<UpdatesResponse> {
-  return runBackend<UpdatesResponse>("check-updates");
+  return runBackend<UpdatesResponse>("check-updates", [], { superuser: "none" });
 }
 
 export async function checkLock(): Promise<LockStatus> {
@@ -413,17 +299,17 @@ export async function getSecurityInfo(name: string): Promise<SecurityInfoRespons
 }
 
 export async function getPackageInfo(name: string): Promise<PackageDetails> {
-  return runBackend<PackageDetails>("local-package-info", [name]);
+  return runBackend<PackageDetails>("local-package-info", [name], { superuser: "none" });
 }
 
 export async function searchPackages(params: SearchParams): Promise<SearchResponse> {
   const { query, offset = 0, limit = 100, installed = "all", sortBy = "", sortDir = "" } = params;
-  return runBackend<SearchResponse>("search", [sanitizeSearchInput(query), String(offset), String(limit), installed, sortBy, sortDir]);
+  return runBackend<SearchResponse>("search", [sanitizeSearchInput(query), String(offset), String(limit), installed, sortBy, sortDir], { superuser: "none" });
 }
 
 export async function getSyncPackageInfo(name: string, repo?: string): Promise<SyncPackageDetails> {
   const args = repo ? [name, repo] : [name];
-  return runBackend<SyncPackageDetails>("sync-package-info", args);
+  return runBackend<SyncPackageDetails>("sync-package-info", args, { superuser: "none" });
 }
 
 export async function preflightUpgrade(ignore?: string[]): Promise<PreflightResponse> {
@@ -453,7 +339,7 @@ export interface UpgradeCallbacks {
   /** Called when the operation completes successfully */
   onComplete: () => void;
   /** Called when the operation fails with an error message and a classified code */
-  onError: (error: string, code?: ErrorCode) => void;
+  onError: (error: string, code?: ErrorCode, details?: string) => void;
   /** Timeout in seconds for the operation (default: 300) */
   timeout?: number;
   /** Superuser mode for cockpit.spawn (default: "require") */
@@ -492,7 +378,12 @@ function runStreamingBackend(
   let buffer = "";
   let completionHandled = false;
 
-  const markComplete = (success: boolean, message?: string, code?: ErrorCode) => {
+  const markComplete = (
+    success: boolean,
+    message?: string,
+    code?: ErrorCode,
+    details?: string,
+  ) => {
     // Guard against duplicate callbacks from concurrent paths (stream, then, catch)
     // Set flag immediately before any other work to prevent re-entry
     if (completionHandled) return;
@@ -504,7 +395,7 @@ function runStreamingBackend(
         callbacks.onComplete();
       } else {
         const msg = message || "Operation failed";
-        callbacks.onError(msg, code ?? parseErrorCode(msg));
+        callbacks.onError(msg, code ?? parseErrorCode(msg), details);
       }
     } catch (callbackError) {
       console.error("Callback error in markComplete:", callbackError);
@@ -515,13 +406,19 @@ function runStreamingBackend(
   // main.rs print a structured error envelope on stdout. It has a known code
   // and message but no StreamEvent `type`; treat it as a terminal error so the
   // backend's classification is not lost as an unknown event.
-  const asErrorEnvelope = (parsed: Record<string, unknown>): { code: ErrorCode; message: string } | null => {
+  const asErrorEnvelope = (
+    parsed: Record<string, unknown>,
+  ): { code: ErrorCode; message: string; details?: string } | null => {
     if (
       !("type" in parsed) &&
       typeof parsed.message === "string" &&
       typeof parsed.code === "string"
     ) {
-      return { code: asErrorCode(parsed.code), message: parsed.message };
+      return {
+        code: asErrorCode(parsed.code),
+        message: parsed.message,
+        details: typeof parsed.details === "string" ? parsed.details : undefined,
+      };
     }
     return null;
   };
@@ -531,7 +428,26 @@ function runStreamingBackend(
     { superuser: callbacks.superuser || "require", err: "out" }
   );
 
+  let firstOutputTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+    firstOutputTimer = undefined;
+    proc.close("timeout");
+    markComplete(
+      false,
+      `Backend command '${command}' produced no output within ${STREAM_FIRST_OUTPUT_TIMEOUT_MS / 1000}s. ` +
+        "The privileged bridge may be waiting for administrative access.",
+      "timeout"
+    );
+  }, STREAM_FIRST_OUTPUT_TIMEOUT_MS);
+
+  const clearFirstOutputTimer = () => {
+    if (firstOutputTimer !== undefined) {
+      clearTimeout(firstOutputTimer);
+      firstOutputTimer = undefined;
+    }
+  };
+
   proc.stream((data) => {
+    clearFirstOutputTimer();
     buffer += data;
     const lines = buffer.split("\n");
     buffer = lines.pop() || "";
@@ -545,7 +461,7 @@ function runStreamingBackend(
 
         const envelope = asErrorEnvelope(parsed);
         if (envelope) {
-          markComplete(false, envelope.message, envelope.code);
+          markComplete(false, envelope.message, envelope.code, envelope.details);
           continue;
         }
 
@@ -567,8 +483,13 @@ function runStreamingBackend(
           callbacks.onData?.(`${event.event}${event.package ? `: ${event.package}` : ""}\n`);
         } else if (event.type === "complete") {
           markComplete(event.success, event.message);
+        } else if (event.type === "mirror_test") {
+          callbacks.onData?.(
+            `[${event.current}/${event.total}] ${event.url}: ${event.result.success ? `${event.result.latency_ms}ms` : event.result.error}\n`,
+          );
         } else {
-          console.warn("Unknown StreamEvent type:", (event as { type: string }).type);
+          const unhandled: never = event;
+          console.warn("Unknown StreamEvent type:", (unhandled as StreamEvent).type);
         }
       } catch {
         callbacks.onData?.(line + "\n");
@@ -577,13 +498,14 @@ function runStreamingBackend(
   });
 
   proc.then(() => {
+    clearFirstOutputTimer();
     // Process any remaining buffer
     if (buffer.trim()) {
       try {
         const parsed = JSON.parse(buffer) as Record<string, unknown>;
         const envelope = asErrorEnvelope(parsed);
         if (envelope) {
-          markComplete(false, envelope.message, envelope.code);
+          markComplete(false, envelope.message, envelope.code, envelope.details);
           return;
         }
         const event = parsed as unknown as StreamEvent;
@@ -603,6 +525,7 @@ function runStreamingBackend(
   });
 
   proc.catch((ex: unknown) => {
+    clearFirstOutputTimer();
     markComplete(false, extractErrorMessage(ex));
   });
 
@@ -622,8 +545,8 @@ export function runUpgrade(callbacks: UpgradeCallbacks, ignore?: string[]): Stre
   return runStreamingBackend("upgrade", args, callbacks, { gracefulCancel: true });
 }
 
-export function syncDatabase(callbacks: UpgradeCallbacks): StreamingHandle {
-  const args = ["true"];
+export function syncDatabase(callbacks: UpgradeCallbacks, force = false): StreamingHandle {
+  const args = [String(force)];
   if (callbacks.timeout !== undefined) {
     args.push(String(callbacks.timeout));
   }
@@ -652,7 +575,7 @@ export function initKeyring(callbacks: UpgradeCallbacks): StreamingHandle {
 }
 
 export async function listOrphans(): Promise<OrphanResponse> {
-  return runBackend<OrphanResponse>("list-orphans");
+  return runBackend<OrphanResponse>("list-orphans", [], { superuser: "none" });
 }
 
 export function installPackage(
@@ -686,7 +609,7 @@ export function removeOrphans(callbacks: UpgradeCallbacks): StreamingHandle {
 }
 
 export async function listIgnoredPackages(): Promise<IgnoredPackagesResponse> {
-  return runBackend<IgnoredPackagesResponse>("list-ignored");
+  return runBackend<IgnoredPackagesResponse>("list-ignored", [], { superuser: "none" });
 }
 
 export async function addIgnoredPackage(name: string): Promise<IgnoreOperationResponse> {
@@ -698,7 +621,7 @@ export async function removeIgnoredPackage(name: string): Promise<IgnoreOperatio
 }
 
 export async function getCacheInfo(): Promise<CacheInfo> {
-  return runBackend<CacheInfo>("cache-info");
+  return runBackend<CacheInfo>("cache-info", [], { superuser: "none" });
 }
 
 export function cleanCache(callbacks: UpgradeCallbacks, keepVersions: number = 3, packages?: string[]): StreamingHandle {
@@ -722,17 +645,17 @@ export async function getGroupedHistory(params: HistoryParams = {}): Promise<Gro
     String(limit),
     filter,
     search,
-  ]);
+  ], { superuser: "none" });
 }
 
 export async function getHistory(params: HistoryParams = {}): Promise<LogResponse> {
   const { offset = 0, limit = 20, filter = "all", search = "" } = params;
-  return runBackend<LogResponse>("history", [String(offset), String(limit), filter, search]);
+  return runBackend<LogResponse>("history", [String(offset), String(limit), filter, search], { superuser: "none" });
 }
 
 export async function listDowngrades(packageName?: string): Promise<DowngradeResponse> {
   const args = packageName ? [sanitizeSearchInput(packageName)] : [];
-  return runBackend<DowngradeResponse>("list-downgrades", args);
+  return runBackend<DowngradeResponse>("list-downgrades", args, { superuser: "none" });
 }
 
 export function downgradePackage(
@@ -748,7 +671,7 @@ export async function listArchiveVersions(packageName: string, query?: string): 
   if (query && query.trim()) {
     args.push(sanitizeSearchInput(query));
   }
-  return runBackend<DowngradeResponse>("list-archive-versions", args);
+  return runBackend<DowngradeResponse>("list-archive-versions", args, { superuser: "none" });
 }
 
 export function downgradeFromArchive(
@@ -765,7 +688,7 @@ export interface ScheduledRunsParams {
 }
 
 export async function getScheduleConfig(): Promise<ScheduleConfig> {
-  return runBackend<ScheduleConfig>("get-schedule");
+  return runBackend<ScheduleConfig>("get-schedule", [], { superuser: "none" });
 }
 
 export interface SetScheduleParams {
@@ -787,13 +710,13 @@ export async function setScheduleConfig(params: SetScheduleParams): Promise<Sche
 
 export async function getScheduledRuns(params: ScheduledRunsParams = {}): Promise<ScheduledRunsResponse> {
   const { offset = 0, limit = 50 } = params;
-  return runBackend<ScheduledRunsResponse>("list-scheduled-runs", [String(offset), String(limit)]);
+  return runBackend<ScheduledRunsResponse>("list-scheduled-runs", [String(offset), String(limit)], { superuser: "none" });
 }
 
 export type RebootReason = "kernel_update" | "critical_packages" | "none";
 
 export async function getRebootStatus(): Promise<RebootStatus> {
-  return runBackend<RebootStatus>("reboot-status");
+  return runBackend<RebootStatus>("reboot-status", [], { superuser: "none" });
 }
 
 export type PacnewKind = "pacnew" | "pacsave";
@@ -851,11 +774,11 @@ export interface MirrorTestCallbacks {
 }
 
 export async function listMirrors(): Promise<MirrorListResponse> {
-  return runBackend<MirrorListResponse>("list-mirrors");
+  return runBackend<MirrorListResponse>("list-mirrors", [], { superuser: "none" });
 }
 
 export async function fetchMirrorStatus(): Promise<MirrorStatusResponse> {
-  return runBackend<MirrorStatusResponse>("fetch-mirror-status");
+  return runBackend<MirrorStatusResponse>("fetch-mirror-status", [], { superuser: "none" });
 }
 
 export function testMirrors(
@@ -878,8 +801,6 @@ export function testMirrors(
       if (event.type === "mirror_test") {
         const e = event as unknown as Extract<StreamEvent, { type: "mirror_test" }>;
         callbacks.onTestResult?.(e.result, e.current, e.total);
-        callbacks.onData?.(`[${e.current}/${e.total}] ${e.url}: ${e.result.success ? `${e.result.latency_ms}ms` : e.result.error}\n`);
-        return true;
       }
       return false;
     },
@@ -911,7 +832,7 @@ export async function refreshMirrors(params: RefreshMirrorsParams = {}): Promise
 }
 
 export async function listMirrorBackups(): Promise<MirrorBackupListResponse> {
-  return runBackend<MirrorBackupListResponse>("list-mirror-backups");
+  return runBackend<MirrorBackupListResponse>("list-mirror-backups", [], { superuser: "none" });
 }
 
 export async function restoreMirrorBackup(timestamp: number): Promise<RestoreMirrorBackupResponse> {
@@ -923,7 +844,7 @@ export async function deleteMirrorBackup(timestamp: number): Promise<RestoreMirr
 }
 
 export async function fetchNews(days: number = 30): Promise<NewsResponse> {
-  return runBackend<NewsResponse>("fetch-news", [String(days)]);
+  return runBackend<NewsResponse>("fetch-news", [String(days)], { superuser: "none" });
 }
 
 export async function getNewsReadState(): Promise<NewsReadState> {
@@ -965,7 +886,7 @@ export async function getDependencyTree(params: DependencyTreeParams): Promise<D
     sanitizeSearchInput(name),
     String(depth),
     direction,
-  ]);
+  ], { superuser: "none" });
 }
 
 // Signoff types
@@ -1002,7 +923,7 @@ export async function revokeSignoff(
 }
 
 export async function listRepos(): Promise<ListReposResponse> {
-  return runBackend<ListReposResponse>("list-repos", [], { superuser: "require" });
+  return runBackend<ListReposResponse>("list-repos", [], { superuser: "none" });
 }
 
 export async function saveRepos(repos: RepoEntry[]): Promise<SaveReposResponse> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -586,7 +586,7 @@ export function installPackage(
   if (callbacks.timeout !== undefined) {
     args.push(String(callbacks.timeout));
   }
-  return runStreamingBackend("install-package", args, callbacks);
+  return runStreamingBackend("install-package", args, callbacks, { gracefulCancel: true });
 }
 
 export function removePackage(
@@ -597,7 +597,7 @@ export function removePackage(
   if (callbacks.timeout !== undefined) {
     args.push(String(callbacks.timeout));
   }
-  return runStreamingBackend("remove-package", args, callbacks);
+  return runStreamingBackend("remove-package", args, callbacks, { gracefulCancel: true });
 }
 
 export function removeOrphans(callbacks: UpgradeCallbacks): StreamingHandle {
@@ -605,7 +605,7 @@ export function removeOrphans(callbacks: UpgradeCallbacks): StreamingHandle {
   if (callbacks.timeout !== undefined) {
     args.push(String(callbacks.timeout));
   }
-  return runStreamingBackend("remove-orphans", args, callbacks);
+  return runStreamingBackend("remove-orphans", args, callbacks, { gracefulCancel: true });
 }
 
 export async function listIgnoredPackages(): Promise<IgnoredPackagesResponse> {

--- a/src/bindings/index.ts
+++ b/src/bindings/index.ts
@@ -38,7 +38,7 @@ export type ListReposResponse = { repos: Array<RepoEntry>, };
 
 export type LockRemoveResult = { removed: boolean, error?: string, };
 
-export type LockStatus = { locked: boolean, stale: boolean, lock_path: string, blocking_process?: string, };
+export type LockStatus = { locked: boolean, stale: boolean, lock_path: string, blocking_process?: string, holder_unknown: boolean, };
 
 export type LogEntry = { timestamp: string, action: string, package: string, old_version: string | null, new_version: string | null, };
 

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -108,7 +108,7 @@ describe("UpdatesView", () => {
     });
     mockFetchNews.mockResolvedValue(mockNewsResponseEmpty);
     mockCheckSecurity.mockResolvedValue({ advisories: [] });
-    mockCheckLock.mockResolvedValue({ locked: true, stale: true, lock_path: "/var/lib/pacman/db.lck" });
+    mockCheckLock.mockResolvedValue({ locked: true, stale: true, lock_path: "/var/lib/pacman/db.lck", holder_unknown: false });
     mockRemoveStaleLock.mockResolvedValue({ removed: true });
     mockAddIgnoredPackage.mockResolvedValue({ success: true, package: "linux", message: "Package ignored" });
     mockGetNewsReadState.mockResolvedValue({ dismissed: [] });
@@ -881,6 +881,7 @@ describe("UpdatesView", () => {
         locked: true,
         stale: false,
         lock_path: "/var/lib/pacman/db.lck",
+        holder_unknown: false,
         blocking_process: "pacman (pid 1234)",
       });
       render(<UpdatesView />);
@@ -893,6 +894,33 @@ describe("UpdatesView", () => {
       });
     });
 
+    it("does not offer removal when the holder could not be determined", async () => {
+      mockCheckUpdates.mockRejectedValue(new Error("Unable to lock database"));
+      mockCheckLock.mockResolvedValue({
+        locked: true,
+        stale: false,
+        lock_path: "/var/lib/pacman/db.lck",
+        holder_unknown: true,
+      });
+      render(<UpdatesView />);
+
+      expect(
+        await screen.findByText(/Could not determine whether the database lock/)
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Remove stale lock/ })).not.toBeInTheDocument();
+    });
+
+    it("does not offer removal when the lock check itself failed", async () => {
+      mockCheckUpdates.mockRejectedValue(new Error("Unable to lock database"));
+      mockCheckLock.mockRejectedValue(new Error("Not permitted"));
+      render(<UpdatesView />);
+
+      expect(
+        await screen.findByText(/Could not determine whether the database lock/)
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Remove stale lock/ })).not.toBeInTheDocument();
+    });
+
     it("auto-retries when lock is already cleared", async () => {
       mockCheckUpdates.mockRejectedValueOnce(new Error("Unable to lock database"));
       mockCheckUpdates.mockResolvedValueOnce(mockUpdatesResponse);
@@ -900,6 +928,7 @@ describe("UpdatesView", () => {
         locked: false,
         stale: false,
         lock_path: "/var/lib/pacman/db.lck",
+        holder_unknown: false,
       });
       render(<UpdatesView />);
 
@@ -933,6 +962,50 @@ describe("UpdatesView", () => {
         expect(screen.getByText("Applying Updates")).toBeInTheDocument();
       });
       expect(mockCheckUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it("says a transaction was interrupted once the retry it triggered settles", async () => {
+      mockPreflightUpgrade.mockRejectedValueOnce(new Error("Unable to lock database"));
+      let upgradeCallbacks: Parameters<typeof api.runUpgrade>[0] | undefined;
+      mockRunUpgrade.mockImplementation((callbacks) => {
+        upgradeCallbacks = callbacks;
+        return { cancel: vi.fn(), forceStop: vi.fn() };
+      });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText(/1 of 1 update/)).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Apply 1 Update/i }));
+      });
+
+      const removeButton = await screen.findByRole("button", { name: /Remove stale lock/ });
+      await act(async () => {
+        fireEvent.click(removeButton);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Applying Updates")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Cleared a leftover database lock")).not.toBeInTheDocument();
+
+      await act(async () => {
+        upgradeCallbacks?.onComplete();
+      });
+
+      expect(
+        await screen.findByText("Cleared a leftover database lock")
+      ).toBeInTheDocument();
+    });
+
+    it("does not claim a lock was cleared when none was", async () => {
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText(/1 of 1 update/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Cleared a leftover database lock")).not.toBeInTheDocument();
     });
 
     it("re-runs preflight before restarting an upgrade interrupted by a lock", async () => {
@@ -1065,6 +1138,7 @@ describe("UpdatesView", () => {
         locked: false,
         stale: false,
         lock_path: "/var/lib/pacman/db.lck",
+        holder_unknown: false,
       });
       mockRunUpgrade.mockImplementation((callbacks) => {
         setTimeout(() => callbacks.onError("Failed to initialize transaction: invalid or corrupted database"), 0);

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -1779,6 +1779,43 @@ describe("UpdatesView", () => {
     });
   });
 
+  describe("Error details", () => {
+    it("shows the backend's context chain when a sync fails", async () => {
+      mockSyncDatabase.mockImplementation((callbacks) => {
+        setTimeout(
+          () =>
+            callbacks.onError(
+              "Failed to prepare transaction",
+              "transaction_failed",
+              "caused by: conflicting files in /usr/bin"
+            ),
+          0
+        );
+        return { cancel: vi.fn(), forceStop: vi.fn() };
+      });
+
+      render(<UpdatesView />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/conflicting files in \/usr\/bin/)).toBeInTheDocument();
+      });
+    });
+
+    it("shows nothing extra when the failure carries no chain", async () => {
+      mockSyncDatabase.mockImplementation((callbacks) => {
+        setTimeout(() => callbacks.onError("Failed to prepare transaction", "transaction_failed"), 0);
+        return { cancel: vi.fn(), forceStop: vi.fn() };
+      });
+
+      render(<UpdatesView />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/Failed to prepare transaction/).length).toBeGreaterThan(0);
+      });
+      expect(screen.queryByText(/caused by/)).not.toBeInTheDocument();
+    });
+  });
+
   describe("News Feed", () => {
     it("displays news items when returned", async () => {
       mockCheckUpdates.mockResolvedValue({ updates: [], warnings: [] });

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -555,8 +555,6 @@ describe("UpdatesView", () => {
         expect(screen.getByText("Applying Updates")).toBeInTheDocument();
       });
 
-      // dispatchEvent returns false once a listener has cancelled it, which is
-      // what makes the browser prompt.
       expect(window.dispatchEvent(new Event("beforeunload", { cancelable: true }))).toBe(false);
 
       await act(async () => {

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -701,7 +701,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     const { cancel } = syncDatabase({
       onData: (data) => setLog((prev) => appendCapped(prev, data)),
       onComplete: () => loadUpdates(),
-      onError: (err, code) => failWith("sync", err, code),
+      onError: (err, code, details) => failWith("sync", err, code, details),
     });
     return () => cancel();
   }, [loadUpdates, failWith]);
@@ -839,11 +839,14 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     setLog("");
     setSelectedPackages(new Set());
     setLockRetryExhausted(false);
-    cancelRef.current = syncDatabase({
-      onData: (data) => setLog((prev) => appendCapped(prev, data)),
-      onComplete: () => loadUpdates(),
-      onError: (err, code) => failWith("sync", err, code),
-    });
+    cancelRef.current = syncDatabase(
+      {
+        onData: (data) => setLog((prev) => appendCapped(prev, data)),
+        onComplete: () => loadUpdates(),
+        onError: (err, code, details) => failWith("sync", err, code, details),
+      },
+      true,
+    );
   };
 
   const handleApplyUpdates = async () => {
@@ -969,7 +972,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           }
         });
       },
-      onError: (err, code) => {
+      onError: (err, code, details) => {
         cancelRef.current = null;
         if (isCancellingRef.current) {
           setCancelling(false);
@@ -979,7 +982,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           loadPacnewStatus();
           return;
         }
-        failWith("upgrade", err, code);
+        failWith("upgrade", err, code, details);
       },
     }, ignoredPackages);
   };

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -259,11 +259,12 @@ interface UpdatesViewProps {
 
 type ErrorOrigin = "check" | "sync" | "preflight" | "upgrade";
 
-const LockErrorBody: React.FC<{ onRetry: () => void; onAutoRetry: () => void }> = ({ onRetry, onAutoRetry }) => {
+const LockErrorBody: React.FC<{ onRetry: () => void; onAutoRetry: () => void; onCleared: () => void }> = ({ onRetry, onAutoRetry, onCleared }) => {
   const [checking, setChecking] = useState(true);
   const [removing, setRemoving] = useState(false);
-  const [lockInfo, setLockInfo] = useState<{ stale: boolean; process?: string } | null>(null);
+  const [lockInfo, setLockInfo] = useState<{ stale: boolean; process?: string; unknown: boolean } | null>(null);
   const [removeError, setRemoveError] = useState<string | null>(null);
+  const [checkFailed, setCheckFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -274,11 +275,16 @@ const LockErrorBody: React.FC<{ onRetry: () => void; onAutoRetry: () => void }> 
           onAutoRetry();
           return;
         }
-        setLockInfo({ stale: status.stale, process: status.blocking_process });
+        setLockInfo({
+          stale: status.stale,
+          process: status.blocking_process,
+          unknown: status.holder_unknown,
+        });
       })
       .catch(() => {
         if (cancelled) return;
         setLockInfo(null);
+        setCheckFailed(true);
       })
       .finally(() => {
         if (cancelled) return;
@@ -293,6 +299,9 @@ const LockErrorBody: React.FC<{ onRetry: () => void; onAutoRetry: () => void }> 
     try {
       const result = await removeStaleLock();
       if (result.removed) {
+        // Raised on the page, not here: this component is replaced by the retry
+        // it triggers, and what the lock proves outlives the retry.
+        onCleared();
         onRetry();
       } else {
         setRemoveError(result.error || "Failed to remove lock");
@@ -312,6 +321,18 @@ const LockErrorBody: React.FC<{ onRetry: () => void; onAutoRetry: () => void }> 
     return (
       <Content component={ContentVariants.p}>
         The database is locked by <strong>{lockInfo.process}</strong>. Wait for it to finish, then retry.
+      </Content>
+    );
+  }
+
+  // Offering removal here would be acting on a check that did not conclude.
+  // A session without administrative access cannot see root's open files, so
+  // it finds no holder for a lock a running pacman still owns.
+  if (checkFailed || lockInfo?.unknown) {
+    return (
+      <Content component={ContentVariants.p}>
+        Could not determine whether the database lock is still in use. This check needs
+        administrative access. Grant it and retry, or wait for the running operation to finish.
       </Content>
     );
   }
@@ -348,9 +369,9 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [errorOrigin, setErrorOrigin] = useState<ErrorOrigin>("check");
   const autoResumedRef = useRef(false);
   const [lockRetryExhausted, setLockRetryExhausted] = useState(false);
+  const [lockCleared, setLockCleared] = useState(false);
   const [errorEpoch, setErrorEpoch] = useState(0);
 
-  // alpm acts on a cancel only between packages; leaving mid-transaction half-applies the upgrade.
   useEffect(() => {
     if (state !== "applying") return;
     const warn = (event: Event) => event.preventDefault();
@@ -1204,6 +1225,19 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     </Alert>
   ) : null;
 
+  const lockClearedAlert = lockCleared ? (
+    <Alert
+      variant="info"
+      isInline
+      title="Cleared a leftover database lock"
+      className="pf-v6-u-mb-md"
+      actionClose={<AlertActionCloseButton onClose={() => setLockCleared(false)} />}
+    >
+      A package transaction was interrupted before it could finish. If an earlier upgrade looks
+      incomplete, check the package list.
+    </Alert>
+  ) : null;
+
   const scheduledAlert = scheduledUnacked && latestScheduledRun ? (
     <Alert
       variant={latestScheduledRun.status === "failed" ? "danger" : "warning"}
@@ -1349,7 +1383,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
             >
               <EmptyStateBody>
                 {showLockRecovery
-                  ? <LockErrorBody key={errorEpoch} onRetry={manualResumeAfterLock} onAutoRetry={autoResumeAfterLock} />
+                  ? <LockErrorBody key={errorEpoch} onRetry={manualResumeAfterLock} onAutoRetry={autoResumeAfterLock} onCleared={() => setLockCleared(true)} />
                   : error}
                 {!showLockRecovery && <ErrorDetails details={errorDetails} />}
               </EmptyStateBody>
@@ -1504,6 +1538,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       <Card>
         <CardBody>
           {cancelAlert}
+          {lockClearedAlert}
           {rebootAlert}
           {servicesAlert}
           {pacnewAlert}
@@ -1530,6 +1565,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     return (
       <>
         {cancelAlert}
+        {lockClearedAlert}
         {rebootAlert}
         {servicesAlert}
         {pacnewAlert}
@@ -1628,6 +1664,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   return (
     <>
       {cancelAlert}
+      {lockClearedAlert}
       {rebootAlert}
       {servicesAlert}
       {pacnewAlert}

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { ARCH_STATUS_URL, NEWS_LOOKBACK_DAYS, REBOOT_PACKAGES } from "../constants";
+import { ARCH_STATUS_URL, LOG_FLUSH_MS, NEWS_LOOKBACK_DAYS, REBOOT_PACKAGES } from "../constants";
 import { useBackdropClose } from "../hooks/useBackdropClose";
 import { usePackageDetails } from "../hooks/usePackageDetails";
 import { useSortableTable } from "../hooks/useSortableTable";
@@ -361,6 +361,8 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [state, setState] = useState<ViewState>("loading");
   const [updates, setUpdates] = useState<UpdateInfo[]>([]);
   const [log, setLog] = useState("");
+  const logBuffer = useRef("");
+  const logFlush = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<ErrorCode | undefined>(undefined);
   const [errorDetails, setErrorDetails] = useState<string | undefined>(undefined);
@@ -378,6 +380,33 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     window.addEventListener("beforeunload", warn);
     return () => window.removeEventListener("beforeunload", warn);
   }, [state]);
+
+  // One upgrade emits tens of thousands of stream events, and a setState each
+  // re-renders this view far faster than anything can be read. Coalescing into
+  // one append per interval keeps the string concatenation off that path too.
+  const appendLog = useCallback((data: string) => {
+    logBuffer.current += data;
+    if (logFlush.current !== null) return;
+    logFlush.current = setTimeout(() => {
+      logFlush.current = null;
+      const pending = logBuffer.current;
+      logBuffer.current = "";
+      if (pending) setLog((prev) => appendCapped(prev, pending));
+    }, LOG_FLUSH_MS);
+  }, []);
+
+  const resetLog = useCallback(() => {
+    if (logFlush.current !== null) {
+      clearTimeout(logFlush.current);
+      logFlush.current = null;
+    }
+    logBuffer.current = "";
+    setLog("");
+  }, []);
+
+  useEffect(() => () => {
+    if (logFlush.current !== null) clearTimeout(logFlush.current);
+  }, []);
 
   // Consecutive errors can commit in one render batch without ever showing
   // the intermediate state, so the epoch forces LockErrorBody to remount
@@ -720,12 +749,12 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
 
   useEffect(() => {
     const { cancel } = syncDatabase({
-      onData: (data) => setLog((prev) => appendCapped(prev, data)),
+      onData: appendLog,
       onComplete: () => loadUpdates(),
       onError: (err, code, details) => failWith("sync", err, code, details),
     });
     return () => cancel();
-  }, [loadUpdates, failWith]);
+  }, [loadUpdates, failWith, appendLog]);
 
   const loadRebootStatus = useCallback(async () => {
     try {
@@ -857,12 +886,12 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     // Hard close so the old op releases db.lck before the new spawn takes it.
     cancelRef.current?.forceStop();
     setState("checking");
-    setLog("");
+    resetLog();
     setSelectedPackages(new Set());
     setLockRetryExhausted(false);
     cancelRef.current = syncDatabase(
       {
-        onData: (data) => setLog((prev) => appendCapped(prev, data)),
+        onData: appendLog,
         onComplete: () => loadUpdates(),
         onError: (err, code, details) => failWith("sync", err, code, details),
       },
@@ -921,7 +950,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const startUpgrade = () => {
     setConfirmModalOpen(false);
     setState("applying");
-    setLog("");
+    resetLog();
     setLockRetryExhausted(false);
     setCancelling(false);
     setCancelOutcome(null);
@@ -935,14 +964,15 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
 
     const handleEvent = (event: StreamEvent) => {
       if (event.type === "download") {
-        setUpgradeProgress((prev) => ({
-          ...prev,
-          phase: "downloading",
-          currentPackage: event.filename,
-          percent: event.downloaded && event.total
+        setUpgradeProgress((prev) => {
+          const percent = event.downloaded && event.total
             ? Math.round((event.downloaded / event.total) * 100)
-            : prev.percent,
-        }));
+            : prev.percent;
+          if (prev.phase === "downloading" && prev.currentPackage === event.filename && prev.percent === percent) {
+            return prev;
+          }
+          return { ...prev, phase: "downloading", currentPackage: event.filename, percent };
+        });
       } else if (event.type === "progress") {
         const phase = event.operation.includes("hook") ? "hooks" : "installing";
         setUpgradeProgress((prev) => ({
@@ -966,7 +996,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
 
     cancelRef.current = runUpgrade({
       onEvent: handleEvent,
-      onData: (data) => setLog((prev) => appendCapped(prev, data)),
+      onData: appendLog,
       onComplete: () => {
         autoResumedRef.current = false;
         if (isCancellingRef.current) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,8 @@ export const SEARCH_DEBOUNCE_MS = 300;
 
 export const BACKEND_TIMEOUT_MS = 30000;
 
+export const STREAM_FIRST_OUTPUT_TIMEOUT_MS = 60000;
+
 export const MAX_LOG_SIZE_BYTES = 100000;
 
 export const LOG_CONTAINER_HEIGHT = "300px";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,8 @@ export const STREAM_FIRST_OUTPUT_TIMEOUT_MS = 60000;
 
 export const MAX_LOG_SIZE_BYTES = 100000;
 
+export const LOG_FLUSH_MS = 100;
+
 export const LOG_CONTAINER_HEIGHT = "300px";
 
 export const NEWS_LOOKBACK_DAYS = 30;

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,9 @@
+{
+  // Separate from the app's tsconfig: the specs run under Node, the app runs in
+  // a browser. Folding them together would put node globals in scope for src/.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["e2e/**/*"]
+}


### PR DESCRIPTION
Cancel handling was upgrade-only: install, remove and orphan removal left stdin as the live Cockpit channel, so cancelling meant killing the channel mid-transaction. 

All mutation paths share the cancel listener now, and a cancel carries its reason, so a logout or websocket restart no longer interrupts a committing transaction. The stale-lock scan matches db.lck by inode instead of /proc link text and refuses removal when it could not read every process. Read-only commands run as the session user, streaming failures keep the backend's error chain, silent spawns time out at the first byte, and the e2e suite drives the plugin through the shell iframe with assertions that can fail. The first commit trims comments in already-merged files and simplifies applied_from_counts.
