### PR TITLE
feat: advisory toggle and alpm-driven downgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,10 @@ jobs:
         working-directory: backend
         run: cargo clippy -- -D warnings
 
+      # The Arch container has the real pacman state the gated tests need.
       - name: Test
         working-directory: backend
-        run: cargo test
+        run: cargo test --features integration-tests
 
       - name: Check generated TS bindings are up to date
         run: |

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ sudo make install
 make devel-install
 ```
 
+## Documentation
+
+- [Troubleshooting](docs/troubleshooting.md): locked database, interrupted
+  upgrade, a scheduled run with no record, where the config and backups live
+- [Configuration](docs/configuration.md): `/etc/cockpit-pacman/config.json`
+- [Signoffs](docs/signoffs.md): ArchWeb credentials and the signoff view
+
 ## Development
 
 ```bash

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alpm"
 version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,16 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -239,6 +258,12 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
@@ -335,7 +360,7 @@ dependencies = [
  "arch-mirror-client",
  "arch-security-client",
  "archweb-client",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "ctrlc",
  "html2text",
@@ -350,6 +375,7 @@ dependencies = [
  "tokio",
  "ts-rs",
  "ureq",
+ "wiremock",
  "zbus",
 ]
 
@@ -454,6 +480,24 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
@@ -644,16 +688,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.32"
+name = "futures"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -669,25 +749,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.32"
+name = "futures-macro"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -712,6 +808,25 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -765,10 +880,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -931,6 +1111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1233,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1295,6 +1491,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1886,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1741,6 +1977,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ts-rs"
 version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,7 +2039,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "cookie_store",
  "flate2",
  "log",
@@ -1816,7 +2058,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -1868,6 +2110,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2098,6 +2349,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2024"
 [features]
 integration-tests = []
 
+[dev-dependencies]
+wiremock = "0.6"
+tokio = { version = "1", features = ["rt", "macros"] }
+
 [dependencies]
 alpm = "5"
 alpm-sys = "5"

--- a/backend/crates/arch-mirror-client/src/lib.rs
+++ b/backend/crates/arch-mirror-client/src/lib.rs
@@ -11,6 +11,8 @@ pub enum Error {
     Http(#[from] ureq::Error),
     #[error("parsing mirror status failed")]
     Parse(#[from] serde_json::Error),
+    #[error("reading mirror status failed")]
+    Io(#[from] std::io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -74,11 +76,23 @@ impl SortBy {
     }
 }
 
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
+
 /// Fetch and parse the mirror status report. The caller supplies the agent so it
 /// controls timeouts and IP family.
+pub fn fetch_from(agent: &ureq::Agent, url: &str) -> Result<Status> {
+    use std::io::Read;
+
+    let mut body = agent.get(url).call()?.into_body();
+    let mut buf = Vec::new();
+    body.as_reader()
+        .take(MAX_RESPONSE_BYTES)
+        .read_to_end(&mut buf)?;
+    Ok(serde_json::from_slice(&buf)?)
+}
+
 pub fn fetch(agent: &ureq::Agent) -> Result<Status> {
-    let body = agent.get(STATUS_URL).call()?.into_body().read_to_string()?;
-    Ok(serde_json::from_str(&body)?)
+    fetch_from(agent, STATUS_URL)
 }
 
 /// Keep active mirrors at or above `min_completion` (0.0-1.0) matching

--- a/backend/crates/arch-security-client/src/lib.rs
+++ b/backend/crates/arch-security-client/src/lib.rs
@@ -14,6 +14,10 @@ pub struct SecurityClient {
     base_url: String,
 }
 
+pub fn parse_vulnerable(body: &str) -> Result<Vec<Avg>> {
+    serde_json::from_str(body).context("failed to parse vulnerable issues JSON")
+}
+
 impl SecurityClient {
     pub fn new(ip_family: ureq::config::IpFamily) -> Self {
         Self::with_base_url(DEFAULT_BASE_URL, ip_family)
@@ -32,11 +36,13 @@ impl SecurityClient {
     }
 
     pub fn fetch_vulnerable(&self) -> Result<Vec<Avg>> {
+        parse_vulnerable(&self.fetch_vulnerable_raw()?)
+    }
+
+    pub fn fetch_vulnerable_raw(&self) -> Result<String> {
         let url = format!("{}/issues/vulnerable.json", self.base_url);
-        let body = self
-            .get_json(&url)
-            .context("failed to fetch vulnerable issues")?;
-        serde_json::from_str(&body).context("failed to parse vulnerable issues JSON")
+        self.get_json(&url)
+            .context("failed to fetch vulnerable issues")
     }
 
     pub fn fetch_package(&self, name: &str) -> Result<PackageInfo> {

--- a/backend/crates/archweb-client/src/lib.rs
+++ b/backend/crates/archweb-client/src/lib.rs
@@ -5,6 +5,8 @@ use models::{SignoffGroup, SignoffSpec};
 
 pub const DEFAULT_BASE_URL: &str = "https://archlinux.org";
 
+const MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
+
 #[derive(serde::Deserialize)]
 struct SignoffResponse {
     signoff_groups: Vec<SignoffGroup>,
@@ -60,7 +62,15 @@ impl SignoffSession {
             .get(&login_url)
             .call()
             .context("failed to fetch login page")?;
-        let _ = resp.into_body().read_to_vec();
+        {
+            use std::io::Read;
+            let mut buf = Vec::new();
+            let _ = resp
+                .into_body()
+                .as_reader()
+                .take(MAX_RESPONSE_BYTES)
+                .read_to_end(&mut buf);
+        }
 
         let csrf_token = self
             .extract_csrf_token()
@@ -101,15 +111,21 @@ impl SignoffSession {
     }
 
     pub fn get_signoffs(&self) -> Result<Vec<SignoffGroup>> {
+        use std::io::Read;
+
         let url = format!("{}/packages/signoffs/json/", self.base_url);
-        let body = self
+        let mut resp = self
             .agent
             .get(&url)
             .call()
-            .context("failed to fetch signoffs")?
-            .body_mut()
-            .read_to_string()
+            .context("failed to fetch signoffs")?;
+        let mut buf = Vec::new();
+        resp.body_mut()
+            .as_reader()
+            .take(MAX_RESPONSE_BYTES)
+            .read_to_end(&mut buf)
             .context("failed to read signoffs response body")?;
+        let body = String::from_utf8(buf).context("signoffs response is not valid UTF-8")?;
 
         let response: SignoffResponse =
             serde_json::from_str(&body).context("failed to parse signoffs JSON")?;

--- a/backend/src/alpm/transaction.rs
+++ b/backend/src/alpm/transaction.rs
@@ -66,6 +66,14 @@ impl<'a> TransactionGuard<'a> {
         self.handle.syncdbs()
     }
 
+    pub fn load_pkg(
+        &self,
+        path: &str,
+        level: alpm::SigLevel,
+    ) -> Result<alpm::LoadedPackage<'_>, alpm::Error> {
+        self.handle.pkg_load(path, true, level)
+    }
+
     pub fn add_pkg<P: alpm::IntoPkgAdd>(&self, pkg: P) -> Result<(), alpm::AddError<P>> {
         self.handle.trans_add_pkg(pkg)
     }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -129,12 +129,18 @@ impl Default for ScheduleConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+fn security_advisories_default() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
     pub ignored_packages: Vec<String>,
     #[serde(default)]
     pub schedule: ScheduleConfig,
+    #[serde(default = "security_advisories_default")]
+    pub security_advisories: bool,
     // Round-trip keys this binary doesn't know about (e.g. fields added by a
     // newer version) instead of dropping them on the next update() rewrite.
     #[serde(flatten)]
@@ -147,6 +153,17 @@ fn parse_config(content: &str) -> Result<AppConfig> {
     }
     serde_json::from_str(content)
         .with_context(|| format!("Failed to parse config from {}", CONFIG_PATH))
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            ignored_packages: Vec::new(),
+            schedule: ScheduleConfig::default(),
+            security_advisories: security_advisories_default(),
+            extra: serde_json::Map::new(),
+        }
+    }
 }
 
 impl AppConfig {
@@ -374,6 +391,27 @@ impl From<&AppConfig> for IgnoredPackagesResponse {
 
 #[derive(Serialize, TS)]
 #[ts(export, export_to = "../../src/bindings/index.ts")]
+pub struct SettingsResponse {
+    pub security_advisories: bool,
+}
+
+impl From<&AppConfig> for SettingsResponse {
+    fn from(config: &AppConfig) -> Self {
+        Self {
+            security_advisories: config.security_advisories,
+        }
+    }
+}
+
+#[derive(Serialize, TS)]
+#[ts(export, export_to = "../../src/bindings/index.ts")]
+pub struct SettingsSetResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+#[derive(Serialize, TS)]
+#[ts(export, export_to = "../../src/bindings/index.ts")]
 pub struct IgnoreOperationResponse {
     pub success: bool,
     pub package: String,
@@ -467,7 +505,8 @@ pub struct ScheduleSetResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        Budget, SYSTEMD_APPLY_BUDGET, parse_timer_calendar, restore_drop_in, timer_absent,
+        AppConfig, Budget, SYSTEMD_APPLY_BUDGET, parse_timer_calendar, restore_drop_in,
+        timer_absent,
     };
     use std::time::Duration;
 
@@ -578,5 +617,28 @@ mod tests {
         ));
         assert!(!timer_absent("Failed to disable unit: Access denied"));
         assert!(!timer_absent(""));
+    }
+
+    #[test]
+    fn a_config_without_the_security_key_still_shows_advisories() {
+        let cfg: AppConfig =
+            serde_json::from_str(r#"{"ignored_packages":["linux"]}"#).expect("parses");
+        assert!(cfg.security_advisories);
+        assert_eq!(cfg.ignored_packages, vec!["linux".to_string()]);
+    }
+
+    #[test]
+    fn the_security_flag_round_trips_when_set_false() {
+        let cfg: AppConfig =
+            serde_json::from_str(r#"{"security_advisories":false}"#).expect("parses");
+        assert!(!cfg.security_advisories);
+
+        let back = serde_json::to_string(&cfg).expect("serializes");
+        assert!(back.contains("\"security_advisories\":false"), "{back}");
+    }
+
+    #[test]
+    fn the_default_config_shows_advisories() {
+        assert!(AppConfig::default().security_advisories);
     }
 }

--- a/backend/src/handlers/archive.rs
+++ b/backend/src/handlers/archive.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::alpm::get_handle;
 use crate::handlers::downgrade::{
-    compare_versions, get_installed_version, is_version_older, run_pacman_upgrade,
+    DowngradeSource, compare_versions, get_installed_version, install_downgrade, is_version_older,
 };
 use crate::models::{CachedVersion, DowngradeResponse};
 use crate::util::{emit_json, parse_package_filename};
@@ -169,7 +169,6 @@ fn build_archive_versions(
 }
 
 pub fn downgrade_from_archive(name: &str, filename: &str, timeout: Option<u64>) -> Result<()> {
-    crate::util::setup_signal_handler();
     validate_package_name(name)?;
     validate_archive_filename(filename, name)?;
 
@@ -178,7 +177,7 @@ pub fn downgrade_from_archive(name: &str, filename: &str, timeout: Option<u64>) 
     let url =
         archive_file_url(name, filename).ok_or_else(|| anyhow::anyhow!("Invalid package name"))?;
 
-    run_pacman_upgrade(&url, name, &version, timeout)
+    install_downgrade(DowngradeSource::Url(url), name, &version, timeout)
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/archive.rs
+++ b/backend/src/handlers/archive.rs
@@ -14,9 +14,9 @@ const ARCHIVE_BASE_URL: &str = "https://archive.archlinux.org/packages";
 const MAX_LISTING_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_ARCHIVE_VERSIONS: usize = 100;
 
-fn archive_dir_url(name: &str) -> Option<String> {
+fn archive_dir_url_at(base: &str, name: &str) -> Option<String> {
     let first = name.chars().next()?;
-    Some(format!("{}/{}/{}/", ARCHIVE_BASE_URL, first, name))
+    Some(format!("{}/{}/{}/", base, first, name))
 }
 
 fn archive_file_url(name: &str, filename: &str) -> Option<String> {
@@ -85,13 +85,9 @@ fn system_arch() -> &'static str {
     std::env::consts::ARCH
 }
 
-pub fn list_archive_versions(name: &str, query: Option<&str>) -> Result<()> {
-    validate_package_name(name)?;
-    let alpm = get_handle()?;
-    let installed_version = get_installed_version(&alpm, name);
-    let arch = system_arch();
-
-    let url = archive_dir_url(name).ok_or_else(|| anyhow::anyhow!("Invalid package name"))?;
+fn fetch_listing(base: &str, name: &str) -> Result<Option<String>> {
+    let url =
+        archive_dir_url_at(base, name).ok_or_else(|| anyhow::anyhow!("Invalid package name"))?;
 
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
@@ -102,12 +98,7 @@ pub fn list_archive_versions(name: &str, query: Option<&str>) -> Result<()> {
 
     let resp = match agent.get(&url).call() {
         Ok(r) => r,
-        Err(ureq::Error::StatusCode(404)) => {
-            return emit_json(&DowngradeResponse {
-                packages: vec![],
-                total: 0,
-            });
-        }
+        Err(ureq::Error::StatusCode(404)) => return Ok(None),
         Err(e) => return Err(e.into()),
     };
 
@@ -116,7 +107,21 @@ pub fn list_archive_versions(name: &str, query: Option<&str>) -> Result<()> {
     body.as_reader()
         .take(MAX_LISTING_BYTES)
         .read_to_end(&mut buf)?;
-    let html = String::from_utf8_lossy(&buf);
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+}
+
+pub fn list_archive_versions(name: &str, query: Option<&str>) -> Result<()> {
+    validate_package_name(name)?;
+    let alpm = get_handle()?;
+    let installed_version = get_installed_version(&alpm, name);
+    let arch = system_arch();
+
+    let Some(html) = fetch_listing(ARCHIVE_BASE_URL, name)? else {
+        return emit_json(&DowngradeResponse {
+            packages: vec![],
+            total: 0,
+        });
+    };
 
     let packages = build_archive_versions(&html, name, arch, installed_version.as_deref(), query);
     let total = packages.len();
@@ -353,12 +358,63 @@ mod tests {
     #[test]
     fn builds_urls_from_first_char() {
         assert_eq!(
-            archive_dir_url("bash").unwrap(),
+            archive_dir_url_at(ARCHIVE_BASE_URL, "bash").unwrap(),
             "https://archive.archlinux.org/packages/b/bash/"
         );
         assert_eq!(
             archive_file_url("bash", "bash-5.1.016-1-x86_64.pkg.tar.zst").unwrap(),
             "https://archive.archlinux.org/packages/b/bash/bash-5.1.016-1-x86_64.pkg.tar.zst"
         );
+    }
+
+    #[tokio::test]
+    async fn an_unknown_package_gives_no_listing_rather_than_an_error() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/n/nosuchpackage/"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let listing =
+            super::fetch_listing(&server.uri(), "nosuchpackage").expect("404 is not an error");
+        assert!(listing.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_listing_is_returned_for_a_package_that_exists() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/b/bash/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("<a href=\"bash-5.2-1-x86_64.pkg.tar.zst\">"),
+            )
+            .mount(&server)
+            .await;
+
+        let listing = super::fetch_listing(&server.uri(), "bash").expect("fetches");
+        assert!(listing.expect("some listing").contains("bash-5.2-1"));
+    }
+
+    #[tokio::test]
+    async fn a_server_error_is_not_mistaken_for_an_empty_archive() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/b/bash/"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        assert!(super::fetch_listing(&server.uri(), "bash").is_err());
     }
 }

--- a/backend/src/handlers/config.rs
+++ b/backend/src/handlers/config.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 
-use crate::config::{AppConfig, IgnoreOperationResponse, IgnoredPackagesResponse};
+use crate::config::{
+    AppConfig, IgnoreOperationResponse, IgnoredPackagesResponse, SettingsResponse,
+    SettingsSetResponse,
+};
 use crate::util::emit_json;
 
 pub fn list_ignored() -> Result<()> {
@@ -39,4 +42,23 @@ pub fn remove_ignored(package: &str) -> Result<()> {
     };
 
     emit_json(&response)
+}
+
+pub fn get_settings() -> Result<()> {
+    let config = AppConfig::load()?;
+    emit_json(&SettingsResponse::from(&config))
+}
+
+pub fn set_settings(security_advisories: Option<bool>) -> Result<()> {
+    AppConfig::update(|config| {
+        if let Some(enabled) = security_advisories {
+            config.security_advisories = enabled;
+        }
+        Ok(())
+    })?;
+
+    emit_json(&SettingsSetResponse {
+        success: true,
+        message: "Settings saved".to_string(),
+    })
 }

--- a/backend/src/handlers/downgrade.rs
+++ b/backend/src/handlers/downgrade.rs
@@ -1,18 +1,20 @@
-use alpm::Alpm;
+use alpm::{Alpm, SigLevel, TransFlag};
 use anyhow::{Context, Result};
 use std::cmp::Ordering;
 use std::fs;
-use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{Command, ExitStatus, Stdio};
-use std::time::{Duration, Instant};
 
-use crate::alpm::get_handle;
+use crate::alpm::{TransactionGuard, Verbosity, get_handle, setup_dl_cb, setup_log_cb};
+use crate::check_cancel_early;
+use crate::handlers::mutation::{
+    EventScope, commit_and_complete, fail_complete, prepare_failure, setup_event_cb,
+    setup_progress_cb, setup_question_cb,
+};
 use crate::inhibit::ShutdownInhibitor;
 use crate::models::{CachedVersion, DowngradeResponse, StreamEvent};
 use crate::util::{
-    DEFAULT_MUTATION_TIMEOUT_SECS, emit_event, emit_json, get_cache_dir, is_cancelled,
-    list_cache_packages, parse_package_filename, setup_signal_handler, terminate_child,
+    DEFAULT_MUTATION_TIMEOUT_SECS, TimeoutGuard, emit_event, emit_json, get_cache_dir,
+    list_cache_packages, parse_package_filename, setup_signal_handler, spawn_cancel_listener,
 };
 
 use crate::validation::{validate_package_name, validate_version};
@@ -70,7 +72,6 @@ pub fn list_downgrades(package_name: Option<&str>) -> Result<()> {
 }
 
 pub fn downgrade_package(name: &str, version: &str, timeout: Option<u64>) -> Result<()> {
-    setup_signal_handler();
     validate_package_name(name)?;
     validate_version(version)?;
 
@@ -79,174 +80,100 @@ pub fn downgrade_package(name: &str, version: &str, timeout: Option<u64>) -> Res
     let target_filename = find_package_file(cache_path, name, version)?;
     let pkg_path = cache_path.join(&target_filename);
 
-    run_pacman_upgrade(&pkg_path.to_string_lossy(), name, version, timeout)
+    install_downgrade(
+        DowngradeSource::Cached(pkg_path.to_string_lossy().into_owned()),
+        name,
+        version,
+        timeout,
+    )
 }
 
-/// Run `pacman -U` against a package target (a cache path or an archive URL),
-/// streaming its output as log events. Shared by cache and archive downgrades.
-pub(crate) fn run_pacman_upgrade(
-    target: &str,
+pub(crate) enum DowngradeSource {
+    Cached(String),
+    Url(String),
+}
+
+fn file_siglevel(level: SigLevel, default: SigLevel) -> SigLevel {
+    if level.is_empty() { default } else { level }
+}
+
+pub(crate) fn install_downgrade(
+    source: DowngradeSource,
     name: &str,
     version: &str,
-    timeout: Option<u64>,
+    timeout_secs: Option<u64>,
 ) -> Result<()> {
+    setup_signal_handler();
+    spawn_cancel_listener();
+    let timeout = TimeoutGuard::new(timeout_secs.unwrap_or(DEFAULT_MUTATION_TIMEOUT_SECS));
+
+    let mut handle = get_handle()?;
+    setup_log_cb(&mut handle);
+    setup_dl_cb(&mut handle, Verbosity::Streaming);
+    setup_progress_cb(&mut handle);
+    setup_event_cb(&mut handle, EventScope::Upgrade);
+    setup_question_cb(&mut handle, false);
+
+    check_cancel_early!(&timeout);
+
     emit_event(&StreamEvent::Event {
         event: format!("Downgrading {} to version {}", name, version),
         package: Some(name.to_string()),
     });
 
-    let timeout_secs = timeout.unwrap_or(DEFAULT_MUTATION_TIMEOUT_SECS);
-    let timeout_duration = std::time::Duration::from_secs(timeout_secs);
-    let start_time = Instant::now();
-
-    emit_event(&StreamEvent::Log {
-        level: "info".to_string(),
-        message: format!(
-            "Running: pacman -U --noconfirm {} (timeout: {}s)",
-            target, timeout_secs
+    let (path, siglevel) = match source {
+        DowngradeSource::Cached(path) => (
+            path,
+            file_siglevel(handle.local_file_siglevel(), handle.default_siglevel()),
         ),
-    });
+        DowngradeSource::Url(url) => {
+            let fetched = handle
+                .fetch_pkgurl([url.as_str()].into_iter())
+                .map_err(|e| {
+                    fail_complete(format!("Failed to download {} {}: {}", name, version, e))
+                })?;
+            let Some(path) = fetched.first().map(|p| p.to_string()) else {
+                return Err(fail_complete(format!(
+                    "Download of {} {} produced no file",
+                    name, version
+                )));
+            };
+            (
+                path,
+                file_siglevel(handle.remote_file_siglevel(), handle.default_siglevel()),
+            )
+        }
+    };
+
+    check_cancel_early!(&timeout);
 
     let _inhibitor = ShutdownInhibitor::take("Downgrading package");
 
-    let mut child = Command::new("pacman")
-        .args(["-U", "--noconfirm"])
-        .arg(target)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("Failed to spawn pacman")?;
+    let mut tx = TransactionGuard::new(&mut handle, TransFlag::NONE)?;
 
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
-
-    let stdout_handle = std::thread::spawn(move || {
-        if let Some(stdout) = stdout {
-            let reader = BufReader::new(stdout);
-            for line_result in reader.lines() {
-                let line = match line_result {
-                    Ok(l) => l,
-                    Err(e) => {
-                        eprintln!("Warning: Failed to read stdout line: {}", e);
-                        continue;
-                    }
-                };
-                if !line.trim().is_empty() {
-                    emit_event(&StreamEvent::Log {
-                        level: "info".to_string(),
-                        message: line,
-                    });
-                }
-            }
-        }
-    });
-
-    let stderr_handle = std::thread::spawn(move || {
-        if let Some(stderr) = stderr {
-            let reader = BufReader::new(stderr);
-            for line_result in reader.lines() {
-                let line = match line_result {
-                    Ok(l) => l,
-                    Err(e) => {
-                        eprintln!("Warning: Failed to read stderr line: {}", e);
-                        continue;
-                    }
-                };
-                if !line.trim().is_empty() {
-                    emit_event(&StreamEvent::Log {
-                        level: "warning".to_string(),
-                        message: line,
-                    });
-                }
-            }
-        }
-    });
-
-    enum Outcome {
-        // pacman may defer the SIGINT and still finish; carry the real status.
-        Cancelled(ExitStatus),
-        TimedOut(ExitStatus),
-        Exited(ExitStatus),
-    }
-
-    let outcome = loop {
-        // Never SIGKILL pacman: a hard kill mid-commit corrupts the local db.
-        if is_cancelled() {
-            break Outcome::Cancelled(terminate_child(&mut child, None));
-        }
-
-        if start_time.elapsed() > timeout_duration {
-            break Outcome::TimedOut(terminate_child(&mut child, None));
-        }
-
-        match child.try_wait() {
-            Ok(Some(status)) => break Outcome::Exited(status),
-            Ok(None) => {
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            Err(e) => {
-                join_readers(stdout_handle, stderr_handle);
-                emit_event(&StreamEvent::Complete {
-                    success: false,
-                    message: Some(format!("Failed to check process status: {}", e)),
-                });
-                return Err(e.into());
-            }
-        }
+    let pkg = match tx.load_pkg(&path, siglevel) {
+        Ok(pkg) => pkg,
+        Err(e) => return Err(fail_complete(format!("Failed to load {}: {}", path, e))),
     };
 
-    // Join after the child has exited so pacman's final cleanup lines reach the
-    // log, then report a status that reflects what actually happened.
-    join_readers(stdout_handle, stderr_handle);
-
-    let complete = match outcome {
-        Outcome::Cancelled(status) | Outcome::TimedOut(status) if status.success() => {
-            StreamEvent::Complete {
-                success: true,
-                message: Some(format!(
-                    "Downgrade of {} to {} finished before the cancel took effect",
-                    name, version
-                )),
-            }
-        }
-        Outcome::Cancelled(_) => StreamEvent::Complete {
-            success: false,
-            message: Some("Operation cancelled by user".to_string()),
-        },
-        Outcome::TimedOut(_) => StreamEvent::Complete {
-            success: false,
-            message: Some(format!(
-                "Operation timed out after {} seconds",
-                timeout_secs
-            )),
-        },
-        Outcome::Exited(status) if status.success() => StreamEvent::Complete {
-            success: true,
-            message: Some(format!("Successfully downgraded {} to {}", name, version)),
-        },
-        Outcome::Exited(status) => StreamEvent::Complete {
-            success: false,
-            message: Some(format!(
-                "Failed to downgrade {}: exit code {}",
-                name,
-                status.code().unwrap_or(-1)
-            )),
-        },
-    };
-    emit_event(&complete);
-    Ok(())
-}
-
-fn join_readers(
-    stdout_handle: std::thread::JoinHandle<()>,
-    stderr_handle: std::thread::JoinHandle<()>,
-) {
-    if let Err(e) = stdout_handle.join() {
-        eprintln!("Warning: stdout reader thread panicked: {:?}", e);
+    if let Err(e) = tx.add_pkg(pkg) {
+        return Err(fail_complete(format!(
+            "Failed to add '{}' to transaction: {}",
+            name, e
+        )));
     }
-    if let Err(e) = stderr_handle.join() {
-        eprintln!("Warning: stderr reader thread panicked: {:?}", e);
+
+    check_cancel_early!(&timeout);
+
+    if let Some(err_msg) = tx.prepare().err().map(|e| e.to_string()) {
+        return Err(prepare_failure(&err_msg));
     }
+
+    commit_and_complete(
+        &mut tx,
+        "Operation interrupted - package may be in inconsistent state",
+        Some(format!("Successfully downgraded {} to {}", name, version)),
+    )
 }
 
 fn find_package_file(cache_path: &Path, name: &str, version: &str) -> Result<String> {
@@ -287,4 +214,23 @@ pub(crate) fn is_version_older(cached: &str, installed: &str) -> bool {
 
 pub(crate) fn compare_versions(a: &str, b: &str) -> Ordering {
     alpm::vercmp(a, b)
+}
+
+#[cfg(test)]
+mod siglevel_tests {
+    use super::file_siglevel;
+    use alpm::SigLevel;
+
+    #[test]
+    fn an_unset_file_level_falls_back_to_the_default() {
+        let default = SigLevel::PACKAGE | SigLevel::PACKAGE_OPTIONAL;
+        assert_eq!(file_siglevel(SigLevel::NONE, default), default);
+    }
+
+    #[test]
+    fn a_configured_file_level_is_used_as_is() {
+        let configured = SigLevel::PACKAGE;
+        let default = SigLevel::PACKAGE | SigLevel::PACKAGE_OPTIONAL;
+        assert_eq!(file_siglevel(configured, default), configured);
+    }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -20,7 +20,7 @@ pub mod signoff;
 
 pub use archive::{downgrade_from_archive, list_archive_versions};
 pub use cache::{clean_cache, get_cache_info};
-pub use config::{add_ignored, list_ignored, remove_ignored};
+pub use config::{add_ignored, get_settings, list_ignored, remove_ignored, set_settings};
 pub use dependency::get_dependency_tree;
 pub use downgrade::{downgrade_package, list_downgrades};
 pub use keyring::{init_keyring, keyring_status, refresh_keyring};

--- a/backend/src/handlers/mutation.rs
+++ b/backend/src/handlers/mutation.rs
@@ -38,7 +38,7 @@ fn is_kernel_package(
 
 /// Which package operations and informational events a mutation streams.
 #[derive(Clone, Copy, PartialEq)]
-enum EventScope {
+pub(crate) enum EventScope {
     Upgrade,
     Install,
     Remove,
@@ -54,7 +54,7 @@ impl EventScope {
     }
 }
 
-fn setup_progress_cb(handle: &mut Alpm) {
+pub(crate) fn setup_progress_cb(handle: &mut Alpm) {
     let mut last: Option<(&'static str, String, i32, usize, usize)> = None;
 
     handle.set_progress_cb(
@@ -93,7 +93,7 @@ fn setup_progress_cb(handle: &mut Alpm) {
     );
 }
 
-fn setup_event_cb(handle: &mut Alpm, scope: EventScope) {
+pub(crate) fn setup_event_cb(handle: &mut Alpm, scope: EventScope) {
     handle.set_event_cb((), move |event: AnyEvent, _: &mut ()| {
         interrupt_if_cancelled();
         let (event_str, pkg_name) = match event.event() {
@@ -146,7 +146,7 @@ fn setup_event_cb(handle: &mut Alpm, scope: EventScope) {
 /// Auto-answers alpm questions during a streaming mutation, logging each
 /// decision. `answer_remove_pkgs` confirms dependent-removal prompts; when
 /// false the prompt keeps alpm's default answer.
-fn setup_question_cb(handle: &mut Alpm, answer_remove_pkgs: bool) {
+pub(crate) fn setup_question_cb(handle: &mut Alpm, answer_remove_pkgs: bool) {
     handle.set_question_cb(
         (),
         move |mut question: AnyQuestion, _: &mut ()| match question.question() {
@@ -217,8 +217,7 @@ fn setup_question_cb(handle: &mut Alpm, answer_remove_pkgs: bool) {
     );
 }
 
-fn prepare_failure(err_msg: &str) -> anyhow::Error {
-    let message = format!("Failed to prepare transaction: {}", err_msg);
+pub(crate) fn fail_complete(message: String) -> anyhow::Error {
     emit_event(&StreamEvent::Complete {
         success: false,
         message: Some(message.clone()),
@@ -226,7 +225,11 @@ fn prepare_failure(err_msg: &str) -> anyhow::Error {
     anyhow::anyhow!(message)
 }
 
-fn commit_and_complete(
+pub(crate) fn prepare_failure(err_msg: &str) -> anyhow::Error {
+    fail_complete(format!("Failed to prepare transaction: {}", err_msg))
+}
+
+pub(crate) fn commit_and_complete(
     tx: &mut TransactionGuard,
     interrupt_msg: &str,
     success_msg: Option<String>,
@@ -659,12 +662,10 @@ pub fn install_package(name: &str, timeout_secs: Option<u64>) -> Result<()> {
         return Err(not_found());
     };
     if let Err(e) = tx.add_pkg(pkg) {
-        let err_msg = format!("Failed to add '{}' to transaction: {}", name, e);
-        emit_event(&StreamEvent::Complete {
-            success: false,
-            message: Some(err_msg.clone()),
-        });
-        return Err(anyhow::anyhow!(err_msg));
+        return Err(fail_complete(format!(
+            "Failed to add '{}' to transaction: {}",
+            name, e
+        )));
     }
 
     check_cancel_early!(&timeout);

--- a/backend/src/handlers/news.rs
+++ b/backend/src/handlers/news.rs
@@ -45,7 +45,7 @@ pub struct Dismissal {
 
 pub fn fetch_news(days: u32) -> Result<()> {
     let days = days.min(365);
-    match fetch_news_items(days) {
+    match fetch_news_items_from(ARCH_NEWS_URL, days) {
         Ok(items) => {
             let response = NewsResponse {
                 items,
@@ -91,7 +91,7 @@ fn read_news_cache(path: PathBuf) -> Option<Vec<NewsItem>> {
     Some(cached.items)
 }
 
-fn fetch_news_items(days: u32) -> Result<Vec<NewsItem>> {
+fn fetch_news_items_from(url: &str, days: u32) -> Result<Vec<NewsItem>> {
     let agent = ureq::Agent::new_with_config(
         ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(15)))
@@ -99,7 +99,7 @@ fn fetch_news_items(days: u32) -> Result<Vec<NewsItem>> {
             .build(),
     );
 
-    let mut body = agent.get(ARCH_NEWS_URL).call()?.into_body();
+    let mut body = agent.get(url).call()?.into_body();
     let mut buf = Vec::new();
     body.as_reader().take(MAX_RSS_BYTES).read_to_end(&mut buf)?;
 
@@ -360,5 +360,51 @@ fn decode_entity(chars: &mut std::iter::Peekable<std::str::Chars>) -> String {
                 .unwrap_or_else(|| format!("&{};", entity))
         }
         _ => format!("&{};", entity),
+    }
+}
+
+#[cfg(test)]
+mod fetch_tests {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn serve(body: &str) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/feeds/news/"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn a_feed_that_is_not_rss_is_an_error_not_an_empty_list() {
+        let server = serve("not an rss document").await;
+        let url = format!("{}/feeds/news/", server.uri());
+
+        assert!(super::fetch_news_items_from(&url, 30).is_err());
+    }
+
+    #[tokio::test]
+    async fn an_item_older_than_the_window_is_dropped() {
+        let feed = r#"<?xml version="1.0"?><rss version="2.0"><channel><title>t</title>
+            <link>https://archlinux.org</link><description>d</description>
+            <item><title>ancient</title><link>https://archlinux.org/news/a/</link>
+            <pubDate>Tue, 01 Jan 2019 00:00:00 +0000</pubDate><description>old</description></item>
+            </channel></rss>"#;
+        let server = serve(feed).await;
+        let url = format!("{}/feeds/news/", server.uri());
+
+        let items = super::fetch_news_items_from(&url, 30).expect("parses");
+        assert!(
+            items.is_empty(),
+            "an item from 2019 is outside a 30 day window"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_feed_is_an_error_so_the_caller_can_fall_back() {
+        assert!(super::fetch_news_items_from("http://127.0.0.1:1/feeds/news/", 30).is_err());
     }
 }

--- a/backend/src/handlers/security.rs
+++ b/backend/src/handlers/security.rs
@@ -102,12 +102,11 @@ struct Feed {
     stale: bool,
 }
 
-fn load_feed(client: &SecurityClient, force: bool) -> Result<Feed> {
-    let path = security_cache_path().ok();
+fn load_feed(client: &SecurityClient, force: bool, path: Option<&Path>) -> Result<Feed> {
     let mut cached = if force {
         None
     } else {
-        path.as_deref().and_then(read_feed_cache)
+        path.and_then(read_feed_cache)
     };
 
     if let Some(ref c) = cached
@@ -119,7 +118,7 @@ fn load_feed(client: &SecurityClient, force: bool) -> Result<Feed> {
 
     let stale_fallback = |cached: Option<FeedCache>| {
         cached
-            .or_else(|| path.as_deref().and_then(read_feed_cache))
+            .or_else(|| path.and_then(read_feed_cache))
             .and_then(|c| arch_security_client::parse_vulnerable(&c.body).ok())
             .map(|avgs| Feed { avgs, stale: true })
     };
@@ -127,7 +126,7 @@ fn load_feed(client: &SecurityClient, force: bool) -> Result<Feed> {
     match client.fetch_vulnerable_raw() {
         Ok(body) => match arch_security_client::parse_vulnerable(&body) {
             Ok(avgs) => {
-                if let Some(ref p) = path {
+                if let Some(p) = path {
                     let _ = write_feed_cache(
                         p,
                         &FeedCache {
@@ -154,7 +153,7 @@ pub fn check_security(force: bool) -> Result<()> {
     }
 
     let client = SecurityClient::new(crate::util::detected_ip_family());
-    let feed = load_feed(&client, force)?;
+    let feed = load_feed(&client, force, security_cache_path().ok().as_deref())?;
     let avgs = feed.avgs;
 
     let handle = get_handle()?;
@@ -399,5 +398,173 @@ mod tests {
             "a Low one an update fixes outranks a High one it cannot"
         );
         assert_eq!(list[1].package, "linux");
+    }
+}
+
+#[cfg(test)]
+mod feed_tests {
+    use super::{FeedCache, load_feed, now_secs, write_feed_cache};
+    use arch_security_client::SecurityClient;
+    use wiremock::matchers::{method, path as req_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const ONE_AVG: &str = r#"[{"name":"AVG-1","packages":["bash"],"status":"Vulnerable",
+        "severity":"High","type":"code execution","affected":"5.0-1","fixed":null,
+        "issues":["CVE-2024-1"],"advisories":[]}]"#;
+
+    fn cache_file(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("cpac-feed-{tag}-{}", std::process::id()))
+    }
+
+    fn ipv4() -> ureq::config::IpFamily {
+        ureq::config::IpFamily::Ipv4Only
+    }
+
+    async fn serving(body: &str) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(req_path("/issues/vulnerable.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn a_fresh_cache_is_served_without_asking_upstream() {
+        let path = cache_file("fresh");
+        write_feed_cache(
+            &path,
+            &FeedCache {
+                fetched_at: now_secs(),
+                body: ONE_AVG.to_string(),
+            },
+        )
+        .expect("writes");
+
+        let server = MockServer::start().await;
+        let client = SecurityClient::with_base_url(&server.uri(), ipv4());
+
+        let feed = load_feed(&client, false, Some(&path)).expect("served from cache");
+        assert_eq!(feed.avgs.len(), 1);
+        assert!(!feed.stale, "reuse inside the window is not staleness");
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty()
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn force_refetches_even_when_the_cache_is_fresh() {
+        let path = cache_file("force");
+        write_feed_cache(
+            &path,
+            &FeedCache {
+                fetched_at: now_secs(),
+                body: "[]".to_string(),
+            },
+        )
+        .expect("writes");
+
+        let server = serving(ONE_AVG).await;
+        let client = SecurityClient::with_base_url(&server.uri(), ipv4());
+
+        let feed = load_feed(&client, true, Some(&path)).expect("refetches");
+        assert_eq!(
+            feed.avgs.len(),
+            1,
+            "the served feed won, not the cached one"
+        );
+        assert_eq!(
+            server.received_requests().await.unwrap_or_default().len(),
+            1
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn an_old_cache_answers_when_the_fetch_fails() {
+        let path = cache_file("stale");
+        write_feed_cache(
+            &path,
+            &FeedCache {
+                fetched_at: now_secs() - 86_400,
+                body: ONE_AVG.to_string(),
+            },
+        )
+        .expect("writes");
+
+        let client = SecurityClient::with_base_url("http://127.0.0.1:1", ipv4());
+        let feed = load_feed(&client, false, Some(&path)).expect("falls back");
+
+        assert_eq!(feed.avgs.len(), 1);
+        assert!(feed.stale, "a fallback must be marked stale");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn a_fresh_but_malformed_cache_is_refetched() {
+        let path = cache_file("malformed-fresh");
+        write_feed_cache(
+            &path,
+            &FeedCache {
+                fetched_at: now_secs(),
+                body: "not json".to_string(),
+            },
+        )
+        .expect("writes");
+
+        let server = serving(ONE_AVG).await;
+        let client = SecurityClient::with_base_url(&server.uri(), ipv4());
+
+        let feed = load_feed(&client, false, Some(&path)).expect("refetches");
+        assert_eq!(feed.avgs.len(), 1);
+        assert_eq!(
+            server.received_requests().await.unwrap_or_default().len(),
+            1
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn a_garbled_live_body_falls_back_to_an_old_cache() {
+        let path = cache_file("garbled-live");
+        write_feed_cache(
+            &path,
+            &FeedCache {
+                fetched_at: now_secs() - 86_400,
+                body: ONE_AVG.to_string(),
+            },
+        )
+        .expect("writes");
+
+        let server = serving("<html>maintenance</html>").await;
+        let client = SecurityClient::with_base_url(&server.uri(), ipv4());
+
+        let feed = load_feed(&client, false, Some(&path)).expect("falls back");
+        assert_eq!(feed.avgs.len(), 1);
+        assert!(feed.stale);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[tokio::test]
+    async fn a_failed_fetch_with_no_cache_is_an_error() {
+        let client = SecurityClient::with_base_url("http://127.0.0.1:1", ipv4());
+        let missing = cache_file("absent");
+        std::fs::remove_file(&missing).ok();
+
+        assert!(
+            load_feed(&client, false, Some(&missing)).is_err(),
+            "the failure must be explicit, not an empty advisory list"
+        );
     }
 }

--- a/backend/src/handlers/security.rs
+++ b/backend/src/handlers/security.rs
@@ -3,52 +3,164 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use arch_security_client::SecurityClient;
-use arch_security_client::models::{AvgStatus, Severity};
+use arch_security_client::models::{Avg, AvgStatus, Severity};
+use serde::{Deserialize, Serialize};
 
 use crate::alpm::get_handle;
 use crate::models::{PackageSecurityAdvisory, SecurityInfoResponse, SecurityResponse};
 use crate::util::{config_path, emit_json, write_json_atomic};
 
+const FEED_TTL_SECS: i64 = 3600;
+
+#[derive(Serialize, Deserialize)]
+struct FeedCache {
+    fetched_at: i64,
+    body: String,
+}
+
 fn security_cache_path() -> Result<PathBuf> {
-    config_path("security-cache.json")
+    config_path("security-feed.json")
 }
 
-fn read_security_cache(path: PathBuf) -> Option<Vec<PackageSecurityAdvisory>> {
-    let content = std::fs::read_to_string(&path).ok()?;
-    let cached: SecurityResponse = serde_json::from_str(&content).ok()?;
-    Some(cached.advisories)
+fn read_feed_cache(path: &Path) -> Option<FeedCache> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
 }
 
-fn write_security_cache(path: &Path, response: &SecurityResponse) -> Result<()> {
+fn write_feed_cache(path: &Path, cache: &FeedCache) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
+        let _ = std::fs::remove_file(parent.join("security-cache.json"));
     }
-    write_json_atomic(path, response)
+    write_json_atomic(path, cache)
 }
 
-pub fn check_security() -> Result<()> {
-    let client = SecurityClient::new(crate::util::detected_ip_family());
-    let avgs = match client.fetch_vulnerable() {
-        Ok(v) => v,
-        Err(e) => {
-            // Serve cached advisories (marked stale) if we have them. With no
-            // cache, propagate the error: an empty list would be
-            // indistinguishable from "no known vulnerabilities", a false
-            // sense of safety. The frontend renders this as "unavailable".
-            if let Some(advisories) = security_cache_path().ok().and_then(read_security_cache) {
-                return emit_json(&SecurityResponse {
-                    advisories,
-                    stale: true,
-                });
-            }
-            return Err(e);
-        }
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs() as i64)
+}
+
+fn feed_is_fresh(fetched_at: i64, now: i64) -> bool {
+    let age = now - fetched_at;
+    (0..FEED_TTL_SECS).contains(&age)
+}
+
+fn advisories_enabled() -> bool {
+    crate::config::AppConfig::load().map_or(true, |c| c.security_advisories)
+}
+
+fn advisory_for(pkg_name: &str, installed: &str, avg: &Avg) -> Option<PackageSecurityAdvisory> {
+    if matches!(avg.status, AvgStatus::NotAffected) {
+        return None;
+    }
+
+    // alpm::vercmp goes through CString and panics on interior NULs, and the
+    // versions come from the remote feed.
+    if avg.affected.contains('\0') || avg.fixed.as_deref().is_some_and(|f| f.contains('\0')) {
+        return None;
+    }
+
+    if alpm::vercmp(installed, &avg.affected) == std::cmp::Ordering::Less {
+        return None;
+    }
+
+    if let Some(ref fixed) = avg.fixed
+        && alpm::vercmp(installed, fixed) != std::cmp::Ordering::Less
+    {
+        return None;
+    }
+
+    Some(PackageSecurityAdvisory {
+        package: pkg_name.to_string(),
+        severity: avg.severity.as_str().to_string(),
+        advisory_type: avg.advisory_type.clone(),
+        avg_name: avg.name.clone(),
+        cve_ids: avg.issues.clone(),
+        fixed_version: avg.fixed.clone(),
+        affected_version: avg.affected.clone(),
+        installed_version: installed.to_string(),
+        status: avg.status.as_str().to_string(),
+    })
+}
+
+fn is_actionable(a: &PackageSecurityAdvisory) -> bool {
+    a.fixed_version.is_some()
+}
+
+fn sort_advisories(advisories: &mut [PackageSecurityAdvisory]) {
+    advisories.sort_by(|a, b| {
+        is_actionable(b)
+            .cmp(&is_actionable(a))
+            .then_with(|| parse_severity(&b.severity).cmp(&parse_severity(&a.severity)))
+            .then_with(|| a.package.cmp(&b.package))
+    });
+}
+
+struct Feed {
+    avgs: Vec<Avg>,
+    stale: bool,
+}
+
+fn load_feed(client: &SecurityClient, force: bool) -> Result<Feed> {
+    let path = security_cache_path().ok();
+    let mut cached = if force {
+        None
+    } else {
+        path.as_deref().and_then(read_feed_cache)
     };
+
+    if let Some(ref c) = cached
+        && feed_is_fresh(c.fetched_at, now_secs())
+        && let Ok(avgs) = arch_security_client::parse_vulnerable(&c.body)
+    {
+        return Ok(Feed { avgs, stale: false });
+    }
+
+    let stale_fallback = |cached: Option<FeedCache>| {
+        cached
+            .or_else(|| path.as_deref().and_then(read_feed_cache))
+            .and_then(|c| arch_security_client::parse_vulnerable(&c.body).ok())
+            .map(|avgs| Feed { avgs, stale: true })
+    };
+
+    match client.fetch_vulnerable_raw() {
+        Ok(body) => match arch_security_client::parse_vulnerable(&body) {
+            Ok(avgs) => {
+                if let Some(ref p) = path {
+                    let _ = write_feed_cache(
+                        p,
+                        &FeedCache {
+                            fetched_at: now_secs(),
+                            body,
+                        },
+                    );
+                }
+                Ok(Feed { avgs, stale: false })
+            }
+            Err(e) => stale_fallback(cached.take()).ok_or(e),
+        },
+        Err(e) => stale_fallback(cached.take()).ok_or(e),
+    }
+}
+
+pub fn check_security(force: bool) -> Result<()> {
+    if !advisories_enabled() {
+        return emit_json(&SecurityResponse {
+            advisories: Vec::new(),
+            stale: false,
+            disabled: true,
+        });
+    }
+
+    let client = SecurityClient::new(crate::util::detected_ip_family());
+    let feed = load_feed(&client, force)?;
+    let avgs = feed.avgs;
 
     let handle = get_handle()?;
     let localdb = handle.localdb();
 
-    let mut pkg_map: HashMap<&str, Vec<&arch_security_client::models::Avg>> = HashMap::new();
+    let mut pkg_map: HashMap<&str, Vec<&Avg>> = HashMap::new();
     for avg in &avgs {
         for pkg_name in &avg.packages {
             pkg_map.entry(pkg_name.as_str()).or_default().push(avg);
@@ -63,59 +175,32 @@ pub fn check_security() -> Result<()> {
         };
 
         for avg in matching_avgs {
-            let is_actionable = matches!(
-                avg.status,
-                AvgStatus::Vulnerable | AvgStatus::Fixed | AvgStatus::Testing
-            );
-            if !is_actionable {
-                continue;
+            if let Some(advisory) = advisory_for(pkg.name(), pkg.version().as_str(), avg) {
+                advisories.push(advisory);
             }
-
-            // "affected" is the first version known to be vulnerable.
-            // The package is affected if installed >= affected.
-            let installed_ver = pkg.version().as_str();
-            let at_or_above_affected =
-                alpm::vercmp(installed_ver, &avg.affected) != std::cmp::Ordering::Less;
-            if !at_or_above_affected {
-                continue;
-            }
-
-            // If a fix exists, the package is only vulnerable if installed < fixed.
-            if let Some(ref fixed) = avg.fixed
-                && alpm::vercmp(installed_ver, fixed) != std::cmp::Ordering::Less
-            {
-                continue;
-            }
-
-            advisories.push(PackageSecurityAdvisory {
-                package: pkg.name().to_string(),
-                severity: avg.severity.as_str().to_string(),
-                advisory_type: avg.advisory_type.clone(),
-                avg_name: avg.name.clone(),
-                cve_ids: avg.issues.clone(),
-                fixed_version: avg.fixed.clone(),
-                status: avg.status.as_str().to_string(),
-            });
         }
     }
 
-    advisories.sort_by(|a, b| {
-        let sev_a = parse_severity(&a.severity);
-        let sev_b = parse_severity(&b.severity);
-        sev_b.cmp(&sev_a).then(a.package.cmp(&b.package))
-    });
+    sort_advisories(&mut advisories);
 
-    let response = SecurityResponse {
+    emit_json(&SecurityResponse {
         advisories,
-        stale: false,
-    };
-    if let Ok(path) = security_cache_path() {
-        let _ = write_security_cache(&path, &response);
-    }
-    emit_json(&response)
+        stale: feed.stale,
+        disabled: false,
+    })
 }
 
 pub fn security_info(name: &str) -> Result<()> {
+    if !advisories_enabled() {
+        return emit_json(&SecurityInfoResponse {
+            name: name.to_string(),
+            advisories: Vec::new(),
+            groups: Vec::new(),
+            issues: Vec::new(),
+            disabled: true,
+        });
+    }
+
     let client = SecurityClient::new(crate::util::detected_ip_family());
     let info = client.fetch_package(name)?;
 
@@ -156,6 +241,7 @@ pub fn security_info(name: &str) -> Result<()> {
         advisories,
         groups,
         issues,
+        disabled: false,
     })
 }
 
@@ -166,5 +252,152 @@ fn parse_severity(s: &str) -> Severity {
         "Medium" => Severity::Medium,
         "Low" => Severity::Low,
         _ => Severity::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{advisory_for, feed_is_fresh, is_actionable, sort_advisories};
+    use arch_security_client::models::{Avg, AvgStatus, Severity};
+
+    fn avg(status: AvgStatus, affected: &str, fixed: Option<&str>) -> Avg {
+        Avg {
+            name: "AVG-1879".to_string(),
+            packages: vec!["linux".to_string()],
+            status,
+            severity: Severity::High,
+            advisory_type: "arbitrary code execution".to_string(),
+            affected: affected.to_string(),
+            fixed: fixed.map(str::to_string),
+            issues: vec!["CVE-2021-43976".to_string()],
+            advisories: vec![],
+        }
+    }
+
+    #[test]
+    fn a_version_below_the_first_affected_one_is_not_reported() {
+        let a = avg(AvgStatus::Vulnerable, "5.15.8.arch1-1", None);
+        assert!(advisory_for("linux", "5.15.7.arch1-1", &a).is_none());
+    }
+
+    #[test]
+    fn the_first_affected_version_itself_is_reported() {
+        let a = avg(AvgStatus::Vulnerable, "5.15.8.arch1-1", None);
+        assert!(advisory_for("linux", "5.15.8.arch1-1", &a).is_some());
+    }
+
+    #[test]
+    fn an_advisory_with_no_recorded_fix_keeps_matching_far_newer_versions() {
+        let a = avg(AvgStatus::Vulnerable, "5.15.8.arch1-1", None);
+        let got = advisory_for("linux", "7.1.8.arch1-3", &a).expect("still reported");
+
+        assert!(!is_actionable(&got), "nothing to update to");
+        assert_eq!(got.affected_version, "5.15.8.arch1-1");
+        assert_eq!(got.installed_version, "7.1.8.arch1-3");
+    }
+
+    #[test]
+    fn a_version_short_of_the_fix_is_reported_as_actionable() {
+        let a = avg(AvgStatus::Vulnerable, "9.0.1224-1", Some("9.0.1225-1"));
+        let got = advisory_for("vim", "9.0.1224-1", &a).expect("reported");
+
+        assert!(is_actionable(&got));
+        assert_eq!(got.fixed_version.as_deref(), Some("9.0.1225-1"));
+    }
+
+    #[test]
+    fn reaching_the_fix_clears_the_advisory() {
+        let a = avg(AvgStatus::Vulnerable, "9.0.1224-1", Some("9.0.1225-1"));
+        assert!(advisory_for("vim", "9.0.1225-1", &a).is_none());
+        assert!(advisory_for("vim", "9.2.0849-1", &a).is_none());
+    }
+
+    #[test]
+    fn a_package_the_tracker_says_is_unaffected_is_not_reported() {
+        let a = avg(AvgStatus::NotAffected, "5.15.8.arch1-1", None);
+        assert!(advisory_for("linux", "7.1.8.arch1-3", &a).is_none());
+    }
+
+    #[test]
+    fn a_feed_inside_its_window_is_reused_and_an_older_one_is_not() {
+        let now = 1_800_000_000;
+        assert!(feed_is_fresh(now, now));
+        assert!(feed_is_fresh(now - (super::FEED_TTL_SECS - 1), now));
+        assert!(!feed_is_fresh(now - super::FEED_TTL_SECS, now));
+        assert!(!feed_is_fresh(now - 86_400, now));
+    }
+
+    #[test]
+    fn a_feed_stamped_in_the_future_is_not_reused() {
+        let now = 1_800_000_000;
+        assert!(!feed_is_fresh(now + 60, now));
+    }
+
+    #[test]
+    fn an_untriaged_group_with_a_fix_is_still_reported() {
+        let a = Avg {
+            severity: Severity::Unknown,
+            advisory_type: "unknown".to_string(),
+            ..avg(AvgStatus::Unknown, "9.0.1224-1", Some("9.0.1225-1"))
+        };
+        let got = advisory_for("vim", "9.0.1224-1", &a).expect("reported");
+
+        assert!(is_actionable(&got));
+        assert_eq!(got.fixed_version.as_deref(), Some("9.0.1225-1"));
+        assert_eq!(got.severity, "Unknown");
+    }
+
+    #[test]
+    fn an_epoch_outranks_a_higher_looking_version() {
+        let a = avg(AvgStatus::Vulnerable, "1:1.0-1", None);
+        assert!(
+            advisory_for("pkg", "2.0-1", &a).is_none(),
+            "2.0-1 < 1:1.0-1"
+        );
+        assert!(advisory_for("pkg", "1:1.0-1", &a).is_some());
+    }
+
+    #[test]
+    fn a_version_with_an_interior_nul_is_dropped_not_a_panic() {
+        let a = avg(AvgStatus::Vulnerable, "5.0-1\0", None);
+        assert!(advisory_for("bash", "5.2-1", &a).is_none());
+
+        let a = avg(AvgStatus::Vulnerable, "5.0-1", Some("5.1\0-1"));
+        assert!(advisory_for("bash", "5.2-1", &a).is_none());
+    }
+
+    #[test]
+    fn a_pkgrel_bump_is_enough_to_be_affected() {
+        let a = avg(AvgStatus::Vulnerable, "1.0-1", Some("1.0-3"));
+        assert!(advisory_for("pkg", "1.0-2", &a).is_some());
+        assert!(advisory_for("pkg", "1.0-3", &a).is_none());
+    }
+
+    #[test]
+    fn what_an_update_can_fix_sorts_above_what_it_cannot() {
+        let low_fixable = advisory_for(
+            "vim",
+            "9.0.1224-1",
+            &Avg {
+                severity: Severity::Low,
+                ..avg(AvgStatus::Vulnerable, "9.0.1224-1", Some("9.0.1225-1"))
+            },
+        )
+        .expect("reported");
+        let high_stuck = advisory_for(
+            "linux",
+            "7.1.8.arch1-3",
+            &avg(AvgStatus::Vulnerable, "5.15.8.arch1-1", None),
+        )
+        .expect("reported");
+
+        let mut list = vec![high_stuck, low_fixable];
+        sort_advisories(&mut list);
+
+        assert_eq!(
+            list[0].package, "vim",
+            "a Low one an update fixes outranks a High one it cannot"
+        );
+        assert_eq!(list[1].package, "linux");
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,15 +5,16 @@ use cockpit_pacman_backend::handlers::{
     add_ignored, check_lock, check_security, check_updates, clean_cache, delete_mirror_backup,
     delete_repo_backup, downgrade_from_archive, downgrade_package, fetch_mirror_status, fetch_news,
     get_cache_info, get_dependency_tree, get_grouped_history, get_history, get_pacnew_status,
-    get_reboot_status, get_schedule_config, get_scheduled_runs, get_services_status, init_keyring,
-    install_package, keyring_status, list_archive_versions, list_downgrades, list_ignored,
-    list_installed, list_mirror_backups, list_mirrors, list_orphans, list_repo_backups, list_repos,
-    local_package_info, mark_dismissed, mark_news_read, preflight_upgrade,
-    read_credentials_from_stdin, read_dismissal, read_news_state, record_interrupted,
-    refresh_keyring, refresh_mirrors, remove_ignored, remove_orphans, remove_package,
-    remove_stale_lock, restore_mirror_backup, restore_repo_backup, run_upgrade, save_mirrorlist,
-    save_repos, scheduled_run, search, security_info, set_schedule_config, signoff_list,
-    signoff_revoke, signoff_sign, sync_database, sync_package_info, test_mirrors,
+    get_reboot_status, get_schedule_config, get_scheduled_runs, get_services_status, get_settings,
+    init_keyring, install_package, keyring_status, list_archive_versions, list_downgrades,
+    list_ignored, list_installed, list_mirror_backups, list_mirrors, list_orphans,
+    list_repo_backups, list_repos, local_package_info, mark_dismissed, mark_news_read,
+    preflight_upgrade, read_credentials_from_stdin, read_dismissal, read_news_state,
+    record_interrupted, refresh_keyring, refresh_mirrors, remove_ignored, remove_orphans,
+    remove_package, remove_stale_lock, restore_mirror_backup, restore_repo_backup, run_upgrade,
+    save_mirrorlist, save_repos, scheduled_run, search, security_info, set_schedule_config,
+    set_settings, signoff_list, signoff_revoke, signoff_sign, sync_database, sync_package_info,
+    test_mirrors,
 };
 use cockpit_pacman_backend::models::{MirrorEntry, RepoEntry, StructuredError};
 use cockpit_pacman_backend::util::{classify_error, emit_json, shutdown_event_writer};
@@ -46,6 +47,8 @@ const COMMANDS: &[&str] = &[
     "install-package",
     "remove-package",
     "list-ignored",
+    "get-settings",
+    "set-settings",
     "add-ignored",
     "remove-ignored",
     "cache-info",
@@ -144,6 +147,10 @@ Commands:
                          Remove an installed package (requires root)
                          timeout: seconds (default: 300)
   list-ignored           List packages ignored during upgrades
+  get-settings           Read the plugin settings
+  set-settings [security-advisories]
+                         Change a setting (requires root)
+                         security-advisories: true|false, empty leaves unchanged
   add-ignored NAME       Add a package to the ignored list (requires root)
   remove-ignored NAME    Remove a package from the ignored list (requires root)
   cache-info             Show package cache information and size
@@ -219,7 +226,8 @@ Commands:
   signoff-revoke PKGBASE REPO ARCH
                          Revoke a signoff
                          credentials: base64-encoded JSON {username, password} on stdin
-  check-security         Check installed packages against Arch Security Tracker
+  check-security [force] Check installed packages against Arch Security Tracker
+                         force: true refetches instead of reusing a recent copy
   security-info NAME     Get security advisory history for a package
   check-lock             Check if the pacman database lock exists and if it's stale
   version                Print the backend version, for the frontend to compare against
@@ -322,13 +330,17 @@ fn parse_refresh_mirrors(args: &[String]) -> RefreshMirrorsArgs {
     (count, arg_opt(args, 3), protocol, sort_by)
 }
 
-type SetScheduleArgs = (Option<bool>, Option<String>, Option<String>, Option<usize>);
-fn parse_set_schedule(args: &[String]) -> SetScheduleArgs {
-    let enabled = args.get(2).and_then(|s| match s.as_str() {
+fn parse_bool_arg(s: &str) -> Option<bool> {
+    match s {
         "true" => Some(true),
         "false" => Some(false),
         _ => None,
-    });
+    }
+}
+
+type SetScheduleArgs = (Option<bool>, Option<String>, Option<String>, Option<usize>);
+fn parse_set_schedule(args: &[String]) -> SetScheduleArgs {
+    let enabled = args.get(2).and_then(|s| parse_bool_arg(s));
     let max_packages = args.get(5).and_then(|s| s.parse().ok());
     (enabled, arg_opt(args, 3), arg_opt(args, 4), max_packages)
 }
@@ -449,6 +461,20 @@ fn main() {
             validate_package_name(&args[2]).and_then(|_| remove_package(&args[2], timeout))
         }
         "list-ignored" => list_ignored(),
+        "get-settings" => get_settings(),
+        "set-settings" => {
+            let security = match args.get(2) {
+                None => None,
+                Some(s) => match parse_bool_arg(s) {
+                    Some(b) => Some(b),
+                    None => {
+                        eprintln!("Error: set-settings expects true or false");
+                        std::process::exit(1);
+                    }
+                },
+            };
+            set_settings(security)
+        }
         "add-ignored" => {
             if args.len() < 3 {
                 eprintln!("Error: add-ignored requires a package name");
@@ -701,7 +727,19 @@ fn main() {
                 .and_then(|_| read_credentials_from_stdin())
                 .and_then(|creds| signoff_revoke(&creds, &args[2..]))
         }
-        "check-security" => check_security(),
+        "check-security" => {
+            let force = match args.get(2) {
+                None => false,
+                Some(s) => match parse_bool_arg(s) {
+                    Some(b) => b,
+                    None => {
+                        eprintln!("Error: check-security expects true or false");
+                        std::process::exit(1);
+                    }
+                },
+            };
+            check_security(force)
+        }
         "security-info" => {
             if args.len() < 3 {
                 eprintln!("Error: security-info requires a package name");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -831,6 +831,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     const SCHEDULED_UNIT: &str = include_str!("../../systemd/cockpit-pacman-scheduled.service");
     const FAILURE_UNIT: &str = include_str!("../../systemd/cockpit-pacman-failure@.service");
@@ -1034,6 +1035,32 @@ mod tests {
                 "command `{c}` is not documented in USAGE"
             );
         }
+    }
+
+    #[test]
+    fn every_dispatched_command_is_in_the_table() {
+        let source = include_str!("main.rs");
+        let body = source
+            .split_once("let result = match args[1].as_str() {")
+            .expect("the dispatch match is still shaped this way")
+            .1;
+
+        let dispatched: BTreeSet<&str> = body
+            .lines()
+            .filter_map(|line| {
+                let rest = line.strip_prefix("        \"")?;
+                if rest.starts_with(' ') {
+                    return None;
+                }
+                let (name, after) = rest.split_once('"')?;
+                after.trim_start().starts_with("=>").then_some(name)
+            })
+            .collect();
+
+        let declared: BTreeSet<&str> = COMMANDS.iter().copied().collect();
+
+        assert!(!dispatched.is_empty(), "match arm scraping found nothing");
+        assert_eq!(dispatched, declared, "dispatch match and COMMANDS disagree");
     }
 
     #[test]

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -728,6 +728,10 @@ pub struct PackageSecurityAdvisory {
     pub cve_ids: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fixed_version: Option<String>,
+    #[serde(default)]
+    pub affected_version: String,
+    #[serde(default)]
+    pub installed_version: String,
     pub status: String,
 }
 
@@ -738,6 +742,8 @@ pub struct SecurityResponse {
     /// True when served from the on-disk cache because the live fetch failed.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub stale: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub disabled: bool,
 }
 
 #[derive(Serialize, Deserialize, TS)]
@@ -773,6 +779,8 @@ pub struct SecurityInfoResponse {
     pub advisories: Vec<SecurityInfoAdvisory>,
     pub groups: Vec<SecurityInfoGroup>,
     pub issues: Vec<SecurityInfoIssue>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub disabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, TS)]

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -1579,3 +1579,70 @@ fn test_classify_error_falls_back_to_message() {
     let unknown = anyhow::anyhow!("package conflict detected");
     assert_eq!(classify_error(&unknown), None);
 }
+
+#[test]
+fn signoff_arg_rejects_what_it_cannot_put_in_a_url() {
+    use crate::validation::validate_signoff_arg;
+
+    assert!(validate_signoff_arg("linux", "pkgbase").is_ok());
+    assert!(validate_signoff_arg("gcc-libs", "pkgbase").is_ok());
+    assert!(validate_signoff_arg("x86_64", "arch").is_ok());
+
+    assert!(validate_signoff_arg("", "pkgbase").is_err());
+    assert!(validate_signoff_arg(&"a".repeat(257), "pkgbase").is_err());
+    assert!(validate_signoff_arg("core/linux", "pkgbase").is_err());
+    assert!(validate_signoff_arg("linux stable", "pkgbase").is_err());
+    assert!(validate_signoff_arg("../etc", "pkgbase").is_err());
+}
+
+#[test]
+fn signoff_arg_names_the_field_it_rejected() {
+    use crate::validation::validate_signoff_arg;
+
+    let err = validate_signoff_arg("", "arch").unwrap_err().to_string();
+    assert!(err.contains("arch"), "{err}");
+}
+
+#[test]
+fn repo_name_allows_what_pacman_conf_allows() {
+    use crate::validation::validate_repo_name;
+
+    assert!(validate_repo_name("core").is_ok());
+    assert!(validate_repo_name("extra-testing").is_ok());
+    assert!(validate_repo_name("my_repo.2").is_ok());
+
+    assert!(validate_repo_name("").is_err());
+    assert!(validate_repo_name(&"a".repeat(257)).is_err());
+    assert!(validate_repo_name("core]").is_err());
+    assert!(validate_repo_name("core\nServer = evil").is_err());
+    assert!(validate_repo_name("two words").is_err());
+}
+
+#[test]
+fn refresh_protocol_and_sort_accept_only_their_own_values() {
+    use crate::validation::{validate_refresh_protocol, validate_refresh_sort};
+
+    for ok in ["https", "http", "all"] {
+        assert!(validate_refresh_protocol(ok).is_ok(), "{ok}");
+    }
+    for bad in ["", "ftp", "HTTPS", "https "] {
+        assert!(validate_refresh_protocol(bad).is_err(), "{bad}");
+    }
+
+    for ok in ["score", "delay", "age"] {
+        assert!(validate_refresh_sort(ok).is_ok(), "{ok}");
+    }
+    for bad in ["", "speed", "Score", "score "] {
+        assert!(validate_refresh_sort(bad).is_err(), "{bad}");
+    }
+}
+
+#[test]
+fn the_mirror_parsers_default_instead_of_rejecting() {
+    use arch_mirror_client::{Protocol, SortBy};
+
+    assert_eq!(Protocol::parse("ftp"), Protocol::Any);
+    assert_eq!(Protocol::parse(""), Protocol::Any);
+    assert_eq!(SortBy::parse("speed"), SortBy::Score);
+    assert_eq!(SortBy::parse(""), SortBy::Score);
+}

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -557,41 +557,6 @@ pub fn reconcile_backup_provenance(manifest: &Path, backup_dir: &Path, name_pref
     }
 }
 
-/// SIGINT a child (pacman traps it and defers to a safe point). `Some(grace)`
-/// escalates to SIGKILL after the grace; a pacman child passes `None` because
-/// a hard kill mid-commit corrupts the db and hooks have no safe upper bound.
-pub(crate) fn terminate_child(
-    child: &mut std::process::Child,
-    grace: Option<Duration>,
-) -> std::process::ExitStatus {
-    use std::os::unix::process::ExitStatusExt;
-
-    // SAFETY: kill(2) with a valid pid and signal number has no memory effects.
-    unsafe {
-        libc::kill(child.id() as libc::pid_t, libc::SIGINT);
-    }
-
-    let deadline = grace.map(|g| Instant::now() + g);
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return status,
-            Ok(None) => {
-                if deadline.is_some_and(|d| Instant::now() >= d) {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-            Err(_) => break,
-        }
-    }
-
-    let _ = child.kill();
-    child.wait().unwrap_or_else(|_| {
-        // Already reaped between the loop and here; report the SIGINT we sent.
-        std::process::ExitStatus::from_raw(libc::SIGINT)
-    })
-}
-
 /// Run a command and capture its output, killing it and returning an error if it
 /// doesn't finish within `timeout`. `wait_with_output` drains stdout/stderr and
 /// reaps on a worker thread (so a hung child can't deadlock on a full pipe),
@@ -968,7 +933,7 @@ mod tests {
     use super::{
         ERROR_CODES, backups_to_prune, classify_error, classify_message, config_path,
         enqueue_capped, list_cache_packages, output_with_timeout, read_backup_provenance,
-        reconcile_backup_provenance, record_backup_provenance, terminate_child, write_bytes_atomic,
+        reconcile_backup_provenance, record_backup_provenance, write_bytes_atomic,
         write_event_flushed, write_json_atomic_with_mode,
     };
     use crate::models::{BackupSource, StreamEvent};
@@ -1309,55 +1274,6 @@ mod tests {
             0,
             "SIGTERM not in SigCgt; ctrlc 'termination' feature missing?"
         );
-    }
-
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn terminate_child_graceful_exit() {
-        use std::os::unix::process::ExitStatusExt;
-
-        let mut child = std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .unwrap();
-        let start = std::time::Instant::now();
-        let status = terminate_child(&mut child, Some(Duration::from_secs(5)));
-        // SIGINT ended it well before the grace window, no SIGKILL escalation.
-        assert!(start.elapsed() < Duration::from_secs(5));
-        assert_eq!(status.signal(), Some(libc::SIGINT));
-    }
-
-    // The wait-forever branch (child ignoring SIGINT) is left untested: it
-    // would hang the suite.
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn terminate_child_without_grace_waits_for_exit() {
-        use std::os::unix::process::ExitStatusExt;
-
-        let mut child = std::process::Command::new("sleep")
-            .arg("30")
-            .spawn()
-            .unwrap();
-        let status = terminate_child(&mut child, None);
-        assert_eq!(status.signal(), Some(libc::SIGINT));
-    }
-
-    #[test]
-    #[allow(clippy::unwrap_used)]
-    fn terminate_child_escalates_when_sigint_ignored() {
-        use std::os::unix::process::ExitStatusExt;
-
-        // The loop keeps the shell resident (no exec-into-sleep optimization) so
-        // it actually stays alive ignoring SIGINT, forcing the SIGKILL path.
-        let mut child = std::process::Command::new("sh")
-            .args(["-c", "trap \"\" INT; while :; do sleep 1; done"])
-            .spawn()
-            .unwrap();
-        // Let the shell install the trap before signalling, else SIGINT hits the
-        // default disposition during startup and kills it before the loop.
-        std::thread::sleep(Duration::from_millis(300));
-        let status = terminate_child(&mut child, Some(Duration::from_millis(300)));
-        assert_eq!(status.signal(), Some(libc::SIGKILL));
     }
 
     #[test]

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -738,9 +738,6 @@ pub const NETWORK_ERROR_KEYWORDS: &[&str] = &[
     "download library error",
 ];
 
-/// Classify an error message into a frontend ErrorCode by keyword. Returns None
-/// when nothing matches confidently. Mirrors parseErrorCode in api.ts so both
-/// ends agree on the same buckets.
 pub fn classify_message(message: &str) -> Option<&'static str> {
     let lower = message.to_lowercase();
     if lower.contains("timed out") || lower.contains("timeout") {
@@ -821,21 +818,20 @@ pub fn check_cancel(timeout: &TimeoutGuard) -> CheckResult {
     }
 }
 
-pub fn emit_cancellation_complete(reason: &CheckResult) {
+pub fn cancellation_message(reason: &CheckResult) -> Option<String> {
     match reason {
-        CheckResult::Cancelled => {
-            emit_event(&StreamEvent::Complete {
-                success: false,
-                message: Some("Operation cancelled by user".to_string()),
-            });
-        }
-        CheckResult::TimedOut(secs) => {
-            emit_event(&StreamEvent::Complete {
-                success: false,
-                message: Some(format!("Operation timed out after {} seconds", secs)),
-            });
-        }
-        CheckResult::Continue => {}
+        CheckResult::Cancelled => Some("Operation cancelled by user".to_string()),
+        CheckResult::TimedOut(secs) => Some(format!("Operation timed out after {} seconds", secs)),
+        CheckResult::Continue => None,
+    }
+}
+
+pub fn emit_cancellation_complete(reason: &CheckResult) {
+    if let Some(message) = cancellation_message(reason) {
+        emit_event(&StreamEvent::Complete {
+            success: false,
+            message: Some(message),
+        });
     }
 }
 

--- a/backend/tests/cli_tests.rs
+++ b/backend/tests/cli_tests.rs
@@ -1,0 +1,149 @@
+use std::process::{Command, Output};
+
+const BIN: &str = env!("CARGO_BIN_EXE_cockpit-pacman-backend");
+
+fn run(args: &[&str]) -> Output {
+    Command::new(BIN)
+        .args(args)
+        .output()
+        .expect("the backend binary builds and runs")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout is utf-8")
+}
+
+fn expect_error_envelope(args: &[&str]) -> serde_json::Value {
+    let output = run(args);
+    let stdout = stdout_of(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a frontend command reports failure in the envelope, not the exit code: {args:?} gave {stdout}"
+    );
+    assert_eq!(
+        stdout.trim().lines().count(),
+        1,
+        "the envelope is exactly one line: {stdout}"
+    );
+
+    let envelope: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout is JSON: {e}: {stdout}"));
+    assert!(
+        envelope.get("code").and_then(|c| c.as_str()).is_some(),
+        "envelope carries a code: {envelope}"
+    );
+    assert!(
+        !envelope["message"].as_str().unwrap_or_default().is_empty(),
+        "envelope carries a message: {envelope}"
+    );
+    envelope
+}
+
+#[test]
+fn an_unknown_command_exits_non_zero_and_says_so() {
+    let output = run(&["not-a-real-command"]);
+    let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is utf-8");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(stderr.contains("unknown command"), "{stderr}");
+    assert!(
+        stdout_of(&output).is_empty(),
+        "nothing goes to stdout, which is the data channel"
+    );
+}
+
+#[test]
+fn no_command_at_all_exits_non_zero() {
+    let output = run(&[]);
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn a_missing_required_argument_exits_non_zero() {
+    for args in [
+        vec!["security-info"],
+        vec!["local-package-info"],
+        vec!["downgrade-archive", "linux"],
+    ] {
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{args:?} should refuse to run without its arguments"
+        );
+    }
+}
+
+#[test]
+fn a_bool_argument_that_is_neither_true_nor_false_is_refused() {
+    for args in [vec!["set-settings", "yes"], vec!["check-security", "1"]] {
+        let output = run(&args);
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{args:?} must not be treated as unset or false"
+        );
+    }
+}
+
+#[test]
+fn pagination_beyond_the_limit_is_refused_before_the_database_is_opened() {
+    let envelope = expect_error_envelope(&["list-installed", "0", "2000"]);
+    assert!(
+        envelope["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Limit"),
+        "{envelope}"
+    );
+}
+
+#[test]
+fn a_depth_outside_the_range_is_refused() {
+    let envelope = expect_error_envelope(&["dependency-tree", "linux", "99", "forward"]);
+    assert!(
+        envelope["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Depth"),
+        "{envelope}"
+    );
+}
+
+#[test]
+fn an_archive_filename_that_escapes_its_directory_is_refused() {
+    for filename in [
+        "../evil.pkg.tar.zst",
+        "sub/dir.pkg.tar.zst",
+        "linux-1.0-1-x86_64.tar.gz",
+    ] {
+        let envelope = expect_error_envelope(&["downgrade-archive", "linux", filename]);
+        assert_eq!(
+            envelope["code"], "internal_error",
+            "{filename} rejected with an unexpected code: {envelope}"
+        );
+    }
+}
+
+#[test]
+fn an_archive_filename_for_a_different_package_is_refused() {
+    expect_error_envelope(&[
+        "downgrade-archive",
+        "linux",
+        "bash-5.2-1-x86_64.pkg.tar.zst",
+    ]);
+}
+
+#[test]
+fn an_empty_search_query_is_refused() {
+    expect_error_envelope(&["search", ""]);
+}
+
+#[test]
+fn an_invalid_package_name_is_refused() {
+    for name in ["../etc/passwd", "linux;reboot", ""] {
+        expect_error_envelope(&["local-package-info", name]);
+    }
+}

--- a/backend/tests/contract_tests.rs
+++ b/backend/tests/contract_tests.rs
@@ -2030,3 +2030,36 @@ fn error_codes_match_shared_fixture() {
         fixture["networkKeywords"].as_array().unwrap().len()
     );
 }
+
+#[test]
+fn the_backend_never_spawns_a_pacman_binary() {
+    let mut offenders = Vec::new();
+    let mut stack = vec![std::path::PathBuf::from("src")];
+
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("backend/src is readable") {
+            let path = entry.expect("readable entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).expect("source is utf-8");
+            for (n, line) in body.lines().enumerate() {
+                let spawns_pacman = line.contains("Command::new(\"pacman")
+                    || line.contains("Command::new(\"paccache")
+                    || line.contains("Command::new(\"checkupdates");
+                if spawns_pacman {
+                    offenders.push(format!("{}:{}", path.display(), n + 1));
+                }
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "use the alpm bindings instead of spawning pacman: {offenders:?}"
+    );
+}

--- a/backend/tests/contract_tests.rs
+++ b/backend/tests/contract_tests.rs
@@ -965,6 +965,8 @@ fn security_advisory_fixed_version_absent_when_none() {
         avg_name: "AVG-2024-1234".into(),
         cve_ids: vec!["CVE-2024-0001".into()],
         fixed_version: None,
+        affected_version: "3.0.0-1".into(),
+        installed_version: "3.2.1-1".into(),
         status: "Vulnerable".into(),
     };
     let v = to_json(&advisory);
@@ -975,6 +977,8 @@ fn security_advisory_fixed_version_absent_when_none() {
     assert_string(&v, "avg_name");
     assert_array(&v, "cve_ids");
     assert_string(&v, "status");
+    assert_string(&v, "affected_version");
+    assert_string(&v, "installed_version");
     // When None, fixed_version is ABSENT (not null) due to skip_serializing_if
     assert_absent(&v, "fixed_version");
 }
@@ -988,6 +992,8 @@ fn security_advisory_fixed_version_present_when_some() {
         avg_name: "AVG-2024-5678".into(),
         cve_ids: vec![],
         fixed_version: Some("8.5.0-1".into()),
+        affected_version: "8.4.0-1".into(),
+        installed_version: "8.4.0-2".into(),
         status: "Fixed".into(),
     };
     let v = to_json(&advisory);
@@ -1012,6 +1018,16 @@ fn security_advisories_fixture_documents_absent_vs_present_fixed_version() {
     // Second advisory has fixed_version present
     let fixed = &fixture["advisories"][1];
     assert_string(fixed, "fixed_version");
+
+    let stale = fixture["advisories"]
+        .as_array()
+        .expect("advisories is an array")
+        .last()
+        .expect("fixture has entries");
+    assert_eq!(stale["package"], "linux");
+    assert!(stale.get("fixed_version").is_none());
+    assert_eq!(stale["affected_version"], "5.15.8.arch1-1");
+    assert_eq!(stale["installed_version"], "7.1.8.arch1-3");
 }
 
 // LogEntry / GroupedLogResponse
@@ -1494,6 +1510,7 @@ fn security_info_response_shape() {
             issue_type: "arbitrary code execution".into(),
             status: "Fixed".into(),
         }],
+        disabled: false,
     };
     let v = to_json(&resp);
 

--- a/backend/tests/contract_tests.rs
+++ b/backend/tests/contract_tests.rs
@@ -2080,3 +2080,68 @@ fn the_backend_never_spawns_a_pacman_binary() {
         "use the alpm bindings instead of spawning pacman: {offenders:?}"
     );
 }
+
+/// The frontend derives ErrorCode from these strings; a reword changes what users see.
+#[test]
+fn the_messages_the_frontend_classifies_are_still_produced() {
+    use cockpit_pacman_backend::util::{CheckResult, cancellation_message};
+
+    let fixture = parse_fixture(include_str!(
+        "../../test/fixtures/stream-complete-codes.json"
+    ));
+    let pinned: Vec<&str> = fixture["messages"]
+        .as_array()
+        .expect("messages is an array")
+        .iter()
+        .map(|m| m["message"].as_str().expect("message is a string"))
+        .collect();
+
+    assert!(
+        pinned.contains(&"Operation cancelled by user"),
+        "fixture lost the cancel message"
+    );
+    assert_eq!(
+        cancellation_message(&CheckResult::Cancelled).as_deref(),
+        Some("Operation cancelled by user"),
+        "the cancel wording changed; update the fixture and the frontend test with it"
+    );
+    assert_eq!(
+        cancellation_message(&CheckResult::TimedOut(300)).as_deref(),
+        Some("Operation timed out after 300 seconds"),
+        "the timeout wording changed; update the fixture and the frontend test with it"
+    );
+    assert_eq!(cancellation_message(&CheckResult::Continue), None);
+
+    // The two the backend classifies itself must agree with the fixture, or the
+    // envelope path and the streaming path would disagree about the same text.
+    for entry in fixture["messages"].as_array().expect("array") {
+        let message = entry["message"].as_str().expect("string");
+        let code = entry["code"].as_str().expect("string");
+        if let Some(backend_code) = cockpit_pacman_backend::util::classify_message(message) {
+            assert_eq!(
+                backend_code, code,
+                "backend and frontend disagree on {message:?}"
+            );
+        }
+    }
+}
+
+/// The same list exists in api.ts; the two sides cannot share code.
+#[test]
+fn the_network_keywords_match_the_shared_list() {
+    let fixture = parse_fixture(include_str!(
+        "../../test/fixtures/network-error-keywords.json"
+    ));
+    let expected: Vec<&str> = fixture["keywords"]
+        .as_array()
+        .expect("keywords is an array")
+        .iter()
+        .map(|k| k.as_str().expect("keyword is a string"))
+        .collect();
+
+    assert_eq!(
+        cockpit_pacman_backend::util::NETWORK_ERROR_KEYWORDS,
+        expected.as_slice(),
+        "update test/fixtures/network-error-keywords.json and api.ts together"
+    );
+}

--- a/backend/tests/http_tests.rs
+++ b/backend/tests/http_tests.rs
@@ -1,0 +1,163 @@
+use cockpit_pacman_backend::util::classify_error;
+use std::net::TcpListener;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn dead_url() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("can bind a loopback port");
+    let port = listener.local_addr().expect("bound address").port();
+    drop(listener);
+    format!("http://127.0.0.1:{port}")
+}
+
+fn ipv4() -> ureq::config::IpFamily {
+    ureq::config::IpFamily::Ipv4Only
+}
+
+#[tokio::test]
+async fn a_404_from_the_security_tracker_is_an_error_not_an_empty_answer() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/vulnerable.json"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let client = arch_security_client::SecurityClient::with_base_url(&server.uri(), ipv4());
+    let err = client.fetch_vulnerable().expect_err("404 is a failure");
+
+    assert_eq!(
+        classify_error(&err),
+        Some("not_found"),
+        "a missing feed must not read as an empty one: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn a_refused_connection_reads_as_a_network_error() {
+    let client = arch_security_client::SecurityClient::with_base_url(&dead_url(), ipv4());
+    let err = client.fetch_vulnerable().expect_err("nothing is listening");
+
+    assert_eq!(classify_error(&err), Some("network_error"), "{err:#}");
+}
+
+fn valid_feed_of_bytes(at_least: usize) -> String {
+    let element = |i: usize| {
+        format!(
+            r#"{{"name":"AVG-{i}","packages":["bash"],"status":"Vulnerable","severity":"High",
+            "type":"arbitrary code execution","affected":"5.0-1","fixed":null,
+            "issues":["CVE-2024-{i}"],"advisories":[]}}"#
+        )
+    };
+    let mut elements = Vec::new();
+    let mut len = 2;
+    let mut i = 0;
+    while len < at_least {
+        let e = element(i);
+        len += e.len() + 1;
+        elements.push(e);
+        i += 1;
+    }
+    format!("[{}]", elements.join(","))
+}
+
+#[tokio::test]
+async fn a_body_past_the_cap_fails_instead_of_parsing_a_truncated_feed() {
+    let cap = 2 * 1024 * 1024;
+    let huge = valid_feed_of_bytes(cap + 1024);
+    let under = valid_feed_of_bytes(1024);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/vulnerable.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(huge))
+        .mount(&server)
+        .await;
+
+    let client = arch_security_client::SecurityClient::with_base_url(&server.uri(), ipv4());
+    client
+        .fetch_vulnerable()
+        .expect_err("a capped read truncates the body mid-element");
+
+    // The same shape under the cap parses, so only the truncation can fail it.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/issues/vulnerable.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(under))
+        .mount(&server)
+        .await;
+    let client = arch_security_client::SecurityClient::with_base_url(&server.uri(), ipv4());
+    assert!(!client.fetch_vulnerable().expect("parses").is_empty());
+}
+
+#[tokio::test]
+async fn a_well_formed_feed_parses() {
+    let server = MockServer::start().await;
+    let body = r#"[{"name":"AVG-1","packages":["bash"],"status":"Vulnerable","severity":"High",
+        "type":"arbitrary code execution","affected":"5.0-1","fixed":"5.1-1",
+        "issues":["CVE-2024-1"],"advisories":[]}]"#;
+    Mock::given(method("GET"))
+        .and(path("/issues/vulnerable.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&server)
+        .await;
+
+    let client = arch_security_client::SecurityClient::with_base_url(&server.uri(), ipv4());
+    let avgs = client.fetch_vulnerable().expect("parses");
+
+    assert_eq!(avgs.len(), 1);
+    assert_eq!(avgs[0].name, "AVG-1");
+    assert_eq!(avgs[0].fixed.as_deref(), Some("5.1-1"));
+}
+
+#[tokio::test]
+async fn a_mirror_report_past_the_cap_fails_instead_of_parsing_truncated() {
+    let mirror = r#"{"url":"https://a.example/","protocol":"https","last_sync":"2026-01-01T00:00:00Z",
+        "completion_pct":1.0,"delay":60,"score":1.5,"active":true,"country":"Germany","country_code":"DE",
+        "duration_avg":0.1,"duration_stddev":0.01,"ipv4":true,"ipv6":false,"isos":true,"details":""}"#;
+    let per = mirror.len() + 1;
+    let count = (8 * 1024 * 1024) / per + 2;
+    let body = format!("{{\"urls\":[{}]}}", vec![mirror; count].join(","));
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/mirrors/status/json/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&server)
+        .await;
+
+    let agent =
+        ureq::Agent::new_with_config(ureq::Agent::config_builder().ip_family(ipv4()).build());
+    let url = format!("{}/mirrors/status/json/", server.uri());
+    assert!(arch_mirror_client::fetch_from(&agent, &url).is_err());
+}
+
+#[tokio::test]
+async fn the_mirror_status_report_parses() {
+    let server = MockServer::start().await;
+    let body = r#"{"urls":[{"url":"https://a.example/","protocol":"https","last_sync":"2026-01-01T00:00:00Z",
+        "completion_pct":1.0,"delay":60,"score":1.5,"active":true,"country":"Germany","country_code":"DE",
+        "duration_avg":0.1,"duration_stddev":0.01,"ipv4":true,"ipv6":false,"isos":true,"details":""}]}"#;
+    Mock::given(method("GET"))
+        .and(path("/mirrors/status/json/"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(body))
+        .mount(&server)
+        .await;
+
+    let agent =
+        ureq::Agent::new_with_config(ureq::Agent::config_builder().ip_family(ipv4()).build());
+    let url = format!("{}/mirrors/status/json/", server.uri());
+    let status = arch_mirror_client::fetch_from(&agent, &url).expect("parses");
+
+    assert_eq!(status.mirrors.len(), 1);
+    assert_eq!(status.mirrors[0].score, Some(1.5));
+}
+
+#[tokio::test]
+async fn a_mirror_status_failure_is_reported_not_swallowed() {
+    let agent =
+        ureq::Agent::new_with_config(ureq::Agent::config_builder().ip_family(ipv4()).build());
+    let url = format!("{}/mirrors/status/json/", dead_url());
+
+    assert!(arch_mirror_client::fetch_from(&agent, &url).is_err());
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ save, which rewrites it `0644`.
 
 ```json
 {
+  "security_advisories": true,
   "ignored_packages": ["linux", "nvidia"],
   "schedule": {
     "enabled": false,
@@ -40,3 +41,17 @@ Keys the running backend does not recognize are preserved, not dropped, when the
 file is rewritten. A config written by a newer version round-trips through an
 older one without losing fields, so upgrading and downgrading the plugin does not
 silently discard settings.
+
+## security_advisories
+
+Whether to consult the Arch Security Tracker. Defaults to `true`.
+
+Set it to `false` on systems the tracker does not describe, for example a
+distribution that backports fixes without closing the tracker's records (see
+[troubleshooting](troubleshooting.md#advisories-that-look-ancient) for why
+those records linger). With the feature off the backend makes no request to
+security.archlinux.org and says so explicitly, rather than showing an empty
+list that would read as a clean bill of health.
+
+The setting fails open: a config that cannot be read or parsed leaves
+advisories on, so a broken file cannot quietly suppress security data.

--- a/docs/signoffs.md
+++ b/docs/signoffs.md
@@ -38,4 +38,4 @@ Should print your ArchWeb password. Once configured, reload cockpit-pacman and t
 
 ## How it works
 
-On page load, the cockpit-pacman frontend queries the Secret Service via D-Bus for an item matching `{service: "cockpit-pacman", type: "archweb"}`. If found, credentials are read from the keyring and passed to the backend as a base64-encoded argument on each signoff operation. The backend never stores or caches credentials.
+On page load, the cockpit-pacman frontend queries the Secret Service via D-Bus for an item matching `{service: "cockpit-pacman", type: "archweb"}`. If found, credentials are read from the keyring and passed to the backend over stdin, base64-encoded, on each signoff operation. Never as a command-line argument: `/proc/<pid>/cmdline` is world-readable. The backend never stores or caches credentials.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,118 @@
+# Troubleshooting
+
+Where things live, what the less obvious messages mean, and how to recover.
+
+## The database is locked
+
+pacman holds `db.lck` in its database directory (`/var/lib/pacman`, or `DBPath`
+from `pacman.conf`) for the length of a transaction. A lock left behind by a
+crash blocks every later operation.
+
+The plugin looks for a process holding the file, matching by inode so a holder
+in another mount namespace is still found. If nothing holds it, the Updates
+view offers to clear it and logs that it did (`journalctl -t cockpit-pacman`).
+
+By hand:
+
+```bash
+sudo fuser -v /var/lib/pacman/db.lck
+sudo rm /var/lib/pacman/db.lck   # only when fuser found nothing
+```
+
+If `fuser` prints a process, it is mid-transaction; leave the lock alone.
+
+## An upgrade was interrupted
+
+> Operation interrupted - system may be in inconsistent state
+
+libalpm stops between packages: some are upgraded, the rest are not, and the
+post-transaction hooks (initramfs, systemd reload) did not run.
+
+Re-run the upgrade. Nothing resumes; the transaction is recomputed from the
+database, so whatever is still out of date is upgraded and the hooks run at
+the end.
+
+Two lookalikes:
+
+- Cancel interrupts on purpose, and reports this.
+- Closing the tab, logging out, or a dropped websocket does not interrupt a
+  transaction that is already applying. The backend finishes it, records it,
+  and notes the disconnection in the journal. Work that has not started stops.
+
+## Only some repositories updated
+
+> Failed to refresh package databases: failed to retrieve some files
+
+Databases refresh per repository, so one dead mirror leaves that repository
+stale while the others move on. Upgrading against a half-updated set is the
+partial upgrade Arch does not support, so the upgrade refuses to start.
+
+Check which repository failed in the log above the message, then fix the
+mirrorlist in the Mirrors tab or retry later.
+
+> error: failed to synchronize all databases (no servers configured for repository)
+
+That repository has no enabled `Server` or `Include` line. If this follows an
+edit, restore the previous `/etc/pacman.conf` from Backup history in the
+Repositories tab.
+
+## A scheduled run did not happen
+
+```bash
+systemctl list-timers cockpit-pacman-scheduled.timer
+journalctl -u cockpit-pacman-scheduled.service
+```
+
+Each run appends one JSON line to `/var/log/cockpit-pacman/scheduled.jsonl`,
+and the Updates view reads that file. Three cases run without writing a record:
+
+- The service was killed cgroup-wide (`systemctl kill`, systemd-oomd). The
+  failure handler (`cockpit-pacman-failure@.service`) runs outside the cgroup
+  and still leaves a line.
+- `config.json` is malformed. The run exits non-zero before doing any work,
+  which also reaches the failure handler.
+- `/var/log` is full. The write error goes to stderr and the run still exits
+  0, since an upgrade that already landed must not be reported as failed. The
+  journal has the line.
+
+When the file and the journal disagree, the journal is the authority.
+
+## Advisories that look ancient
+
+The Security panel reads Arch's security tracker, whose records stay open
+until someone closes them, often long after a fix ships, so an old advisory
+keeps matching current versions.
+
+Advisories are split by whether updating resolves them; "no fix recorded"
+means the tracker names no version to upgrade to. To turn the panel off, see
+`security_advisories` in [configuration.md](configuration.md).
+
+## Where things live
+
+| Path | What |
+|---|---|
+| `/etc/cockpit-pacman/config.json` | Schedule, ignored packages, feature flags. Root owned, `0644`. |
+| `/etc/systemd/system/cockpit-pacman-scheduled.timer.d/schedule.conf` | The `OnCalendar` override the schedule writes. |
+| `/var/log/cockpit-pacman/scheduled.jsonl` | One line per scheduled run. |
+| `~/.config/cockpit-pacman/` | Per-user caches and dismissals. Deleting it costs the dismissals; the caches rebuild. |
+| `/etc/pacman.conf.backup.<epoch>` | Taken before each repository save. |
+| `/etc/pacman.d/mirrorlist.backup.<epoch>` | Taken before each mirrorlist save. |
+
+Five backups of each are kept. Manual ones outrank the automatic ones taken
+before a restore, so a run of restores cannot evict them; the Origin column in
+Backup history says which is which.
+
+Restore from Backup history in the Mirrors and Repositories tabs, or by hand:
+
+```bash
+sudo cp /etc/pacman.d/mirrorlist.backup.1787527641 /etc/pacman.d/mirrorlist
+```
+
+## Every panel says not permitted
+
+The plugin reads as the logged-in user and asks for administrator access only
+to change something. A view that stopped working usually means the session has
+not escalated: use the administrative access button in Cockpit's header.
+
+Uninstalling keeps `/etc/cockpit-pacman`, `/var/log/cockpit-pacman` and the
+backups. Remove them by hand if you want them gone.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,5 @@
   },
   "overrides": {
     "minimatch": ">=10.2.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -9,6 +9,7 @@ import {
   createMockStreamingProcess,
 } from "./test/mocks";
 import { STREAM_FIRST_OUTPUT_TIMEOUT_MS } from "./constants";
+import { getSignoffList, signoffPackage, revokeSignoff } from "./api";
 import {
   formatSize,
   listInstalled,
@@ -863,5 +864,37 @@ describe("downgradeFromArchive", () => {
 
     expect(callbacks.onComplete).toHaveBeenCalledTimes(1);
     expect(callbacks.onError).not.toHaveBeenCalled();
+  });
+});
+
+describe("signoff credentials", () => {
+  const credentials = { username: "someone", password: "hunter2" };
+
+  let sentToStdin: string[];
+
+  beforeEach(() => {
+    sentToStdin = [];
+    const promise = createMockSpawnPromise(JSON.stringify({ groups: [] }));
+    promise.input = ((data: string) => {
+      sentToStdin.push(data);
+    }) as unknown as () => void;
+    mockSpawn.mockReturnValue(promise);
+  });
+
+  it.each([
+    ["signoff-list", () => getSignoffList(credentials)],
+    ["signoff-sign", () => signoffPackage("linux", "core", "x86_64", credentials)],
+    ["signoff-revoke", () => revokeSignoff("linux", "core", "x86_64", credentials)],
+  ])("passes credentials to %s on stdin, never in argv", async (_cmd, call) => {
+    await call();
+
+    const [argv] = mockSpawn.mock.calls[0];
+    const joined = (argv as string[]).join(" ");
+    expect(joined).not.toContain(credentials.password);
+    expect(joined).not.toContain(credentials.username);
+    expect(joined).not.toContain(btoa(JSON.stringify(credentials)));
+
+    expect(sentToStdin).toHaveLength(1);
+    expect(JSON.parse(atob(sentToStdin[0]))).toEqual(credentials);
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -663,7 +663,7 @@ export function downgradePackage(
   name: string,
   version: string
 ): StreamingHandle {
-  return runStreamingBackend("downgrade", [sanitizeSearchInput(name), sanitizeSearchInput(version)], callbacks);
+  return runStreamingBackend("downgrade", [sanitizeSearchInput(name), sanitizeSearchInput(version)], callbacks, { gracefulCancel: true });
 }
 
 export async function listArchiveVersions(packageName: string, query?: string): Promise<DowngradeResponse> {
@@ -679,7 +679,7 @@ export function downgradeFromArchive(
   name: string,
   filename: string
 ): StreamingHandle {
-  return runStreamingBackend("downgrade-archive", [sanitizeSearchInput(name), filename], callbacks);
+  return runStreamingBackend("downgrade-archive", [sanitizeSearchInput(name), filename], callbacks, { gracefulCancel: true });
 }
 
 export interface ScheduledRunsParams {

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,6 +45,8 @@ import type {
   SecurityInfoResponse,
   SecurityResponse,
   ServicesStatus,
+  SettingsResponse,
+  SettingsSetResponse,
   SignoffActionResponse,
   SignoffListResponse,
   StreamEvent,
@@ -290,12 +292,20 @@ export async function removeStaleLock(): Promise<LockRemoveResult> {
   return runBackend<LockRemoveResult>("remove-stale-lock", [], { superuser: "require" });
 }
 
-export async function checkSecurity(): Promise<SecurityResponse> {
-  return runBackend<SecurityResponse>("check-security", [], { superuser: "none" });
+export async function checkSecurity(force = false): Promise<SecurityResponse> {
+  return runBackend<SecurityResponse>("check-security", [String(force)], { superuser: "none" });
 }
 
 export async function getSecurityInfo(name: string): Promise<SecurityInfoResponse> {
   return runBackend<SecurityInfoResponse>("security-info", [name], { superuser: "none" });
+}
+
+export async function getSettings(): Promise<SettingsResponse> {
+  return runBackend<SettingsResponse>("get-settings", [], { superuser: "none" });
+}
+
+export async function setSecurityAdvisories(enabled: boolean): Promise<SettingsSetResponse> {
+  return runBackend<SettingsSetResponse>("set-settings", [String(enabled)]);
 }
 
 export async function getPackageInfo(name: string): Promise<PackageDetails> {

--- a/src/bindings/index.ts
+++ b/src/bindings/index.ts
@@ -82,7 +82,7 @@ export type PackageDetails = { name: string, version: string, description: strin
 
 export type PackageListResponse = { packages: Array<Package>, total: number, total_explicit: number, total_dependency: number, repositories: Array<string>, warnings: Array<string>, };
 
-export type PackageSecurityAdvisory = { package: string, severity: string, advisory_type: string, avg_name: string, cve_ids: Array<string>, fixed_version: string | null, status: string, };
+export type PackageSecurityAdvisory = { package: string, severity: string, advisory_type: string, avg_name: string, cve_ids: Array<string>, fixed_version: string | null, affected_version: string, installed_version: string, status: string, };
 
 export type PacnewFile = { path: string, package: string, kind: string, mtime: number, };
 
@@ -155,13 +155,13 @@ export type SecurityInfoGroup = { name: string, status: string, severity: string
 
 export type SecurityInfoIssue = { name: string, severity: string, issue_type: string, status: string, };
 
-export type SecurityInfoResponse = { name: string, advisories: Array<SecurityInfoAdvisory>, groups: Array<SecurityInfoGroup>, issues: Array<SecurityInfoIssue>, };
+export type SecurityInfoResponse = { name: string, advisories: Array<SecurityInfoAdvisory>, groups: Array<SecurityInfoGroup>, issues: Array<SecurityInfoIssue>, disabled?: boolean, };
 
 export type SecurityResponse = { advisories: Array<PackageSecurityAdvisory>, 
 /**
  * True when served from the on-disk cache because the live fetch failed.
  */
-stale?: boolean, };
+stale?: boolean, disabled?: boolean, };
 
 export type ServiceRestart = { name: string, pid: number, affected_packages: Array<string>, reason: string, restart_blocked?: RestartBlocked | null, };
 
@@ -170,6 +170,10 @@ export type ServicesStatus = { restart_required: boolean, services: Array<Servic
  * The scan could not see every process, so `services` may be short.
  */
 scan_incomplete: boolean, };
+
+export type SettingsResponse = { security_advisories: boolean, };
+
+export type SettingsSetResponse = { success: boolean, message: string, };
 
 /**
  * Wire mirror of archweb_client's Signoff so the type can derive TS bindings

--- a/src/components/PackageDetailsModal.test.tsx
+++ b/src/components/PackageDetailsModal.test.tsx
@@ -122,4 +122,28 @@ describe("PackageDetailsModal", () => {
       expect(screen.getByText(/No advisories for this package/i)).toBeInTheDocument();
     });
   });
+
+  it("says so when advisories are turned off, rather than showing none", async () => {
+    mockGetSecurityInfo.mockResolvedValue({
+      name: "linux",
+      advisories: [],
+      groups: [],
+      issues: [],
+      disabled: true,
+    });
+    render(
+      <PackageDetailsModal
+        packageDetails={mockPackageDetails}
+        isLoading={false}
+        onClose={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Security advisories"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/turned off for this system/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/No advisories for this package/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/PackageDetailsModal.tsx
+++ b/src/components/PackageDetailsModal.tsx
@@ -58,6 +58,13 @@ const PackageSecuritySection: React.FC<{ name: string }> = ({ name }) => {
   if (state === "error") {
     return <span className="pf-v6-u-color-200">{sanitizeErrorMessage(err)}</span>;
   }
+  if (info?.disabled) {
+    return (
+      <span className="pf-v6-u-color-200">
+        Security advisories are turned off for this system.
+      </span>
+    );
+  }
   if (!info || (!info.advisories.length && !info.groups.length && !info.issues.length)) {
     return <span className="pf-v6-u-color-200">No advisories for this package.</span>;
   }

--- a/src/components/UpdatesView.test.tsx
+++ b/src/components/UpdatesView.test.tsx
@@ -1708,7 +1708,9 @@ describe("UpdatesView", () => {
       advisory_type: "security",
       avg_name: "AVG-1",
       cve_ids: ["CVE-1"],
-      fixed_version: null,
+      fixed_version: "1.1-1",
+      affected_version: "1.0-1",
+      installed_version: "1.0-1",
       status: "Vulnerable",
     };
 
@@ -1827,7 +1829,9 @@ describe("UpdatesView", () => {
       advisory_type: "security",
       avg_name: "AVG-1",
       cve_ids: ["CVE-1"],
-      fixed_version: null,
+      fixed_version: "1.1-1",
+      affected_version: "1.0-1",
+      installed_version: "1.0-1",
       status: "Vulnerable",
     };
 
@@ -1859,6 +1863,64 @@ describe("UpdatesView", () => {
       // The row's onRowClick (which opens the details modal via getPackageInfo)
       // must not fire when a link inside the portaled popover is clicked.
       expect(mockGetPackageInfo).not.toHaveBeenCalled();
+    });
+
+    const unresolved = {
+      package: "zzz-package",
+      severity: "High",
+      advisory_type: "security",
+      avg_name: "AVG-1879",
+      cve_ids: ["CVE-2021-43976"],
+      fixed_version: null,
+      affected_version: "5.15.8.arch1-1",
+      installed_version: "7.1.8.arch1-3",
+      status: "Vulnerable",
+    };
+
+    it("leaves an advisory with no recorded fix out of the security count", async () => {
+      mockCheckUpdates.mockResolvedValue(onePackage);
+      mockCheckSecurity.mockResolvedValue({ advisories: [unresolved] });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText("zzz-package")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("No fix")).toBeInTheDocument();
+      expect(screen.queryByText("High")).not.toBeInTheDocument();
+    });
+
+    it("shows both versions and the caveat for an advisory with no recorded fix", async () => {
+      mockCheckUpdates.mockResolvedValue(onePackage);
+      mockCheckSecurity.mockResolvedValue({ advisories: [unresolved] });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText("zzz-package")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("No fix"));
+      });
+
+      expect(await screen.findByText("No fix recorded")).toBeInTheDocument();
+      expect(
+        screen.getByText(/filed against 5\.15\.8\.arch1-1, installed 7\.1\.8\.arch1-3/)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/tracker lists no fixed version/)).toBeInTheDocument();
+    });
+
+    it("renders nothing about security when the feature is disabled", async () => {
+      mockCheckUpdates.mockResolvedValue(onePackage);
+      mockCheckSecurity.mockResolvedValue({ advisories: [], disabled: true });
+
+      render(<UpdatesView />);
+      await waitFor(() => {
+        expect(screen.getByText("zzz-package")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("No fix")).not.toBeInTheDocument();
+      expect(screen.queryByText("High")).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/UpdatesView.tsx
+++ b/src/components/UpdatesView.tsx
@@ -74,6 +74,7 @@ import {
   PackageSecurityAdvisory,
   checkUpdates,
   checkSecurity,
+  setSecurityAdvisories,
   runUpgrade,
   syncDatabase,
   preflightUpgrade,
@@ -107,12 +108,38 @@ import { CompactPagination } from "./CompactPagination";
 
 import { appendCapped, isDbLockError, sanitizeUrl } from "../utils";
 import { severityColor } from "../severity";
+import { NO_FIX_CAVEAT, partitionAdvisories } from "../security";
+import { useAdminPermission } from "../hooks/useAdminPermission";
 import { TimeAgo } from "./TimeAgo";
 import { PackageDetailsModal } from "./PackageDetailsModal";
 import { StatBox } from "./StatBox";
 import { IgnoredPackagesModal } from "./IgnoredPackagesModal";
 import { ScheduleModal } from "./ScheduleModal";
 import { useNavigation } from "../contexts/NavigationContext";
+
+/// One advisory in the popover. Shows the versions side by side so the reader
+/// can judge a record for themselves rather than being told a verdict.
+const AdvisoryLine: React.FC<{ advisory: PackageSecurityAdvisory }> = ({ advisory }) => (
+  <div style={{ marginBottom: "0.5rem" }}>
+    <a
+      href={`https://security.archlinux.org/${advisory.avg_name}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {advisory.avg_name}
+    </a>
+    {" "}<Label isCompact color={severityColor(advisory.severity)}>{advisory.severity}</Label>
+    <div style={{ color: "var(--pf-t--global--text--color--subtle)", fontSize: "0.85em" }}>
+      {advisory.advisory_type}
+      {advisory.cve_ids.length > 0 && ` (${advisory.cve_ids.join(", ")})`}
+    </div>
+    <div style={{ color: "var(--pf-t--global--text--color--subtle)", fontSize: "0.85em" }}>
+      {advisory.fixed_version
+        ? `fixed in ${advisory.fixed_version}, installed ${advisory.installed_version}`
+        : `filed against ${advisory.affected_version}, installed ${advisory.installed_version}`}
+    </div>
+  </div>
+);
 
 const SEVERITY_ORDER: Record<string, number> = {
   Critical: 4,
@@ -167,9 +194,16 @@ const SystemOverviewCard: React.FC<{
   pendingSignoffs?: number | null;
   securityFilterActive?: boolean;
   onToggleSecurityFilter?: () => void;
-}> = ({ updates, securityCount, securityLoading, securityUnavailable, orphanCount, cacheSize, keyringStatus, summaryLoading, pendingSignoffs, securityFilterActive, onToggleSecurityFilter }) => {
-  const securityFilterable = !!onToggleSecurityFilter && !securityLoading && !securityUnavailable && securityCount > 0;
+  securityEnabled: boolean;
+  onSetSecurityEnabled: (enabled: boolean) => void;
+  securityToggleBusy: boolean;
+}> = ({ updates, securityCount, securityLoading, securityUnavailable, orphanCount, cacheSize, keyringStatus, summaryLoading, pendingSignoffs, securityFilterActive, onToggleSecurityFilter, securityEnabled, onSetSecurityEnabled, securityToggleBusy }) => {
+  const securityFilterable = securityEnabled && !!onToggleSecurityFilter && !securityLoading && !securityUnavailable && securityCount > 0;
   const { onViewOrphans, onViewCache, onViewKeyring, onViewSignoffs } = useNavigation();
+  // Writing the setting needs root, so an unescalated session sees why it
+  // cannot, rather than a control that silently fails.
+  const isAdmin = useAdminPermission();
+  const mayToggle = isAdmin === true && !securityToggleBusy;
   return (
   <Card className="pf-v6-u-mb-md">
     <CardBody>
@@ -183,6 +217,8 @@ const SystemOverviewCard: React.FC<{
           />
         </FlexItem>
         <FlexItem>
+          <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsXs" }}>
+            <FlexItem>
           <StatBox
             label={securityFilterActive ? "Show all" : "Security"}
             value={
@@ -198,6 +234,27 @@ const SystemOverviewCard: React.FC<{
             isActive={securityFilterable ? securityFilterActive : undefined}
             ariaLabel={securityFilterActive ? "Show all updates" : "Filter to security updates"}
           />
+            </FlexItem>
+            <FlexItem>
+              <Tooltip
+                content={
+                  isAdmin === false
+                    ? "Not permitted to change system settings"
+                    : "Stop checking the Arch Security Tracker. Its records can stay open long after a fix ships."
+                }
+              >
+                <div>
+                  <Checkbox
+                    id="security-advisories-enabled"
+                    label="Check advisories"
+                    isChecked={securityEnabled}
+                    isDisabled={!mayToggle}
+                    onChange={(_e, checked) => onSetSecurityEnabled(checked)}
+                  />
+                </div>
+              </Tooltip>
+            </FlexItem>
+          </Flex>
         </FlexItem>
         <FlexItem>
           <Tooltip content="Packages installed as dependencies that are no longer required by any other package. Usually safe to remove.">
@@ -472,6 +529,8 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
   const [securityMap, setSecurityMap] = useState<Map<string, PackageSecurityAdvisory[]>>(new Map());
   const [securityLoading, setSecurityLoading] = useState(true);
   const [securityStale, setSecurityStale] = useState(false);
+  const [securityEnabled, setSecurityEnabled] = useState(true);
+  const [savingSecurityToggle, setSavingSecurityToggle] = useState(false);
   const [securityUnavailable, setSecurityUnavailable] = useState(false);
   const [newsItems, setNewsItems] = useState<NewsItem[]>([]);
   const [newsError, setNewsError] = useState(false);
@@ -500,9 +559,23 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     return Array.from(repos).sort();
   }, [updates]);
 
+  // Only advisories an update can clear. An unresolved record cannot be acted
+  // on from here, and counting it turned the overview into an alarm about
+  // things the user has no way to fix.
+  const actionableSecurityMap = useMemo(() => {
+    const map = new Map<string, PackageSecurityAdvisory[]>();
+    for (const [pkg, advisories] of securityMap) {
+      const { actionable } = partitionAdvisories(advisories);
+      if (actionable.length > 0) {
+        map.set(pkg, actionable);
+      }
+    }
+    return map;
+  }, [securityMap]);
+
   const securityUpdateCount = useMemo(() => {
-    return updates.filter((u) => securityMap.has(u.name)).length;
-  }, [updates, securityMap]);
+    return updates.filter((u) => actionableSecurityMap.has(u.name)).length;
+  }, [updates, actionableSecurityMap]);
 
   // The filter only applies while there are security updates to show, so a
   // refresh that drops the count to zero never strands the list on an empty result.
@@ -523,10 +596,10 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       result = result.filter((u) => u.repository === repoFilter);
     }
     if (securityFilterOn) {
-      result = result.filter((u) => securityMap.has(u.name));
+      result = result.filter((u) => actionableSecurityMap.has(u.name));
     }
     return result;
-  }, [updates, searchFilter, repoFilter, securityFilterOn, securityMap]);
+  }, [updates, searchFilter, repoFilter, securityFilterOn, actionableSecurityMap]);
 
   const sortedUpdates = useMemo(() => {
     if (activeSortKey === null) return filteredUpdates;
@@ -656,10 +729,18 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     [updates]
   );
 
-  const loadSecurityData = useCallback(async () => {
+  const loadSecurityData = useCallback(async (force = false) => {
     setSecurityLoading(true);
     try {
-      const response = await checkSecurity();
+      const response = await checkSecurity(force);
+      if (response.disabled) {
+        setSecurityEnabled(false);
+        setSecurityMap(new Map());
+        setSecurityStale(false);
+        setSecurityUnavailable(false);
+        return;
+      }
+      setSecurityEnabled(true);
       const map = new Map<string, PackageSecurityAdvisory[]>();
       for (const advisory of response.advisories) {
         const existing = map.get(advisory.package) ?? [];
@@ -678,7 +759,24 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
     }
   }, []);
 
-  const loadUpdates = useCallback(async () => {
+  const handleSetSecurityEnabled = useCallback(
+    async (enabled: boolean) => {
+      setSavingSecurityToggle(true);
+      // Optimistic, so the tile does not sit stale while the write escalates.
+      setSecurityEnabled(enabled);
+      try {
+        await setSecurityAdvisories(enabled);
+        await loadSecurityData();
+      } catch {
+        setSecurityEnabled(!enabled);
+      } finally {
+        setSavingSecurityToggle(false);
+      }
+    },
+    [loadSecurityData]
+  );
+
+  const loadUpdates = useCallback(async (force = false) => {
     setState("checking");
     setError(null);
     setErrorCode(undefined);
@@ -693,7 +791,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
       setUpdates(response.updates);
       setWarnings(response.warnings);
       setState(response.updates.length > 0 ? "available" : "uptodate");
-      loadSecurityData();
+      loadSecurityData(force);
     } catch (ex) {
       failWith("check", ex instanceof Error ? ex.message : String(ex), ex instanceof BackendError ? ex.code : undefined, ex instanceof BackendError ? ex.details : undefined);
     }
@@ -1435,7 +1533,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
               </EmptyStateBody>
               <EmptyStateFooter>
                 <EmptyStateActions>
-                  <Button variant="primary" onClick={showLockRecovery ? manualResumeAfterLock : loadUpdates}>Retry</Button>
+                  <Button variant="primary" onClick={showLockRecovery ? manualResumeAfterLock : () => loadUpdates(true)}>Retry</Button>
                   <Button variant="link" onClick={() => setState("uptodate")}>Dismiss</Button>
                 </EmptyStateActions>
               </EmptyStateFooter>
@@ -1596,7 +1694,7 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
             </EmptyStateBody>
             <EmptyStateFooter>
               <EmptyStateActions>
-                <Button variant="primary" onClick={loadUpdates}>
+                <Button variant="primary" onClick={() => loadUpdates(true)}>
                   Check Again
                 </Button>
               </EmptyStateActions>
@@ -1647,6 +1745,9 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
           keyringStatus={keyringStatus}
           summaryLoading={summaryLoading}
           pendingSignoffs={pendingSignoffs}
+          securityEnabled={securityEnabled}
+          onSetSecurityEnabled={handleSetSecurityEnabled}
+          securityToggleBusy={savingSecurityToggle}
         />
 
         <Card className="pf-v6-u-mb-md">
@@ -1754,6 +1855,9 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
         pendingSignoffs={pendingSignoffs}
         securityFilterActive={securityFilterOn}
         onToggleSecurityFilter={() => setSecurityFilterActive((v) => !v)}
+        securityEnabled={securityEnabled}
+        onSetSecurityEnabled={handleSetSecurityEnabled}
+        securityToggleBusy={savingSecurityToggle}
       />
 
       <Card>
@@ -1898,11 +2002,16 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
               const isIgnored = update.ignored;
               const advisories = securityMap.get(update.name);
               const hasAdvisories = advisories && advisories.length > 0;
-              const highest = hasAdvisories
-                ? advisories.reduce((a, b) =>
-                    (SEVERITY_ORDER[b.severity] ?? 0) > (SEVERITY_ORDER[a.severity] ?? 0) ? b : a
-                  )
-                : null;
+              const { actionable, unresolved } = partitionAdvisories(advisories ?? []);
+              // Severity, and the stripe it drives, describe what an update can
+              // still fix. A record with no fix recorded is not an emergency and
+              // must not paint the row red.
+              const highest =
+                actionable.length > 0
+                  ? actionable.reduce((a, b) =>
+                      (SEVERITY_ORDER[b.severity] ?? 0) > (SEVERITY_ORDER[a.severity] ?? 0) ? b : a
+                    )
+                  : null;
               const borderColor = highest
                 ? `var(--pf-t--global--color--status--${highest.severity === "Critical" || highest.severity === "High" ? "danger" : "warning"}--default)`
                 : undefined;
@@ -1941,39 +2050,42 @@ export const UpdatesView: React.FC<UpdatesViewProps> = ({ signoffCredentials }) 
                         ignored
                       </Label>
                     )}
-                    {hasAdvisories && highest && (
+                    {hasAdvisories && (
                       <Popover
                         headerContent={<>{advisories.length} securit{advisories.length === 1 ? "y advisory" : "y advisories"}</>}
                         bodyContent={
                           <div onClick={(e) => e.stopPropagation()}>
-                            {advisories.map((a) => (
-                              <div key={a.avg_name} style={{ marginBottom: "0.5rem" }}>
-                                <a
-                                  href={`https://security.archlinux.org/${a.avg_name}`}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                >
-                                  {a.avg_name}
-                                </a>
-                                {" "}<Label isCompact color={severityColor(a.severity)}>{a.severity}</Label>
-                                <div style={{ color: "var(--pf-t--global--text--color--subtle)", fontSize: "0.85em" }}>
-                                  {a.advisory_type}
-                                  {a.cve_ids.length > 0 && ` (${a.cve_ids.join(", ")})`}
+                            {actionable.length > 0 && (
+                              <div style={{ marginBottom: "0.75rem" }}>
+                                <strong>Fixed by updating</strong>
+                                {actionable.map((a) => (
+                                  <AdvisoryLine key={a.avg_name} advisory={a} />
+                                ))}
+                              </div>
+                            )}
+                            {unresolved.length > 0 && (
+                              <div>
+                                <strong>No fix recorded</strong>
+                                {unresolved.map((a) => (
+                                  <AdvisoryLine key={a.avg_name} advisory={a} />
+                                ))}
+                                <div style={{ color: "var(--pf-t--global--text--color--subtle)", fontSize: "0.85em", marginTop: "0.25rem" }}>
+                                  {NO_FIX_CAVEAT}
                                 </div>
                               </div>
-                            ))}
+                            )}
                           </div>
                         }
                       >
                         <Label
                           isCompact
-                          color={severityColor(highest.severity)}
+                          color={highest ? severityColor(highest.severity) : "grey"}
                           icon={<ShieldAltIcon />}
                           className="pf-v6-u-ml-sm"
                           style={{ cursor: "pointer" }}
                           onClick={(e) => e.stopPropagation()}
                         >
-                          {highest.severity}
+                          {highest ? highest.severity : "No fix"}
                           {advisories.length > 1 && ` +${advisories.length - 1}`}
                         </Label>
                       </Popover>

--- a/src/errorCodes.test.ts
+++ b/src/errorCodes.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { NETWORK_ERROR_KEYWORDS, parseErrorCode } from "./api";
+import fixture from "../test/fixtures/stream-complete-codes.json";
+import networkKeywords from "../test/fixtures/network-error-keywords.json";
+
+// The backend asserts it produces these strings; this end asserts the mapping.
+describe("parseErrorCode against the messages the backend emits", () => {
+  it.each(fixture.messages.map((m) => [m.message, m.code] as const))(
+    "maps %j to %s",
+    (message, code) => {
+      expect(parseErrorCode(message)).toBe(code);
+    },
+  );
+
+  it("covers every message in the fixture", () => {
+    expect(fixture.messages.length).toBeGreaterThan(0);
+  });
+});
+
+describe("NETWORK_ERROR_KEYWORDS", () => {
+  it("matches the list the backend classifies by", () => {
+    expect(NETWORK_ERROR_KEYWORDS).toEqual(networkKeywords.keywords);
+  });
+
+  it("actually classifies each keyword as a network error", () => {
+    for (const keyword of networkKeywords.keywords) {
+      expect(parseErrorCode(`pacman: ${keyword} while fetching`)).toBe("network_error");
+    }
+  });
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,6 @@
       "order": 50
     }
   },
-  "overview-health": ["pacman"],
   "preload": ["index"],
   "content-security-policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'",
   "conditions": [

--- a/src/security.test.ts
+++ b/src/security.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { isActionable, partitionAdvisories } from "./security";
+import type { PackageSecurityAdvisory } from "./bindings";
+
+function advisory(over: Partial<PackageSecurityAdvisory> = {}): PackageSecurityAdvisory {
+  return {
+    package: "linux",
+    severity: "High",
+    advisory_type: "arbitrary code execution",
+    avg_name: "AVG-1879",
+    cve_ids: ["CVE-2021-43976"],
+    fixed_version: null,
+    affected_version: "5.15.8.arch1-1",
+    installed_version: "7.1.8.arch1-3",
+    status: "Vulnerable",
+    ...over,
+  };
+}
+
+describe("isActionable", () => {
+  it("is true when the tracker names a fix to update to", () => {
+    expect(isActionable(advisory({ fixed_version: "9.0.1225-1" }))).toBe(true);
+  });
+
+  it("is false when no fix is recorded", () => {
+    expect(isActionable(advisory())).toBe(false);
+  });
+
+  it("is false when the field is absent rather than null", () => {
+    const bare = advisory();
+    delete (bare as { fixed_version?: unknown }).fixed_version;
+    expect(isActionable(bare)).toBe(false);
+  });
+});
+
+describe("partitionAdvisories", () => {
+  it("separates what an update fixes from what it cannot", () => {
+    const fixable = advisory({ package: "vim", fixed_version: "9.0.1225-1" });
+    const stuck = advisory();
+
+    const { actionable, unresolved } = partitionAdvisories([stuck, fixable]);
+
+    expect(actionable.map((a) => a.package)).toEqual(["vim"]);
+    expect(unresolved.map((a) => a.package)).toEqual(["linux"]);
+  });
+
+  it("copes with an empty list", () => {
+    expect(partitionAdvisories([])).toEqual({ actionable: [], unresolved: [] });
+  });
+});

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,0 +1,26 @@
+import type { PackageSecurityAdvisory } from "./bindings";
+
+export function isActionable(advisory: PackageSecurityAdvisory): boolean {
+  return advisory.fixed_version != null;
+}
+
+export interface PartitionedAdvisories {
+  actionable: PackageSecurityAdvisory[];
+  unresolved: PackageSecurityAdvisory[];
+}
+
+export function partitionAdvisories(
+  advisories: readonly PackageSecurityAdvisory[],
+): PartitionedAdvisories {
+  const actionable: PackageSecurityAdvisory[] = [];
+  const unresolved: PackageSecurityAdvisory[] = [];
+  for (const advisory of advisories) {
+    (isActionable(advisory) ? actionable : unresolved).push(advisory);
+  }
+  return { actionable, unresolved };
+}
+
+export const NO_FIX_CAVEAT =
+  "Arch's tracker lists no fixed version for these. Records can stay open after " +
+  "a fix lands upstream, so an advisory may no longer apply to the installed " +
+  "version even though the tracker still matches it.";

--- a/test/fixtures/network-error-keywords.json
+++ b/test/fixtures/network-error-keywords.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Substrings that mark an error as a network failure. Duplicated by necessity: the Rust classifier runs on the backend and parseErrorCode runs in the browser, and they cannot share code across that boundary. Both suites assert against this file.",
+  "keywords": [
+    "network",
+    "connection",
+    "could not connect",
+    "unable to connect",
+    "could not resolve",
+    "resolve host",
+    "host not found",
+    "name resolution",
+    "temporary failure in name resolution",
+    "dns",
+    "failed retrieving file",
+    "failed to retrieve",
+    "download library error"
+  ]
+}

--- a/test/fixtures/security-advisories.json
+++ b/test/fixtures/security-advisories.json
@@ -5,17 +5,26 @@
       "severity": "High",
       "advisory_type": "multiple issues",
       "avg_name": "AVG-2024-1234",
-      "cve_ids": ["CVE-2024-0001", "CVE-2024-0002"],
-      "status": "Fixed"
+      "cve_ids": [
+        "CVE-2024-0001",
+        "CVE-2024-0002"
+      ],
+      "status": "Fixed",
+      "affected_version": "3.0.0-1",
+      "installed_version": "3.2.1-1"
     },
     {
       "package": "curl",
       "severity": "Medium",
       "advisory_type": "information disclosure",
       "avg_name": "AVG-2024-5678",
-      "cve_ids": ["CVE-2024-0003"],
+      "cve_ids": [
+        "CVE-2024-0003"
+      ],
       "fixed_version": "8.5.0-1",
-      "status": "Fixed"
+      "status": "Fixed",
+      "affected_version": "8.4.0-1",
+      "installed_version": "8.4.0-2"
     },
     {
       "package": "libpng",
@@ -23,6 +32,21 @@
       "advisory_type": "denial of service",
       "avg_name": "AVG-2024-9999",
       "cve_ids": [],
+      "status": "Vulnerable",
+      "affected_version": "1.6.40-1",
+      "installed_version": "1.6.43-1"
+    },
+    {
+      "package": "linux",
+      "severity": "High",
+      "advisory_type": "arbitrary code execution",
+      "avg_name": "AVG-1879",
+      "cve_ids": [
+        "CVE-2021-43976",
+        "CVE-2021-4095"
+      ],
+      "affected_version": "5.15.8.arch1-1",
+      "installed_version": "7.1.8.arch1-3",
       "status": "Vulnerable"
     }
   ]

--- a/test/fixtures/stream-complete-codes.json
+++ b/test/fixtures/stream-complete-codes.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Failure messages the backend puts on a streaming Complete, and the ErrorCode the frontend must derive from each. A streaming Complete carries no code, so the frontend classifies by keyword; rewording a message silently changes what the UI shows. Both suites assert against this file.",
+  "messages": [
+    { "message": "Operation cancelled by user", "code": "cancelled" },
+    { "message": "Operation timed out after 300 seconds", "code": "timeout" },
+    { "message": "Failed to commit transaction: could not commit transaction", "code": "transaction_failed" },
+    { "message": "Failed to refresh package databases: failed to retrieve some files", "code": "network_error" },
+    { "message": "unable to lock database", "code": "database_locked" },
+    { "message": "failed retrieving file 'core.db' from mirror : Connection timed out", "code": "timeout" }
+  ]
+}


### PR DESCRIPTION
downgrades now go through alpm like every other operation, so they report progress, classify errors, and cancel gracefully at a safe point. 

the security panel gets a config toggle (`security_advisories`, fails open) and splits advisories by whether updating actually fixes them, so the count stops including things you can't act on.